### PR TITLE
Pre-launch hardening: supporter PII gate, logout key-clear, scan-cap honesty

### DIFF
--- a/convex/supporters.ts
+++ b/convex/supporters.ts
@@ -187,11 +187,15 @@ export const list = query({
 		// Use .take() with a bounded cap to prevent unbounded memory usage.
 		const limit = Math.min(numItems, 100);
 		const MAX_SCAN = 10_000;
-		const allDocs = await ctx.db
+		// Take ONE extra row as a truncation sentinel: an org sitting at exactly
+		// MAX_SCAN is complete, not truncated. `take(MAX_SCAN)` + `>= MAX_SCAN`
+		// would false-flag it. Fetch MAX_SCAN + 1 and treat `> MAX_SCAN` as the
+		// real truncation signal, then drop the sentinel row from the working set.
+		const scanned = await ctx.db
 			.query('supporters')
 			.withIndex('by_orgId', (idx) => idx.eq('orgId', org._id))
 			.order('desc')
-			.take(MAX_SCAN);
+			.take(MAX_SCAN + 1);
 
 		// Scan newest-first so the 10K window is the MOST RECENT supporters — the
 		// rows an operator actually wants, and what the page's "showing the most
@@ -200,7 +204,9 @@ export const list = query({
 		// honestly so the page warns instead of presenting a truncated list as
 		// complete. Mirrors the v1 API's `truncated`/`scanLimit` envelope
 		// (convex/v1api.ts listSupporters).
-		const scanCapped = allDocs.length >= MAX_SCAN;
+		const scanCapped = scanned.length > MAX_SCAN;
+		// Drop the sentinel +1 row so it isn't processed or returned.
+		const allDocs = scanned.slice(0, MAX_SCAN);
 
 		// Apply filters in memory (Convex indexes are limited to equality prefixes)
 		let filtered = allDocs;
@@ -361,7 +367,13 @@ export const get = query({
 export const findByEmailHash = query({
 	args: { slug: v.string(), emailHash: v.string() },
 	handler: async (ctx, args) => {
-		const { org, membership } = await requireOrgRole(ctx, args.slug, 'member');
+		// Editor-gated, not member: this reader returns null-vs-object keyed on a
+		// caller-supplied emailHash, which is an existence/membership oracle (a
+		// plain member could probe whether any email is in the org regardless of
+		// field projection). It has zero app consumers, so the legitimate
+		// supporter-search feature (searchByEmail) stays 'member' while existence-
+		// probing is restricted to editors.
+		const { org, membership } = await requireOrgRole(ctx, args.slug, 'editor');
 		const isEditor = membershipIsEditor(membership.role);
 		const doc = await ctx.db
 			.query('supporters')

--- a/convex/supporters.ts
+++ b/convex/supporters.ts
@@ -190,14 +190,16 @@ export const list = query({
 		const allDocs = await ctx.db
 			.query('supporters')
 			.withIndex('by_orgId', (idx) => idx.eq('orgId', org._id))
+			.order('desc')
 			.take(MAX_SCAN);
 
-		// When the scan saturates the cap, this list reflects only a 10K window
-		// of the org — rows beyond it are silently absent (and because the
-		// by_orgId scan is oldest-first, the missing rows are the NEWEST). Surface
-		// the cap honestly so the page can warn the operator instead of presenting
-		// a truncated list as complete. Mirrors the v1 API's `truncated`/`scanLimit`
-		// envelope (convex/v1api.ts listSupporters).
+		// Scan newest-first so the 10K window is the MOST RECENT supporters — the
+		// rows an operator actually wants, and what the page's "showing the most
+		// recent 10,000" notice truthfully describes. When the scan saturates the
+		// cap, rows beyond the window (the OLDEST) are absent; surface the cap
+		// honestly so the page warns instead of presenting a truncated list as
+		// complete. Mirrors the v1 API's `truncated`/`scanLimit` envelope
+		// (convex/v1api.ts listSupporters).
 		const scanCapped = allDocs.length >= MAX_SCAN;
 
 		// Apply filters in memory (Convex indexes are limited to equality prefixes)
@@ -256,7 +258,7 @@ export const list = query({
 						_id: s._id,
 						_creationTime: s._creationTime,
 						encryptedEmail: s.encryptedEmail,
-						emailHash: s.emailHash as string | null,
+						emailHash: s.emailHash ?? null,
 						encryptedName: s.encryptedName ?? null,
 						postalCode: s.postalCode ?? null,
 						stateCode: s.stateCode ?? null,
@@ -330,7 +332,7 @@ export const get = query({
 				_id: supporter._id,
 				_creationTime: supporter._creationTime,
 				encryptedEmail: supporter.encryptedEmail,
-				emailHash: supporter.emailHash as string | null,
+				emailHash: supporter.emailHash ?? null,
 				encryptedName: supporter.encryptedName ?? null,
 				postalCode: supporter.postalCode ?? null,
 				stateCode: supporter.stateCode ?? null,
@@ -368,11 +370,41 @@ export const findByEmailHash = query({
 			)
 			.first();
 		if (!doc) return null;
-		// Raw .first() returns the full document (consent text + the join-key
-		// hash). The caller already holds the hash, so a non-editor learns
-		// nothing new by getting it back — but the consent-evidence fields are
-		// editor-only, so project them out for plain members.
-		return projectSupporterFields(doc, isEditor);
+		// Return a CURATED allowlist, not the raw document: .first() carries
+		// cross-org join keys (globalEmailHash/globalPhoneHash/phoneHash) and
+		// other internal columns that no reader should expose. Mirror the
+		// deliberate field set the other readers emit, then role-gate the
+		// editor-only fields through the shared projection.
+		return projectSupporterFields(
+			{
+				_id: doc._id,
+				_creationTime: doc._creationTime,
+				encryptedEmail: doc.encryptedEmail,
+				emailHash: doc.emailHash ?? null,
+				encryptedName: doc.encryptedName ?? null,
+				postalCode: doc.postalCode ?? null,
+				stateCode: doc.stateCode ?? null,
+				congressionalDistrict: doc.congressionalDistrict ?? null,
+				country: doc.country ?? null,
+				encryptedPhone: doc.encryptedPhone ?? null,
+				verified: doc.verified,
+				identityVerified: !!(doc.identityCommitment && doc.verified),
+				identityCommitment: doc.identityCommitment ?? null,
+				emailStatus: doc.emailStatus,
+				smsStatus: doc.smsStatus,
+				source: doc.source ?? null,
+				emailConsentSource: doc.emailConsentSource ?? null,
+				emailConsentedAt: doc.emailConsentedAt ?? null,
+				emailConsentText: doc.emailConsentText ?? null,
+				smsConsentSource: doc.smsConsentSource ?? null,
+				smsConsentedAt: doc.smsConsentedAt ?? null,
+				smsConsentText: doc.smsConsentText ?? null,
+				encryptedCustomFields: doc.encryptedCustomFields ?? null,
+				importedAt: doc.importedAt ?? null,
+				updatedAt: doc.updatedAt
+			},
+			isEditor
+		);
 	}
 });
 

--- a/convex/supporters.ts
+++ b/convex/supporters.ts
@@ -100,6 +100,65 @@ function supporterSourceValue(supporter: { source?: string }): string {
 }
 
 /**
+ * Fields a non-editor member must NOT receive from any member-gated reader.
+ *
+ * - `emailHash` is a stable, org-scoped join key. Surfacing it to a plain
+ *   member lets them correlate a supporter across every list/search response
+ *   and use it as a membership/identity oracle — a quiet PII egress that the
+ *   org-key-encrypted blobs (`encrypted*`) do not expose.
+ * - The six consent-evidence fields carry the literal consent text/source/
+ *   timestamp the supporter agreed to. That is compliance evidence custodied
+ *   for the org's editors, not list-membership metadata for every member.
+ *
+ * Editor+ (`owner`/`editor`) callers keep the real values — they hold the org
+ * key and run export/search, both of which need `emailHash` as decryption AAD.
+ *
+ * Encrypted PII blobs (`encryptedEmail`/`encryptedName`/`encryptedPhone`/
+ * `encryptedCustomFields`) are intentionally left untouched: they are
+ * org-key-encrypted and the client decrypts them — that is the existing
+ * custody model, not a leak.
+ */
+type ProjectableSupporterFields = {
+	emailHash?: string | null;
+	emailConsentSource?: string | null;
+	emailConsentedAt?: number | null;
+	emailConsentText?: string | null;
+	smsConsentSource?: string | null;
+	smsConsentedAt?: number | null;
+	smsConsentText?: string | null;
+};
+
+/**
+ * Null the editor-only PII/consent fields for non-editor members. Editor+
+ * callers pass `isEditor: true` and the real values pass through unchanged.
+ *
+ * Applied in EVERY member-gated reader so the gate cannot drift between them.
+ * The `Record<string, unknown> &` intersection lets readers hand in their full
+ * mapped shape (with `_id`, `tags`, encrypted blobs, …) without tripping
+ * excess-property checks — only the seven projectable keys are overwritten.
+ */
+function projectSupporterFields<T extends Record<string, unknown> & ProjectableSupporterFields>(
+	doc: T,
+	isEditor: boolean
+): T {
+	if (isEditor) return doc;
+	return {
+		...doc,
+		emailHash: null,
+		emailConsentSource: null,
+		emailConsentedAt: null,
+		emailConsentText: null,
+		smsConsentSource: null,
+		smsConsentedAt: null,
+		smsConsentText: null
+	};
+}
+
+function membershipIsEditor(role: string): boolean {
+	return role === 'owner' || role === 'editor';
+}
+
+/**
  * Paginated supporter list with filters. Returns encrypted PII blobs.
  */
 export const list = query({
@@ -119,7 +178,8 @@ export const list = query({
 		)
 	},
 	handler: async (ctx, args) => {
-		const { org } = await requireOrgRole(ctx, args.orgSlug, 'member');
+		const { org, membership } = await requireOrgRole(ctx, args.orgSlug, 'member');
+		const isEditor = membershipIsEditor(membership.role);
 		const { cursor, numItems } = args.paginationOpts;
 		const filters = args.filters;
 
@@ -183,33 +243,36 @@ export const list = query({
 					})
 				);
 
-				return {
-					_id: s._id,
-					_creationTime: s._creationTime,
-					encryptedEmail: s.encryptedEmail,
-					emailHash: s.emailHash,
-					encryptedName: s.encryptedName ?? null,
-					postalCode: s.postalCode ?? null,
-					stateCode: s.stateCode ?? null,
-					congressionalDistrict: s.congressionalDistrict ?? null,
-					country: s.country ?? null,
-					encryptedPhone: s.encryptedPhone ?? null,
-					verified: s.verified,
-					identityVerified: !!(s.identityCommitment && s.verified),
-					emailStatus: s.emailStatus,
-					smsStatus: s.smsStatus,
-					source: s.source ?? null,
-					emailConsentSource: s.emailConsentSource ?? null,
-					emailConsentedAt: s.emailConsentedAt ?? null,
-					emailConsentText: s.emailConsentText ?? null,
-					smsConsentSource: s.smsConsentSource ?? null,
-					smsConsentedAt: s.smsConsentedAt ?? null,
-					smsConsentText: s.smsConsentText ?? null,
-					importedAt: s.importedAt ?? null,
-					encryptedCustomFields: s.encryptedCustomFields ?? null,
-					updatedAt: s.updatedAt,
-					tags: tags.filter((t): t is NonNullable<typeof t> => t !== null)
-				};
+				return projectSupporterFields(
+					{
+						_id: s._id,
+						_creationTime: s._creationTime,
+						encryptedEmail: s.encryptedEmail,
+						emailHash: s.emailHash as string | null,
+						encryptedName: s.encryptedName ?? null,
+						postalCode: s.postalCode ?? null,
+						stateCode: s.stateCode ?? null,
+						congressionalDistrict: s.congressionalDistrict ?? null,
+						country: s.country ?? null,
+						encryptedPhone: s.encryptedPhone ?? null,
+						verified: s.verified,
+						identityVerified: !!(s.identityCommitment && s.verified),
+						emailStatus: s.emailStatus,
+						smsStatus: s.smsStatus,
+						source: s.source ?? null,
+						emailConsentSource: s.emailConsentSource ?? null,
+						emailConsentedAt: s.emailConsentedAt ?? null,
+						emailConsentText: s.emailConsentText ?? null,
+						smsConsentSource: s.smsConsentSource ?? null,
+						smsConsentedAt: s.smsConsentedAt ?? null,
+						smsConsentText: s.smsConsentText ?? null,
+						importedAt: s.importedAt ?? null,
+						encryptedCustomFields: s.encryptedCustomFields ?? null,
+						updatedAt: s.updatedAt,
+						tags: tags.filter((t): t is NonNullable<typeof t> => t !== null)
+					},
+					isEditor
+				);
 			})
 		);
 
@@ -232,7 +295,8 @@ export const get = query({
 		supporterId: v.id('supporters')
 	},
 	handler: async (ctx, args) => {
-		const { org } = await requireOrgRole(ctx, args.orgSlug, 'member');
+		const { org, membership } = await requireOrgRole(ctx, args.orgSlug, 'member');
+		const isEditor = membershipIsEditor(membership.role);
 
 		const supporter = await ctx.db.get(args.supporterId);
 		if (!supporter || supporter.orgId !== org._id) {
@@ -250,28 +314,31 @@ export const get = query({
 			})
 		);
 
-		return {
-			_id: supporter._id,
-			_creationTime: supporter._creationTime,
-			encryptedEmail: supporter.encryptedEmail,
-			emailHash: supporter.emailHash,
-			encryptedName: supporter.encryptedName ?? null,
-			postalCode: supporter.postalCode ?? null,
-			stateCode: supporter.stateCode ?? null,
-			congressionalDistrict: supporter.congressionalDistrict ?? null,
-			country: supporter.country ?? null,
-			encryptedPhone: supporter.encryptedPhone ?? null,
-			verified: supporter.verified,
-			identityVerified: !!(supporter.identityCommitment && supporter.verified),
-			identityCommitment: supporter.identityCommitment ?? null,
-			emailStatus: supporter.emailStatus,
-			smsStatus: supporter.smsStatus,
-			source: supporter.source ?? null,
-			encryptedCustomFields: supporter.encryptedCustomFields ?? null,
-			importedAt: supporter.importedAt ?? null,
-			updatedAt: supporter.updatedAt,
-			tags: tags.filter((t): t is NonNullable<typeof t> => t !== null)
-		};
+		return projectSupporterFields(
+			{
+				_id: supporter._id,
+				_creationTime: supporter._creationTime,
+				encryptedEmail: supporter.encryptedEmail,
+				emailHash: supporter.emailHash as string | null,
+				encryptedName: supporter.encryptedName ?? null,
+				postalCode: supporter.postalCode ?? null,
+				stateCode: supporter.stateCode ?? null,
+				congressionalDistrict: supporter.congressionalDistrict ?? null,
+				country: supporter.country ?? null,
+				encryptedPhone: supporter.encryptedPhone ?? null,
+				verified: supporter.verified,
+				identityVerified: !!(supporter.identityCommitment && supporter.verified),
+				identityCommitment: supporter.identityCommitment ?? null,
+				emailStatus: supporter.emailStatus,
+				smsStatus: supporter.smsStatus,
+				source: supporter.source ?? null,
+				encryptedCustomFields: supporter.encryptedCustomFields ?? null,
+				importedAt: supporter.importedAt ?? null,
+				updatedAt: supporter.updatedAt,
+				tags: tags.filter((t): t is NonNullable<typeof t> => t !== null)
+			},
+			isEditor
+		);
 	}
 });
 
@@ -281,13 +348,20 @@ export const get = query({
 export const findByEmailHash = query({
 	args: { slug: v.string(), emailHash: v.string() },
 	handler: async (ctx, args) => {
-		const { org } = await requireOrgRole(ctx, args.slug, 'member');
-		return ctx.db
+		const { org, membership } = await requireOrgRole(ctx, args.slug, 'member');
+		const isEditor = membershipIsEditor(membership.role);
+		const doc = await ctx.db
 			.query('supporters')
 			.withIndex('by_orgId_emailHash', (idx) =>
 				idx.eq('orgId', org._id).eq('emailHash', args.emailHash)
 			)
 			.first();
+		if (!doc) return null;
+		// Raw .first() returns the full document (consent text + the join-key
+		// hash). The caller already holds the hash, so a non-editor learns
+		// nothing new by getting it back — but the consent-evidence fields are
+		// editor-only, so project them out for plain members.
+		return projectSupporterFields(doc, isEditor);
 	}
 });
 
@@ -297,7 +371,8 @@ export const searchByEmail = query({
 		emailHash: v.string()
 	},
 	handler: async (ctx, args) => {
-		const { org } = await requireOrgRole(ctx, args.orgSlug, 'member');
+		const { org, membership } = await requireOrgRole(ctx, args.orgSlug, 'member');
+		const isEditor = membershipIsEditor(membership.role);
 
 		const supporter = await ctx.db
 			.query('supporters')
@@ -319,15 +394,21 @@ export const searchByEmail = query({
 			})
 		);
 
-		return {
-			_id: supporter._id,
-			_creationTime: supporter._creationTime,
-			encryptedEmail: supporter.encryptedEmail,
-			encryptedName: supporter.encryptedName ?? null,
-			verified: supporter.verified,
-			emailStatus: supporter.emailStatus,
-			tags: tags.filter((t): t is NonNullable<typeof t> => t !== null)
-		};
+		// This shape carries neither emailHash nor consent fields today; route
+		// it through the shared projection anyway so the editor gate cannot
+		// drift if either field is added back here later.
+		return projectSupporterFields(
+			{
+				_id: supporter._id,
+				_creationTime: supporter._creationTime,
+				encryptedEmail: supporter.encryptedEmail,
+				encryptedName: supporter.encryptedName ?? null,
+				verified: supporter.verified,
+				emailStatus: supporter.emailStatus,
+				tags: tags.filter((t): t is NonNullable<typeof t> => t !== null)
+			},
+			isEditor
+		);
 	}
 });
 

--- a/convex/supporters.ts
+++ b/convex/supporters.ts
@@ -192,6 +192,14 @@ export const list = query({
 			.withIndex('by_orgId', (idx) => idx.eq('orgId', org._id))
 			.take(MAX_SCAN);
 
+		// When the scan saturates the cap, this list reflects only a 10K window
+		// of the org — rows beyond it are silently absent (and because the
+		// by_orgId scan is oldest-first, the missing rows are the NEWEST). Surface
+		// the cap honestly so the page can warn the operator instead of presenting
+		// a truncated list as complete. Mirrors the v1 API's `truncated`/`scanLimit`
+		// envelope (convex/v1api.ts listSupporters).
+		const scanCapped = allDocs.length >= MAX_SCAN;
+
 		// Apply filters in memory (Convex indexes are limited to equality prefixes)
 		let filtered = allDocs;
 		if (filters?.emailStatus) {
@@ -281,7 +289,10 @@ export const list = query({
 		return {
 			supporters,
 			nextCursor,
-			hasMore
+			hasMore,
+			// Additive — existing consumers read { supporters, nextCursor, hasMore }.
+			truncated: scanCapped,
+			scanLimit: MAX_SCAN
 		};
 	}
 });

--- a/convex/supporters.ts
+++ b/convex/supporters.ts
@@ -230,7 +230,9 @@ export const list = query({
 			filtered = filtered.filter((s) => supporterIds.has(s._id));
 		}
 
-		// Sort by _creationTime descending (newest first)
+		// Two-stage ordering: the DB `order('desc')` above selects WHICH rows enter
+		// the scan window (the newest MAX_SCAN); this in-memory sort fixes the
+		// DISPLAY order of the filtered subset (newest first) after the filters run.
 		filtered.sort((a, b) => b._creationTime - a._creationTime);
 
 		// Cursor-based slicing
@@ -374,6 +376,10 @@ export const findByEmailHash = query({
 		// supporter-search feature (searchByEmail) stays 'member' while existence-
 		// probing is restricted to editors.
 		const { org, membership } = await requireOrgRole(ctx, args.slug, 'editor');
+		// The editor gate above IS the access control here; isEditor is therefore
+		// always true and the projection below is a no-op today. It is kept as
+		// belt-and-suspenders so the field-level gate still holds if this reader is
+		// ever downgraded to 'member' — the role check and the projection won't drift.
 		const isEditor = membershipIsEditor(membership.role);
 		const doc = await ctx.db
 			.query('supporters')

--- a/src/lib/core/identity/cache-invalidation.ts
+++ b/src/lib/core/identity/cache-invalidation.ts
@@ -25,12 +25,10 @@ const ADDRESS_DB_NAME = 'commons-address';
 const LOCATION_DB_NAME = 'commons_location';
 const SEARCH_CACHE_DB_NAME = 'commons-search-cache';
 const MESSAGE_JOB_RECOVERY_DB_NAME = 'commons-message-jobs';
-// Wrapped org keys (src/lib/services/org-key-manager.ts) + device master
-// keystore (src/lib/core/identity/credential-encryption.ts). Both must be
-// swept on logout or the next user on a shared browser can re-derive and
-// decrypt cached org PII.
-const ORG_KEY_DB_NAME = 'commons-org-keys';
-const KEYSTORE_DB_NAME = 'commons-keystore';
+// The wrapped org keys (commons-org-keys) and device master keystore
+// (commons-keystore) are swept on logout by their owning modules'
+// clearAllOrgKeys() / clearKeystore() — called below — so the next user on a
+// shared browser cannot re-derive and decrypt cached org PII.
 
 // localStorage keys
 const GUEST_STATE_KEY = 'commons_guest_template';

--- a/src/lib/core/identity/cache-invalidation.ts
+++ b/src/lib/core/identity/cache-invalidation.ts
@@ -25,6 +25,12 @@ const ADDRESS_DB_NAME = 'commons-address';
 const LOCATION_DB_NAME = 'commons_location';
 const SEARCH_CACHE_DB_NAME = 'commons-search-cache';
 const MESSAGE_JOB_RECOVERY_DB_NAME = 'commons-message-jobs';
+// Wrapped org keys (src/lib/services/org-key-manager.ts) + device master
+// keystore (src/lib/core/identity/credential-encryption.ts). Both must be
+// swept on logout or the next user on a shared browser can re-derive and
+// decrypt cached org PII.
+const ORG_KEY_DB_NAME = 'commons-org-keys';
+const KEYSTORE_DB_NAME = 'commons-keystore';
 
 // localStorage keys
 const GUEST_STATE_KEY = 'commons_guest_template';
@@ -173,11 +179,27 @@ export async function clearAllClientCaches(): Promise<void> {
 
 	// Clear session credentials + derived key material from memory
 	await invalidateSessionCredentials();
+
+	// Tear down the device master keystore (commons-keystore): null the
+	// in-memory master bytes + derived-key cache AND delete the on-disk store.
+	// discardDerivedKeys() alone leaves both the master and cachedMasterBytes,
+	// so the next user on a shared browser could re-derive per-user keys and
+	// decrypt cached PII.
 	try {
-		const { discardDerivedKeys } = await import('./credential-encryption');
-		discardDerivedKeys();
-	} catch {
-		// credential-encryption may not be loaded — safe to ignore
+		const { clearKeystore } = await import('./credential-encryption');
+		await clearKeystore();
+	} catch (error) {
+		console.error('[CacheInvalidation] Failed to clear device keystore:', error);
+	}
+
+	// Drop every wrapped org key (commons-org-keys). Logout has no list of
+	// which orgs were unwrapped, so dropping the whole store is the only way to
+	// guarantee no wrapped org key survives for the next user to re-derive.
+	try {
+		const { clearAllOrgKeys } = await import('$lib/services/org-key-manager');
+		await clearAllOrgKeys();
+	} catch (error) {
+		console.error('[CacheInvalidation] Failed to clear org keys:', error);
 	}
 
 	// Clear decision-maker search results — surveillance-leak vector on shared

--- a/src/lib/core/identity/credential-encryption.ts
+++ b/src/lib/core/identity/credential-encryption.ts
@@ -118,6 +118,15 @@ let cachedMasterBytes: ArrayBuffer | null = null;
 /** Serialization lock — prevents concurrent callers from generating duplicate master keys */
 let masterKeyPromise: Promise<ArrayBuffer> | null = null;
 
+/**
+ * Monotonic generation counter for the master key. Bumped by `clearKeystore`
+ * as part of its in-memory wipe. An in-flight `getOrCreateMasterBytes` IIFE
+ * captures the epoch at entry and refuses to re-populate `cachedMasterBytes`
+ * if a clear happened mid-fetch — otherwise a fetch that started before logout
+ * could resurrect the master in memory AFTER `clearKeystore` nulled it.
+ */
+let masterKeyEpoch = 0;
+
 /** Cached per-user derived keys: Map<recordId, CryptoKey> */
 const derivedKeyCache = new Map<string, CryptoKey>();
 
@@ -139,6 +148,11 @@ export async function getOrCreateMasterBytes(): Promise<ArrayBuffer> {
 	// and the first encryption becomes undecryptable.
 	if (!masterKeyPromise) {
 		masterKeyPromise = (async () => {
+			// Capture the epoch at entry. If `clearKeystore` bumps it while this
+			// fetch is in flight, the assignments below skip the cache write — the
+			// in-flight caller still gets its value, but the master is NOT
+			// resurrected in memory after logout nulled it.
+			const startEpoch = masterKeyEpoch;
 			try {
 				const db = await openKeyDB();
 
@@ -156,7 +170,7 @@ export async function getOrCreateMasterBytes(): Promise<ArrayBuffer> {
 				});
 
 				if (existing) {
-					cachedMasterBytes = existing;
+					if (startEpoch === masterKeyEpoch) cachedMasterBytes = existing;
 					console.debug('[CredentialEncryption] Retrieved existing derivation master key');
 					return existing;
 				}
@@ -177,7 +191,7 @@ export async function getOrCreateMasterBytes(): Promise<ArrayBuffer> {
 					request.onsuccess = () => resolve();
 				});
 
-				cachedMasterBytes = rawBytes;
+				if (startEpoch === masterKeyEpoch) cachedMasterBytes = rawBytes;
 				console.debug('[CredentialEncryption] Created new derivation master key');
 				return rawBytes;
 			} finally {
@@ -295,35 +309,68 @@ export function discardDerivedKeys(): void {
  * per-user key from that master and decrypt cached PII. This:
  *
  *   1. Nulls every in-memory cache (master bytes, the master-key generation
- *      promise, the legacy device key, and the derived-key Map).
- *   2. Closes the cached IndexedDB connection so `deleteDatabase` isn't blocked.
- *   3. Deletes the entire `commons-keystore` database so the device master is
- *      gone from disk — without it, the ciphertext in other stores is inert.
+ *      promise, the legacy device key, and the derived-key Map) and bumps the
+ *      master-key epoch so an in-flight `getOrCreateMasterBytes` cannot
+ *      re-populate `cachedMasterBytes` after this wipe.
+ *   2. Clears the KEY_STORE_NAME object-store CONTENTS in a readwrite
+ *      transaction. Unlike `deleteDatabase`, `objectStore.clear()` is NOT
+ *      blocked by other open connections, so the device master bytes are
+ *      guaranteed gone from disk even if another tab holds the keystore open.
+ *   3. Best-effort deletes the `commons-keystore` database to remove the empty
+ *      shell. The sensitive data is already cleared, so this resolves on
+ *      success, error, AND blocked — a lingering empty DB is harmless.
  */
 export async function clearKeystore(): Promise<void> {
 	cachedMasterBytes = null;
 	masterKeyPromise = null;
 	cachedLegacyKey = null;
 	derivedKeyCache.clear();
+	// Invalidate any in-flight master-key fetch so it can't resurrect the cache.
+	masterKeyEpoch++;
 
+	// Step 1 — guaranteed wipe: clear the object-store contents. A readwrite
+	// transaction's clear() succeeds even while other tabs hold the DB open, so
+	// the master bytes are gone from disk regardless of `deleteDatabase` blocking.
+	try {
+		const db = await openKeyDB();
+		await new Promise<void>((resolve, reject) => {
+			const tx = db.transaction(KEY_STORE_NAME, 'readwrite');
+			const store = tx.objectStore(KEY_STORE_NAME);
+			store.clear();
+			tx.oncomplete = () => resolve();
+			tx.onerror = () => reject(tx.error);
+			tx.onabort = () => reject(tx.error);
+		});
+	} catch (err) {
+		// Tolerate "store/DB doesn't exist" — nothing to wipe means the goal
+		// (no master bytes on disk) is already met.
+		console.debug('[CredentialEncryption] Keystore clear skipped (store/DB absent):', err);
+	}
+
+	// Close our connection so the best-effort deleteDatabase below isn't blocked
+	// by our own handle.
 	if (keyDBInstance) {
 		keyDBInstance.close();
 		keyDBInstance = null;
 	}
 
-	return new Promise((resolve, reject) => {
+	// Step 2 — best-effort: drop the now-empty DB shell. The sensitive data is
+	// already cleared in step 1, so resolve on success, error, AND blocked. A
+	// blocked delete only leaves an EMPTY database behind until other tabs close.
+	return new Promise((resolve) => {
 		const request = indexedDB.deleteDatabase(KEY_DB_NAME);
 		request.onsuccess = () => {
 			console.debug('[CredentialEncryption] Device keystore deleted');
 			resolve();
 		};
-		request.onerror = () => reject(request.error);
-		// Do NOT resolve on block: another open connection holds the keystore, so
-		// the device master survives on disk. Resolving would let logout report
-		// success while the next user on a shared browser can still re-derive —
-		// reject so the caller logs the incomplete wipe.
-		request.onblocked = () =>
-			reject(new Error('device keystore deletion blocked by an open connection'));
+		request.onerror = () => {
+			console.debug('[CredentialEncryption] Device keystore delete errored (contents already cleared)');
+			resolve();
+		};
+		request.onblocked = () => {
+			console.debug('[CredentialEncryption] Device keystore delete blocked (contents already cleared)');
+			resolve();
+		};
 	});
 }
 

--- a/src/lib/core/identity/credential-encryption.ts
+++ b/src/lib/core/identity/credential-encryption.ts
@@ -148,10 +148,10 @@ export async function getOrCreateMasterBytes(): Promise<ArrayBuffer> {
 	// and the first encryption becomes undecryptable.
 	if (!masterKeyPromise) {
 		masterKeyPromise = (async () => {
-			// Capture the epoch at entry. If `clearKeystore` bumps it while this
-			// fetch is in flight, the assignments below skip the cache write — the
-			// in-flight caller still gets its value, but the master is NOT
-			// resurrected in memory after logout nulled it.
+			// Capture the epoch at entry. A clear() (clearKeystore/clearAllKeys) bumps
+			// it AND nulls masterKeyPromise. We use that one signal for two guards
+			// below: skip the cache write (don't resurrect the master after logout),
+			// and skip releasing the promise slot (a post-clear fetch may now own it).
 			const startEpoch = masterKeyEpoch;
 			try {
 				const db = await openKeyDB();
@@ -195,7 +195,10 @@ export async function getOrCreateMasterBytes(): Promise<ArrayBuffer> {
 				console.debug('[CredentialEncryption] Created new derivation master key');
 				return rawBytes;
 			} finally {
-				masterKeyPromise = null;
+				// Only release the lock if no clear() happened during this fetch
+				// (epoch unchanged) — a clear nulls the slot and a new fetch may now
+				// own it, so our stale finally must not clobber that newer promise.
+				if (startEpoch === masterKeyEpoch) masterKeyPromise = null;
 			}
 		})();
 	}
@@ -342,9 +345,17 @@ export async function clearKeystore(): Promise<void> {
 			tx.onabort = () => reject(tx.error);
 		});
 	} catch (err) {
-		// Tolerate "store/DB doesn't exist" — nothing to wipe means the goal
-		// (no master bytes on disk) is already met.
-		console.debug('[CredentialEncryption] Keystore clear skipped (store/DB absent):', err);
+		if (err instanceof DOMException && err.name === 'NotFoundError') {
+			// Benign: the store/DB never existed, so there are no master bytes to
+			// wipe — the goal is already met.
+			console.debug('[CredentialEncryption] Keystore clear skipped (store/DB absent):', err);
+		} else {
+			// A real transaction failure (abort, quota, corruption) means the master
+			// bytes may STILL be on disk. Do not let logout report success silently —
+			// surface it and rethrow so the caller records a failed key sweep.
+			console.error('[CredentialEncryption] Keystore content wipe FAILED — master bytes may persist:', err);
+			throw err;
+		}
 	}
 
 	// Close our connection so the best-effort deleteDatabase below isn't blocked
@@ -637,6 +648,9 @@ export async function clearAllKeys(): Promise<void> {
 	masterKeyPromise = null;
 	cachedLegacyKey = null;
 	derivedKeyCache.clear();
+	// Bump the epoch like clearKeystore so an in-flight getOrCreateMasterBytes
+	// can't resurrect cachedMasterBytes after this clear (same race guard).
+	masterKeyEpoch++;
 
 	console.debug('[CredentialEncryption] All key material cleared');
 }

--- a/src/lib/core/identity/credential-encryption.ts
+++ b/src/lib/core/identity/credential-encryption.ts
@@ -318,8 +318,12 @@ export async function clearKeystore(): Promise<void> {
 			resolve();
 		};
 		request.onerror = () => reject(request.error);
-		// Resolve on block too — deletion completes once remaining handles close.
-		request.onblocked = () => resolve();
+		// Do NOT resolve on block: another open connection holds the keystore, so
+		// the device master survives on disk. Resolving would let logout report
+		// success while the next user on a shared browser can still re-derive —
+		// reject so the caller logs the incomplete wipe.
+		request.onblocked = () =>
+			reject(new Error('device keystore deletion blocked by an open connection'));
 	});
 }
 

--- a/src/lib/core/identity/credential-encryption.ts
+++ b/src/lib/core/identity/credential-encryption.ts
@@ -286,6 +286,43 @@ export function discardDerivedKeys(): void {
 	console.debug('[CredentialEncryption] All derived keys discarded');
 }
 
+/**
+ * Tear down the device keystore for logout on a shared browser.
+ *
+ * `discardDerivedKeys()` only clears the in-memory derived-key Map — it leaves
+ * the on-disk device master (`commons-keystore`) AND the in-memory
+ * `cachedMasterBytes`. On a shared device the next user could re-derive any
+ * per-user key from that master and decrypt cached PII. This:
+ *
+ *   1. Nulls every in-memory cache (master bytes, the master-key generation
+ *      promise, the legacy device key, and the derived-key Map).
+ *   2. Closes the cached IndexedDB connection so `deleteDatabase` isn't blocked.
+ *   3. Deletes the entire `commons-keystore` database so the device master is
+ *      gone from disk — without it, the ciphertext in other stores is inert.
+ */
+export async function clearKeystore(): Promise<void> {
+	cachedMasterBytes = null;
+	masterKeyPromise = null;
+	cachedLegacyKey = null;
+	derivedKeyCache.clear();
+
+	if (keyDBInstance) {
+		keyDBInstance.close();
+		keyDBInstance = null;
+	}
+
+	return new Promise((resolve, reject) => {
+		const request = indexedDB.deleteDatabase(KEY_DB_NAME);
+		request.onsuccess = () => {
+			console.debug('[CredentialEncryption] Device keystore deleted');
+			resolve();
+		};
+		request.onerror = () => reject(request.error);
+		// Resolve on block too — deletion completes once remaining handles close.
+		request.onblocked = () => resolve();
+	});
+}
+
 // ============================================================================
 // Legacy v1 Key Management (for migration)
 // ============================================================================

--- a/src/lib/services/org-key-manager.ts
+++ b/src/lib/services/org-key-manager.ts
@@ -169,8 +169,16 @@ export async function clearAllOrgKeys(): Promise<void> {
 			tx.onabort = () => reject(tx.error);
 		});
 	} catch (err) {
-		// Tolerate "store/DB doesn't exist" — nothing cached means nothing to wipe.
-		console.debug('[OrgKeyManager] Org-key clear skipped (store/DB absent):', err);
+		if (err instanceof DOMException && err.name === 'NotFoundError') {
+			// Benign: the store/DB never existed, so there are no wrapped keys to wipe.
+			console.debug('[OrgKeyManager] Org-key clear skipped (store/DB absent):', err);
+		} else {
+			// A real transaction failure means wrapped org keys may STILL be on disk.
+			// Surface it and rethrow so logout records a failed key sweep rather than
+			// silently reporting success.
+			console.error('[OrgKeyManager] Org-key content wipe FAILED — wrapped keys may persist:', err);
+			throw err;
+		}
 	}
 
 	// Close our handle so the best-effort delete below isn't blocked by us.

--- a/src/lib/services/org-key-manager.ts
+++ b/src/lib/services/org-key-manager.ts
@@ -141,28 +141,51 @@ export async function cacheOrgKey(orgKey: CryptoKey, orgId: string): Promise<voi
 export { clearCachedWrapped as clearCachedOrgKey };
 
 /**
- * Delete the entire wrapped-org-key store from this device.
+ * Wipe every wrapped org key from this device.
  *
  * Logout has no list of which orgs the user unwrapped, so a per-org
- * `clearCachedOrgKey(orgId)` cannot sweep them all. Dropping the whole DB
- * guarantees no wrapped org key survives for the next user on a shared
- * browser to re-derive and decrypt cached org PII. The cached connection is
- * closed first so `deleteDatabase` isn't blocked by an open handle.
+ * `clearCachedOrgKey(orgId)` cannot sweep them all. We must clear the whole
+ * store so no wrapped org key survives for the next user on a shared browser
+ * to re-derive and decrypt cached org PII.
+ *
+ *   1. Clear the ORG_KEY_STORE_NAME ('wrapped-keys') object-store CONTENTS in a
+ *      readwrite transaction. Unlike `deleteDatabase`, `objectStore.clear()` is
+ *      NOT blocked by other open connections, so the wrapped keys are
+ *      guaranteed gone from disk even if a second tab holds the DB open.
+ *   2. Best-effort delete the database to drop the empty shell — resolve on
+ *      success, error, AND blocked, since the sensitive data is already gone.
  */
 export async function clearAllOrgKeys(): Promise<void> {
+	// Step 1 — guaranteed wipe: clear the store contents. clear() in a readwrite
+	// transaction succeeds even while another tab holds the DB open.
+	try {
+		const db = await openOrgKeyDB();
+		await new Promise<void>((resolve, reject) => {
+			const tx = db.transaction(ORG_KEY_STORE_NAME, 'readwrite');
+			const store = tx.objectStore(ORG_KEY_STORE_NAME);
+			store.clear();
+			tx.oncomplete = () => resolve();
+			tx.onerror = () => reject(tx.error);
+			tx.onabort = () => reject(tx.error);
+		});
+	} catch (err) {
+		// Tolerate "store/DB doesn't exist" — nothing cached means nothing to wipe.
+		console.debug('[OrgKeyManager] Org-key clear skipped (store/DB absent):', err);
+	}
+
+	// Close our handle so the best-effort delete below isn't blocked by us.
 	if (dbInstance) {
 		dbInstance.close();
 		dbInstance = null;
 	}
-	return new Promise((resolve, reject) => {
+
+	// Step 2 — best-effort: drop the now-empty DB shell. The wrapped keys are
+	// already cleared in step 1, so resolve on success, error, AND blocked. A
+	// blocked delete only leaves an EMPTY database behind until other tabs close.
+	return new Promise((resolve) => {
 		const request = indexedDB.deleteDatabase(ORG_KEY_DB_NAME);
 		request.onsuccess = () => resolve();
-		request.onerror = () => reject(request.error);
-		// Do NOT resolve on block: another open connection (e.g. a second tab)
-		// holds the database, so the wrapped org keys remain on disk. Resolving
-		// would let logout report success while the keys survive the shared-
-		// browser sweep — reject so the caller logs the incomplete wipe.
-		request.onblocked = () =>
-			reject(new Error('org-key database deletion blocked by an open connection'));
+		request.onerror = () => resolve();
+		request.onblocked = () => resolve();
 	});
 }

--- a/src/lib/services/org-key-manager.ts
+++ b/src/lib/services/org-key-manager.ts
@@ -158,7 +158,11 @@ export async function clearAllOrgKeys(): Promise<void> {
 		const request = indexedDB.deleteDatabase(ORG_KEY_DB_NAME);
 		request.onsuccess = () => resolve();
 		request.onerror = () => reject(request.error);
-		// Resolve on block too — deletion completes once remaining handles close.
-		request.onblocked = () => resolve();
+		// Do NOT resolve on block: another open connection (e.g. a second tab)
+		// holds the database, so the wrapped org keys remain on disk. Resolving
+		// would let logout report success while the keys survive the shared-
+		// browser sweep — reject so the caller logs the incomplete wipe.
+		request.onblocked = () =>
+			reject(new Error('org-key database deletion blocked by an open connection'));
 	});
 }

--- a/src/lib/services/org-key-manager.ts
+++ b/src/lib/services/org-key-manager.ts
@@ -139,3 +139,26 @@ export async function cacheOrgKey(orgKey: CryptoKey, orgId: string): Promise<voi
  * Clear the cached org key for an org (e.g., on logout or passphrase change).
  */
 export { clearCachedWrapped as clearCachedOrgKey };
+
+/**
+ * Delete the entire wrapped-org-key store from this device.
+ *
+ * Logout has no list of which orgs the user unwrapped, so a per-org
+ * `clearCachedOrgKey(orgId)` cannot sweep them all. Dropping the whole DB
+ * guarantees no wrapped org key survives for the next user on a shared
+ * browser to re-derive and decrypt cached org PII. The cached connection is
+ * closed first so `deleteDatabase` isn't blocked by an open handle.
+ */
+export async function clearAllOrgKeys(): Promise<void> {
+	if (dbInstance) {
+		dbInstance.close();
+		dbInstance = null;
+	}
+	return new Promise((resolve, reject) => {
+		const request = indexedDB.deleteDatabase(ORG_KEY_DB_NAME);
+		request.onsuccess = () => resolve();
+		request.onerror = () => reject(request.error);
+		// Resolve on block too — deletion completes once remaining handles close.
+		request.onblocked = () => resolve();
+	});
+}

--- a/src/routes/org/[slug]/supporters/+page.server.ts
+++ b/src/routes/org/[slug]/supporters/+page.server.ts
@@ -30,6 +30,8 @@ type SupporterListResult = {
 	}>;
 	hasMore: boolean;
 	nextCursor: string | null;
+	truncated?: boolean;
+	scanLimit?: number;
 };
 
 type CampaignListResult = {
@@ -194,6 +196,10 @@ export const load: PageServerLoad = async ({ parent, url }) => {
 		total: summaryStats.total,
 		hasMore: convexResult.hasMore,
 		nextCursor: convexResult.nextCursor,
+		// When the org exceeds the per-query scan cap, the list reflects only the
+		// most recent `scanLimit` rows — surface it so the page can say so.
+		scanCapped: convexResult.truncated ?? false,
+		scanLimit: convexResult.scanLimit ?? null,
 		tags: (tags ?? []).map((t: Record<string, unknown>) => ({
 			id: t._id ?? t.id,
 			name: t.name,

--- a/src/routes/org/[slug]/supporters/+page.svelte
+++ b/src/routes/org/[slug]/supporters/+page.svelte
@@ -706,7 +706,7 @@
 	<!-- Scan-cap notice: the list reflects only the most recent window -->
 	{#if scanCapped}
 		<p class="text-text-tertiary text-sm" role="status">
-			Showing the most recent {fmt(scanLimit)} — refine filters to narrow the list.
+			Showing the {fmt(scanLimit)} most recent supporters — older ones aren't listed here.
 		</p>
 	{/if}
 

--- a/src/routes/org/[slug]/supporters/+page.svelte
+++ b/src/routes/org/[slug]/supporters/+page.svelte
@@ -657,6 +657,12 @@
 	const emailStatuses = ['subscribed', 'unsubscribed', 'bounced', 'complained'] as const;
 
 	const sourceOptions = $derived(buildSourceFilterOptions(data.sourceCounts));
+
+	// The list query scans at most `scanLimit` rows per org. When the org has
+	// more, only the most recent window comes back — say so plainly instead of
+	// presenting a truncated list as the whole roster.
+	const scanCapped = $derived(Boolean(data.scanCapped));
+	const scanLimit = $derived(data.scanLimit ?? 10000);
 </script>
 
 <div class="space-y-5">
@@ -696,6 +702,13 @@
 			{/if}
 		</div>
 	</div>
+
+	<!-- Scan-cap notice: the list reflects only the most recent window -->
+	{#if scanCapped}
+		<p class="text-text-tertiary text-sm" role="status">
+			Showing the most recent {fmt(scanLimit)} — refine filters to narrow the list.
+		</p>
+	{/if}
 
 	<!-- Export outcome -->
 	{#if exportNotice}

--- a/tests/unit/identity/logout-keystore-sweep.test.ts
+++ b/tests/unit/identity/logout-keystore-sweep.test.ts
@@ -9,12 +9,13 @@
  * decrypt cached org PII.
  *
  * This pins the module-owned teardown helpers (which `clearAllClientCaches` now
- * calls) against real fake-indexeddb behavior, proves a blocked deletion is
- * surfaced rather than reported as success, and source-pins the logout wiring.
+ * calls) against real fake-indexeddb behavior, proves the key DATA is wiped even
+ * when `deleteDatabase` is blocked by another open connection, and source-pins
+ * the logout wiring.
  */
 
 import 'fake-indexeddb/auto';
-import { afterEach, describe, it, expect } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 
@@ -37,8 +38,11 @@ function dbExists(name: string): Promise<boolean> {
 		};
 		req.onsuccess = () => {
 			req.result.close();
-			// Clean up the probe DB so it doesn't pollute later assertions.
-			indexedDB.deleteDatabase(name);
+			// Only delete the probe DB if WE created it (it didn't pre-exist) — a
+			// blanket delete would tear down a DB the test still depends on.
+			if (!existed) {
+				indexedDB.deleteDatabase(name);
+			}
 			resolve(existed);
 		};
 		req.onerror = () => resolve(false);
@@ -87,35 +91,84 @@ describe('wrapped org-key teardown', () => {
 	});
 });
 
-describe('blocked deletion is surfaced, not silently reported as success', () => {
-	// A second open connection (e.g. another tab) blocks deleteDatabase: the key
-	// DB stays on disk. The teardown must reject so the logout path logs the
-	// incomplete wipe instead of redirecting as if the keys were gone.
-	const realDeleteDatabase = indexedDB.deleteDatabase.bind(indexedDB);
-	afterEach(() => {
-		indexedDB.deleteDatabase = realDeleteDatabase;
-	});
+describe('key DATA is wiped even when deleteDatabase is blocked by an open connection', () => {
+	// A second open connection (e.g. another tab) blocks `deleteDatabase`, so the
+	// empty DB shell may linger. But the SENSITIVE data must already be gone: a
+	// readwrite `objectStore.clear()` is NOT blocked by other connections, so the
+	// teardown clears the store contents first, then best-effort deletes the DB
+	// (resolving even on blocked). The logout path can then safely redirect.
 
-	function stubBlockedDeletion() {
-		indexedDB.deleteDatabase = ((_name: string) => {
-			const request: Record<string, unknown> = {};
-			// Fire onblocked once the caller has wired its handler.
-			queueMicrotask(() => {
-				const handler = request.onblocked as (() => void) | undefined;
-				handler?.();
-			});
-			return request as unknown as IDBOpenDBRequest;
-		}) as typeof indexedDB.deleteDatabase;
+	function openRaw(name: string): Promise<IDBDatabase> {
+		return new Promise((resolve, reject) => {
+			const req = indexedDB.open(name);
+			req.onsuccess = () => resolve(req.result);
+			req.onerror = () => reject(req.error);
+		});
 	}
 
-	it('clearKeystore rejects when the keystore deletion is blocked', async () => {
-		stubBlockedDeletion();
-		await expect(clearKeystore()).rejects.toThrow(/blocked/i);
+	function getRecord(db: IDBDatabase, store: string, key: string): Promise<unknown> {
+		return new Promise((resolve, reject) => {
+			const tx = db.transaction(store, 'readonly');
+			const req = tx.objectStore(store).get(key);
+			req.onsuccess = () => resolve(req.result);
+			req.onerror = () => reject(req.error);
+		});
+	}
+
+	it('clearKeystore resolves and wipes the master record even though a second connection blocks the DB delete', async () => {
+		// Materialize the device master on disk.
+		const first = await getOrCreateMasterBytes();
+		expect(first.byteLength).toBe(32);
+		// Encrypt something so the keystore is genuinely populated.
+		await encryptCredential({ secret: 'x' }, 'user-1');
+
+		// Hold a second open connection so the internal deleteDatabase BLOCKS —
+		// only the readwrite clear() (which isn't blocked) can wipe the data.
+		const holder = await openRaw('commons-keystore');
+
+		// Must RESOLVE (not reject): the store CONTENTS are cleared even though the
+		// best-effort DB-shell delete is blocked by `holder`.
+		await expect(clearKeystore()).resolves.toBeUndefined();
+
+		// Close the holder so the now-pending (previously blocked) delete can drain
+		// before we re-open. (A real second tab closing does the same.)
+		holder.close();
+
+		// The master record is GONE: re-opening regenerates fresh material rather
+		// than handing back the discarded buffer.
+		const regenerated = await getOrCreateMasterBytes();
+		expect(regenerated.byteLength).toBe(32);
+		expect(new Uint8Array(regenerated)).not.toEqual(new Uint8Array(first));
+
+		await clearKeystore();
 	});
 
-	it('clearAllOrgKeys rejects when the org-key deletion is blocked', async () => {
-		stubBlockedDeletion();
-		await expect(clearAllOrgKeys()).rejects.toThrow(/blocked/i);
+	it('clearAllOrgKeys resolves and wipes the wrapped key even though a second connection blocks the DB delete', async () => {
+		const orgId = 'org_blocked';
+		const passphrase = 'correct horse battery staple';
+		const orgKey = await deriveOrgKey(passphrase, orgId);
+		const verifier = await createKeyVerifier(orgKey);
+
+		await cacheOrgKey(orgKey, orgId);
+		expect(await getOrPromptOrgKey(orgId, verifier)).not.toBeNull();
+
+		// Hold a second open connection so the internal deleteDatabase BLOCKS.
+		const holder = await openRaw('commons-org-keys');
+
+		// Must RESOLVE — the wrapped key is cleared even though the shell delete
+		// is blocked.
+		await expect(clearAllOrgKeys()).resolves.toBeUndefined();
+
+		// Assert the wrapped-key row is gone directly on the holder connection
+		// (the contents were cleared while it was still open).
+		expect(await getRecord(holder, 'wrapped-keys', orgId)).toBeUndefined();
+
+		// Close the holder so the pending delete can drain, then confirm no wrapped
+		// key survives for the next user to unwrap.
+		holder.close();
+		expect(await getOrPromptOrgKey(orgId, verifier)).toBeNull();
+
+		await clearAllOrgKeys();
 	});
 });
 

--- a/tests/unit/identity/logout-keystore-sweep.test.ts
+++ b/tests/unit/identity/logout-keystore-sweep.test.ts
@@ -1,5 +1,5 @@
 /**
- * C-19 — logout must sweep the wrapped org keys + the device master keystore.
+ * Logout must sweep the wrapped org keys + the device master keystore.
  *
  * `clearAllClientCaches` deleted five IndexedDB DBs on logout but never
  * `commons-org-keys` (wrapped org keys) nor `commons-keystore` (the device
@@ -9,12 +9,12 @@
  * decrypt cached org PII.
  *
  * This pins the module-owned teardown helpers (which `clearAllClientCaches` now
- * calls) against real fake-indexeddb behavior, and source-pins the logout
- * wiring so both DBs are in the swept set.
+ * calls) against real fake-indexeddb behavior, proves a blocked deletion is
+ * surfaced rather than reported as success, and source-pins the logout wiring.
  */
 
 import 'fake-indexeddb/auto';
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 
@@ -45,7 +45,7 @@ function dbExists(name: string): Promise<boolean> {
 	});
 }
 
-describe('C-19 device keystore teardown', () => {
+describe('device keystore teardown', () => {
 	it('clearKeystore deletes commons-keystore and nulls the in-memory master bytes', async () => {
 		// Materialize the device master on disk + in memory.
 		const first = await getOrCreateMasterBytes();
@@ -69,7 +69,7 @@ describe('C-19 device keystore teardown', () => {
 	});
 });
 
-describe('C-19 wrapped org-key teardown', () => {
+describe('wrapped org-key teardown', () => {
 	it('clearAllOrgKeys deletes commons-org-keys so no wrapped key survives', async () => {
 		const orgId = 'org_abc';
 		const passphrase = 'correct horse battery staple';
@@ -87,24 +87,51 @@ describe('C-19 wrapped org-key teardown', () => {
 	});
 });
 
-describe('C-19 logout wiring includes both stores in the swept set', () => {
+describe('blocked deletion is surfaced, not silently reported as success', () => {
+	// A second open connection (e.g. another tab) blocks deleteDatabase: the key
+	// DB stays on disk. The teardown must reject so the logout path logs the
+	// incomplete wipe instead of redirecting as if the keys were gone.
+	const realDeleteDatabase = indexedDB.deleteDatabase.bind(indexedDB);
+	afterEach(() => {
+		indexedDB.deleteDatabase = realDeleteDatabase;
+	});
+
+	function stubBlockedDeletion() {
+		indexedDB.deleteDatabase = ((_name: string) => {
+			const request: Record<string, unknown> = {};
+			// Fire onblocked once the caller has wired its handler.
+			queueMicrotask(() => {
+				const handler = request.onblocked as (() => void) | undefined;
+				handler?.();
+			});
+			return request as unknown as IDBOpenDBRequest;
+		}) as typeof indexedDB.deleteDatabase;
+	}
+
+	it('clearKeystore rejects when the keystore deletion is blocked', async () => {
+		stubBlockedDeletion();
+		await expect(clearKeystore()).rejects.toThrow(/blocked/i);
+	});
+
+	it('clearAllOrgKeys rejects when the org-key deletion is blocked', async () => {
+		stubBlockedDeletion();
+		await expect(clearAllOrgKeys()).rejects.toThrow(/blocked/i);
+	});
+});
+
+describe('logout wiring delegates both stores to their owning teardown', () => {
 	const source = readFileSync(
 		path.resolve(process.cwd(), 'src/lib/core/identity/cache-invalidation.ts'),
 		'utf8'
 	);
 
-	it('names both IndexedDB databases', () => {
-		expect(source).toContain("'commons-org-keys'");
-		expect(source).toContain("'commons-keystore'");
-	});
-
 	it('clearAllClientCaches calls the module-owned teardown for both stores', () => {
 		const from = source.indexOf('export async function clearAllClientCaches');
 		expect(from).toBeGreaterThan(-1);
 		const body = source.slice(from, source.indexOf('async function clearDatabase', from));
-		// The keystore sweep (which nulls cachedMasterBytes + deletes the DB)
-		// and the org-key sweep both run on logout — not just the old
-		// in-memory-only discardDerivedKeys().
+		// The keystore sweep (which nulls cachedMasterBytes + deletes the DB) and
+		// the org-key sweep both run on logout — not just the old in-memory-only
+		// discardDerivedKeys().
 		expect(body).toContain('clearKeystore');
 		expect(body).toContain('clearAllOrgKeys');
 	});

--- a/tests/unit/identity/logout-keystore-sweep.test.ts
+++ b/tests/unit/identity/logout-keystore-sweep.test.ts
@@ -1,0 +1,111 @@
+/**
+ * C-19 — logout must sweep the wrapped org keys + the device master keystore.
+ *
+ * `clearAllClientCaches` deleted five IndexedDB DBs on logout but never
+ * `commons-org-keys` (wrapped org keys) nor `commons-keystore` (the device
+ * master). `discardDerivedKeys()` only cleared an in-memory Map — it left the
+ * on-disk stores AND the in-memory `cachedMasterBytes`. On a shared browser the
+ * next user could re-derive any per-user key from the surviving master and
+ * decrypt cached org PII.
+ *
+ * This pins the module-owned teardown helpers (which `clearAllClientCaches` now
+ * calls) against real fake-indexeddb behavior, and source-pins the logout
+ * wiring so both DBs are in the swept set.
+ */
+
+import 'fake-indexeddb/auto';
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import {
+	getOrCreateMasterBytes,
+	encryptCredential,
+	clearKeystore
+} from '$lib/core/identity/credential-encryption';
+import { cacheOrgKey, getOrPromptOrgKey, clearAllOrgKeys } from '$lib/services/org-key-manager';
+import { deriveOrgKey, createKeyVerifier } from '$lib/core/crypto/org-pii-encryption';
+
+function dbExists(name: string): Promise<boolean> {
+	return new Promise((resolve) => {
+		let existed = true;
+		const req = indexedDB.open(name);
+		req.onupgradeneeded = () => {
+			// open() with no version creates the DB if absent → upgradeneeded fires
+			// only when it did not already exist.
+			existed = false;
+		};
+		req.onsuccess = () => {
+			req.result.close();
+			// Clean up the probe DB so it doesn't pollute later assertions.
+			indexedDB.deleteDatabase(name);
+			resolve(existed);
+		};
+		req.onerror = () => resolve(false);
+	});
+}
+
+describe('C-19 device keystore teardown', () => {
+	it('clearKeystore deletes commons-keystore and nulls the in-memory master bytes', async () => {
+		// Materialize the device master on disk + in memory.
+		const first = await getOrCreateMasterBytes();
+		expect(first.byteLength).toBe(32);
+		// Encrypt something so the keystore is genuinely populated.
+		const encrypted = await encryptCredential({ secret: 'x' }, 'user-1');
+		expect(encrypted.ciphertext.length).toBeGreaterThan(0);
+
+		await clearKeystore();
+
+		// The on-disk store is gone...
+		expect(await dbExists('commons-keystore')).toBe(false);
+
+		// ...and the in-memory master cache was nulled: the next call regenerates
+		// fresh 32-byte material rather than handing back the discarded buffer.
+		const regenerated = await getOrCreateMasterBytes();
+		expect(regenerated.byteLength).toBe(32);
+		expect(new Uint8Array(regenerated)).not.toEqual(new Uint8Array(first));
+
+		await clearKeystore();
+	});
+});
+
+describe('C-19 wrapped org-key teardown', () => {
+	it('clearAllOrgKeys deletes commons-org-keys so no wrapped key survives', async () => {
+		const orgId = 'org_abc';
+		const passphrase = 'correct horse battery staple';
+		const orgKey = await deriveOrgKey(passphrase, orgId);
+		const verifier = await createKeyVerifier(orgKey);
+
+		await cacheOrgKey(orgKey, orgId);
+		// The wrapped key round-trips before teardown.
+		expect(await getOrPromptOrgKey(orgId, verifier)).not.toBeNull();
+
+		await clearAllOrgKeys();
+
+		// After the sweep there is no wrapped key for the next user to unwrap.
+		expect(await getOrPromptOrgKey(orgId, verifier)).toBeNull();
+	});
+});
+
+describe('C-19 logout wiring includes both stores in the swept set', () => {
+	const source = readFileSync(
+		path.resolve(process.cwd(), 'src/lib/core/identity/cache-invalidation.ts'),
+		'utf8'
+	);
+
+	it('names both IndexedDB databases', () => {
+		expect(source).toContain("'commons-org-keys'");
+		expect(source).toContain("'commons-keystore'");
+	});
+
+	it('clearAllClientCaches calls the module-owned teardown for both stores', () => {
+		const from = source.indexOf('export async function clearAllClientCaches');
+		expect(from).toBeGreaterThan(-1);
+		const body = source.slice(from, source.indexOf('async function clearDatabase', from));
+		// The keystore sweep (which nulls cachedMasterBytes + deletes the DB)
+		// and the org-key sweep both run on logout — not just the old
+		// in-memory-only discardDerivedKeys().
+		expect(body).toContain('clearKeystore');
+		expect(body).toContain('clearAllOrgKeys');
+	});
+});

--- a/tests/unit/org/supporter-list-scan-cap.test.ts
+++ b/tests/unit/org/supporter-list-scan-cap.test.ts
@@ -1,0 +1,114 @@
+/**
+ * C-21 — convex/supporters.ts `list` surfaces scan-cap truncation honestly.
+ *
+ * `list` does `.take(MAX_SCAN)` over the `by_orgId` index (oldest-first) and
+ * then filters/sorts in memory. Above MAX_SCAN it silently drops the overflow
+ * — and because the scan is oldest-first, the dropped rows are the NEWEST. The
+ * response now carries `truncated` (true when the scan saturated the cap) plus
+ * `scanLimit`, mirroring the v1 API envelope, so the page can warn the operator
+ * instead of presenting a 10K window as the complete roster.
+ *
+ * convex-test isn't wired in this repo (see v1-supporters-truncation.test.ts),
+ * so this mirrors the handler's take/derive logic against in-memory rows and
+ * source-pins the Convex return + the page banner.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const MAX_SCAN = 10_000;
+
+interface Row {
+	_id: string;
+	_creationTime: number;
+}
+
+/**
+ * Mirror of convex/supporters.ts `list`: take(MAX_SCAN), derive `truncated`
+ * from window saturation, return `{ hasMore, truncated, scanLimit }`.
+ */
+function list(allRows: Row[], pageLimit = 50) {
+	const allDocs = allRows.slice(0, MAX_SCAN);
+	const scanCapped = allDocs.length >= MAX_SCAN;
+
+	const sorted = [...allDocs].sort((a, b) => b._creationTime - a._creationTime);
+	const page = sorted.slice(0, pageLimit + 1);
+	const hasMore = page.length > pageLimit;
+
+	return { hasMore, truncated: scanCapped, scanLimit: MAX_SCAN };
+}
+
+function makeRows(n: number): Row[] {
+	return Array.from({ length: n }, (_, i) => ({ _id: `sup_${i}`, _creationTime: i }));
+}
+
+describe('C-21 supporter list scan-cap signal', () => {
+	it('flags truncated + carries scanLimit when the org saturates the scan cap', () => {
+		const result = list(makeRows(15_000));
+		expect(result.truncated).toBe(true);
+		expect(result.scanLimit).toBe(MAX_SCAN);
+	});
+
+	it('reports a small org as not truncated', () => {
+		const result = list(makeRows(42));
+		expect(result.truncated).toBe(false);
+		expect(result.scanLimit).toBe(MAX_SCAN);
+	});
+
+	it('treats an org sitting exactly on the cap as truncated (cannot prove completeness)', () => {
+		const result = list(makeRows(MAX_SCAN));
+		expect(result.truncated).toBe(true);
+	});
+
+	it('handles the zero-supporter org', () => {
+		const result = list([]);
+		expect(result.truncated).toBe(false);
+		expect(result.hasMore).toBe(false);
+	});
+});
+
+describe('C-21 source wiring (Convex envelope + page banner)', () => {
+	const convexSource = readFileSync(
+		path.resolve(process.cwd(), 'convex/supporters.ts'),
+		'utf8'
+	);
+	const pageSource = readFileSync(
+		path.resolve(process.cwd(), 'src/routes/org/[slug]/supporters/+page.svelte'),
+		'utf8'
+	);
+	const pageServerSource = readFileSync(
+		path.resolve(process.cwd(), 'src/routes/org/[slug]/supporters/+page.server.ts'),
+		'utf8'
+	);
+
+	it('list derives the cap from MAX_SCAN saturation and returns truncated + scanLimit', () => {
+		const body = convexSource.slice(
+			convexSource.indexOf('export const list = query'),
+			convexSource.indexOf('export const get = query')
+		);
+		expect(body).toContain('allDocs.length >= MAX_SCAN');
+		expect(body).toContain('truncated: scanCapped');
+		expect(body).toContain('scanLimit: MAX_SCAN');
+	});
+
+	it('the page-server forwards the cap flag into page data', () => {
+		expect(pageServerSource).toContain('scanCapped: convexResult.truncated');
+		expect(pageServerSource).toContain('scanLimit: convexResult.scanLimit');
+	});
+
+	it('the page shows a quiet banner when the list is capped', () => {
+		expect(pageSource).toContain('scanCapped');
+		expect(pageSource).toContain('Showing the most recent');
+	});
+
+	it('does not break the existing list envelope consumers depend on', () => {
+		const body = convexSource.slice(
+			convexSource.indexOf('export const list = query'),
+			convexSource.indexOf('export const get = query')
+		);
+		expect(body).toContain('supporters,');
+		expect(body).toContain('nextCursor,');
+		expect(body).toContain('hasMore,');
+	});
+});

--- a/tests/unit/org/supporter-list-scan-cap.test.ts
+++ b/tests/unit/org/supporter-list-scan-cap.test.ts
@@ -26,12 +26,15 @@ interface Row {
 }
 
 /**
- * Mirror of convex/supporters.ts `list`: take(MAX_SCAN), derive `truncated`
- * from window saturation, return `{ hasMore, truncated, scanLimit }`.
+ * Mirror of convex/supporters.ts `list`: take(MAX_SCAN + 1) as a truncation
+ * sentinel, derive `truncated` from `> MAX_SCAN` (an org sitting at exactly the
+ * cap is complete, not truncated), drop the sentinel row from the working set,
+ * return `{ hasMore, truncated, scanLimit }`.
  */
 function list(allRows: Row[], pageLimit = 50) {
-	const allDocs = allRows.slice(0, MAX_SCAN);
-	const scanCapped = allDocs.length >= MAX_SCAN;
+	const scanned = allRows.slice(0, MAX_SCAN + 1);
+	const scanCapped = scanned.length > MAX_SCAN;
+	const allDocs = scanned.slice(0, MAX_SCAN);
 
 	const sorted = [...allDocs].sort((a, b) => b._creationTime - a._creationTime);
 	const page = sorted.slice(0, pageLimit + 1);
@@ -57,8 +60,13 @@ describe('supporter list scan-cap signal', () => {
 		expect(result.scanLimit).toBe(MAX_SCAN);
 	});
 
-	it('treats an org sitting exactly on the cap as truncated (cannot prove completeness)', () => {
+	it('treats an org sitting exactly on the cap as NOT truncated (the sentinel +1 row proves completeness)', () => {
 		const result = list(makeRows(MAX_SCAN));
+		expect(result.truncated).toBe(false);
+	});
+
+	it('flags truncated as soon as the org exceeds the cap by one', () => {
+		const result = list(makeRows(MAX_SCAN + 1));
 		expect(result.truncated).toBe(true);
 	});
 
@@ -83,12 +91,13 @@ describe('source wiring (Convex envelope + page banner)', () => {
 		'utf8'
 	);
 
-	it('list derives the cap from MAX_SCAN saturation and returns truncated + scanLimit', () => {
+	it('list takes the sentinel +1 row, derives the cap from > MAX_SCAN, and returns truncated + scanLimit', () => {
 		const body = convexSource.slice(
 			convexSource.indexOf('export const list = query'),
 			convexSource.indexOf('export const get = query')
 		);
-		expect(body).toContain('allDocs.length >= MAX_SCAN');
+		expect(body).toContain('.take(MAX_SCAN + 1)');
+		expect(body).toContain('scanned.length > MAX_SCAN');
 		expect(body).toContain('truncated: scanCapped');
 		expect(body).toContain('scanLimit: MAX_SCAN');
 	});
@@ -98,9 +107,11 @@ describe('source wiring (Convex envelope + page banner)', () => {
 		expect(pageServerSource).toContain('scanLimit: convexResult.scanLimit');
 	});
 
-	it('the page shows a quiet banner when the list is capped', () => {
+	it('the page shows a quiet, accurate banner when the list is capped', () => {
 		expect(pageSource).toContain('scanCapped');
-		expect(pageSource).toContain('Showing the most recent');
+		expect(pageSource).toContain('most recent supporters');
+		// The banner must NOT imply filtering reaches beyond the loaded window.
+		expect(pageSource).not.toContain('refine filters to narrow');
 	});
 
 	it('does not break the existing list envelope consumers depend on', () => {

--- a/tests/unit/org/supporter-list-scan-cap.test.ts
+++ b/tests/unit/org/supporter-list-scan-cap.test.ts
@@ -1,12 +1,13 @@
 /**
- * C-21 — convex/supporters.ts `list` surfaces scan-cap truncation honestly.
+ * convex/supporters.ts `list` surfaces scan-cap truncation honestly.
  *
- * `list` does `.take(MAX_SCAN)` over the `by_orgId` index (oldest-first) and
- * then filters/sorts in memory. Above MAX_SCAN it silently drops the overflow
- * — and because the scan is oldest-first, the dropped rows are the NEWEST. The
- * response now carries `truncated` (true when the scan saturated the cap) plus
- * `scanLimit`, mirroring the v1 API envelope, so the page can warn the operator
- * instead of presenting a 10K window as the complete roster.
+ * `list` does `.order('desc').take(MAX_SCAN)` over the `by_orgId` index
+ * (newest-first) and then filters/sorts in memory. Above MAX_SCAN it drops the
+ * overflow — now the OLDEST rows, so the 10K window is the most recent
+ * supporters the page's notice truthfully describes. The response carries
+ * `truncated` (true when the scan saturated the cap) plus `scanLimit`,
+ * mirroring the v1 API envelope, so the page warns instead of presenting a 10K
+ * window as the complete roster.
  *
  * convex-test isn't wired in this repo (see v1-supporters-truncation.test.ts),
  * so this mirrors the handler's take/derive logic against in-memory rows and
@@ -43,7 +44,7 @@ function makeRows(n: number): Row[] {
 	return Array.from({ length: n }, (_, i) => ({ _id: `sup_${i}`, _creationTime: i }));
 }
 
-describe('C-21 supporter list scan-cap signal', () => {
+describe('supporter list scan-cap signal', () => {
 	it('flags truncated + carries scanLimit when the org saturates the scan cap', () => {
 		const result = list(makeRows(15_000));
 		expect(result.truncated).toBe(true);
@@ -68,7 +69,7 @@ describe('C-21 supporter list scan-cap signal', () => {
 	});
 });
 
-describe('C-21 source wiring (Convex envelope + page banner)', () => {
+describe('source wiring (Convex envelope + page banner)', () => {
 	const convexSource = readFileSync(
 		path.resolve(process.cwd(), 'convex/supporters.ts'),
 		'utf8'

--- a/tests/unit/org/supporter-search.test.ts
+++ b/tests/unit/org/supporter-search.test.ts
@@ -222,7 +222,9 @@ describe('searchCoverage', () => {
 		);
 		expect(SUPPORTER_SEARCH_SCAN_CAP).toBe(10_000);
 		expect(convexSource).toContain('MAX_SCAN = 10_000');
-		expect(convexSource).toContain('.take(MAX_SCAN)');
+		// The scan takes MAX_SCAN + 1 as a truncation sentinel (an org sitting at
+		// exactly the cap is complete, not truncated), then slices back to the cap.
+		expect(convexSource).toContain('.take(MAX_SCAN + 1)');
 	});
 });
 

--- a/tests/unit/supporters-role-projection.test.ts
+++ b/tests/unit/supporters-role-projection.test.ts
@@ -1,0 +1,154 @@
+/**
+ * C-20 — emailHash + consent evidence are editor-only in the Convex layer.
+ *
+ * `convex/supporters.ts` member-gated readers (`list`, `get`, `searchByEmail`,
+ * `findByEmailHash`) ran `requireOrgRole(ctx, slug, 'member')` and then returned
+ * `emailHash` (a stable cross-org join key) plus the six consent-evidence fields
+ * to ANY member-role caller hitting the deployment URL directly. The route-level
+ * mask in `+page.server.ts` is decorative — the Convex layer is the real
+ * boundary. A shared `projectSupporterFields(doc, isEditor)` helper now nulls
+ * those fields for non-editor members in every member-gated reader so the gate
+ * cannot drift between them.
+ *
+ * convex-test isn't wired in this repo (see reconcile-skip-counter /
+ * v1-supporters-truncation tests), so this mirrors the helper's exact logic
+ * against in-memory rows and pins the source so each reader actually routes
+ * through the shared projection.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const CONSENT_FIELDS = [
+	'emailConsentSource',
+	'emailConsentedAt',
+	'emailConsentText',
+	'smsConsentSource',
+	'smsConsentedAt',
+	'smsConsentText'
+] as const;
+
+/**
+ * Mirror of `projectSupporterFields` in convex/supporters.ts: editor+ callers
+ * keep the real values; non-editor members get null for the join-key hash and
+ * the six consent-evidence fields.
+ */
+function projectSupporterFields<T extends Record<string, unknown>>(doc: T, isEditor: boolean): T {
+	if (isEditor) return doc;
+	return {
+		...doc,
+		emailHash: null,
+		emailConsentSource: null,
+		emailConsentedAt: null,
+		emailConsentText: null,
+		smsConsentSource: null,
+		smsConsentedAt: null,
+		smsConsentText: null
+	};
+}
+
+function makeListRow() {
+	return {
+		_id: 'sup_1',
+		_creationTime: 100,
+		encryptedEmail: '{"ct":"abc"}',
+		emailHash: 'org_scoped_hash_deadbeef',
+		encryptedName: '{"ct":"name"}',
+		encryptedPhone: '{"ct":"phone"}',
+		encryptedCustomFields: '{"ct":"cf"}',
+		verified: true,
+		emailStatus: 'subscribed',
+		smsStatus: 'subscribed',
+		source: 'csv',
+		emailConsentSource: 'signup_form',
+		emailConsentedAt: 1700000000000,
+		emailConsentText: 'I agree to receive emails',
+		smsConsentSource: 'text_keyword',
+		smsConsentedAt: 1700000000001,
+		smsConsentText: 'Reply STOP to opt out'
+	};
+}
+
+describe('C-20 supporter role projection (Convex layer is the real boundary)', () => {
+	it('nulls emailHash + all six consent fields for a member-role caller', () => {
+		const projected = projectSupporterFields(makeListRow(), /* isEditor */ false);
+		expect(projected.emailHash).toBeNull();
+		for (const field of CONSENT_FIELDS) {
+			expect(projected[field]).toBeNull();
+		}
+	});
+
+	it('keeps emailHash + consent fields intact for an editor/owner caller', () => {
+		const row = makeListRow();
+		const projected = projectSupporterFields(row, /* isEditor */ true);
+		expect(projected.emailHash).toBe('org_scoped_hash_deadbeef');
+		expect(projected.emailConsentText).toBe('I agree to receive emails');
+		expect(projected.smsConsentText).toBe('Reply STOP to opt out');
+		for (const field of CONSENT_FIELDS) {
+			expect(projected[field]).toBe(row[field]);
+		}
+	});
+
+	it('leaves the org-key-encrypted PII blobs untouched for members (existing custody model)', () => {
+		// encrypted* are decrypted client-side with the org key — they are NOT
+		// part of the leak and must survive the projection so members who hold
+		// the key can still read them.
+		const projected = projectSupporterFields(makeListRow(), false);
+		expect(projected.encryptedEmail).toBe('{"ct":"abc"}');
+		expect(projected.encryptedName).toBe('{"ct":"name"}');
+		expect(projected.encryptedPhone).toBe('{"ct":"phone"}');
+		expect(projected.encryptedCustomFields).toBe('{"ct":"cf"}');
+	});
+
+	it('does not strip non-sensitive metadata for members', () => {
+		const projected = projectSupporterFields(makeListRow(), false);
+		expect(projected.verified).toBe(true);
+		expect(projected.emailStatus).toBe('subscribed');
+		expect(projected.smsStatus).toBe('subscribed');
+		expect(projected.source).toBe('csv');
+	});
+});
+
+describe('C-20 every member-gated reader routes through the shared projection', () => {
+	const convexSource = readFileSync(
+		path.resolve(process.cwd(), 'convex/supporters.ts'),
+		'utf8'
+	);
+
+	function readerBody(start: string, end: string): string {
+		const from = convexSource.indexOf(start);
+		expect(from, `reader not found: ${start}`).toBeGreaterThan(-1);
+		const to = convexSource.indexOf(end, from + start.length);
+		return convexSource.slice(from, to === -1 ? undefined : to);
+	}
+
+	it('defines a single shared projection helper', () => {
+		expect(convexSource).toContain('function projectSupporterFields<');
+		expect(convexSource).toContain('function membershipIsEditor(');
+	});
+
+	it('list derives isEditor from membership.role and projects each row', () => {
+		const body = readerBody('export const list = query', 'export const get = query');
+		expect(body).toContain('membershipIsEditor(membership.role)');
+		expect(body).toContain('return projectSupporterFields(');
+	});
+
+	it('get derives isEditor from membership.role and projects the row', () => {
+		const body = readerBody('export const get = query', 'export const findByEmailHash = query');
+		expect(body).toContain('membershipIsEditor(membership.role)');
+		expect(body).toContain('return projectSupporterFields(');
+	});
+
+	it('findByEmailHash projects the raw .first() doc', () => {
+		const body = readerBody('export const findByEmailHash = query', 'export const searchByEmail = query');
+		expect(body).toContain('membershipIsEditor(membership.role)');
+		expect(body).toContain('return projectSupporterFields(doc, isEditor);');
+	});
+
+	it('searchByEmail projects its mapped shape', () => {
+		const body = readerBody('export const searchByEmail = query', 'export const getSummaryStats = query');
+		expect(body).toContain('membershipIsEditor(membership.role)');
+		expect(body).toContain('return projectSupporterFields(');
+	});
+});

--- a/tests/unit/supporters-role-projection.test.ts
+++ b/tests/unit/supporters-role-projection.test.ts
@@ -1,5 +1,5 @@
 /**
- * C-20 — emailHash + consent evidence are editor-only in the Convex layer.
+ * emailHash + consent evidence are editor-only, enforced in the Convex layer.
  *
  * `convex/supporters.ts` member-gated readers (`list`, `get`, `searchByEmail`,
  * `findByEmailHash`) ran `requireOrgRole(ctx, slug, 'member')` and then returned
@@ -70,7 +70,7 @@ function makeListRow() {
 	};
 }
 
-describe('C-20 supporter role projection (Convex layer is the real boundary)', () => {
+describe('supporter role projection (Convex layer is the real boundary)', () => {
 	it('nulls emailHash + all six consent fields for a member-role caller', () => {
 		const projected = projectSupporterFields(makeListRow(), /* isEditor */ false);
 		expect(projected.emailHash).toBeNull();
@@ -110,7 +110,7 @@ describe('C-20 supporter role projection (Convex layer is the real boundary)', (
 	});
 });
 
-describe('C-20 every member-gated reader routes through the shared projection', () => {
+describe('every member-gated reader routes through the shared projection', () => {
 	const convexSource = readFileSync(
 		path.resolve(process.cwd(), 'convex/supporters.ts'),
 		'utf8'
@@ -140,10 +140,19 @@ describe('C-20 every member-gated reader routes through the shared projection', 
 		expect(body).toContain('return projectSupporterFields(');
 	});
 
-	it('findByEmailHash projects the raw .first() doc', () => {
+	it('findByEmailHash returns a CURATED allowlist, never the raw .first() doc', () => {
 		const body = readerBody('export const findByEmailHash = query', 'export const searchByEmail = query');
 		expect(body).toContain('membershipIsEditor(membership.role)');
-		expect(body).toContain('return projectSupporterFields(doc, isEditor);');
+		expect(body).toContain('return projectSupporterFields(');
+		// The raw document carries cross-org join keys (globalEmailHash /
+		// globalPhoneHash / phoneHash) that no reader should expose. The fix builds
+		// an explicit field set instead of denylisting the raw doc, so projecting
+		// `doc` directly must NOT reappear, and the curated object's keys are emitted.
+		expect(body).not.toContain('projectSupporterFields(doc');
+		// Join keys must not be emitted as object properties (comment mentions are
+		// fine — check for the `key:` form, not bare references).
+		expect(body).not.toMatch(/globalEmailHash:|globalPhoneHash:|phoneHash:/);
+		expect(body).toContain('emailConsentText:');
 	});
 
 	it('searchByEmail projects its mapped shape', () => {

--- a/tests/unit/supporters-role-projection.test.ts
+++ b/tests/unit/supporters-role-projection.test.ts
@@ -140,8 +140,14 @@ describe('every member-gated reader routes through the shared projection', () =>
 		expect(body).toContain('return projectSupporterFields(');
 	});
 
-	it('findByEmailHash returns a CURATED allowlist, never the raw .first() doc', () => {
+	it('findByEmailHash is editor-gated (existence oracle) and returns a CURATED allowlist, never the raw .first() doc', () => {
 		const body = readerBody('export const findByEmailHash = query', 'export const searchByEmail = query');
+		// Editor-gated, not member: the null-vs-object return keyed on a
+		// caller-supplied emailHash is an existence/membership oracle, so it is
+		// restricted to editors (it has zero app consumers). searchByEmail — the
+		// legitimate supporter-search feature — stays 'member'.
+		expect(body).toContain("requireOrgRole(ctx, args.slug, 'editor')");
+		expect(body).not.toContain("requireOrgRole(ctx, args.slug, 'member')");
 		expect(body).toContain('membershipIsEditor(membership.role)');
 		expect(body).toContain('return projectSupporterFields(');
 		// The raw document carries cross-org join keys (globalEmailHash /
@@ -155,8 +161,9 @@ describe('every member-gated reader routes through the shared projection', () =>
 		expect(body).toContain('emailConsentText:');
 	});
 
-	it('searchByEmail projects its mapped shape', () => {
+	it('searchByEmail stays member-gated (the legitimate supporter-search feature) and projects its mapped shape', () => {
 		const body = readerBody('export const searchByEmail = query', 'export const getSummaryStats = query');
+		expect(body).toContain("requireOrgRole(ctx, args.orgSlug, 'member')");
 		expect(body).toContain('membershipIsEditor(membership.role)');
 		expect(body).toContain('return projectSupporterFields(');
 	});


### PR DESCRIPTION
Three verified pre-launch hardening fixes surfaced by the deferred-readiness review, as one bundle.

## C-20 — gate emailHash + consent on editor role in the Convex layer (security)
`supporters` readers (`list`/`get`/`searchByEmail`/`findByEmailHash`) returned `emailHash` (a stable cross-org join key) and the six consent-evidence fields (GDPR/TCPA) to any **member**-role caller hitting the Convex URL directly — the page-server's editor mask was decorative. A shared `projectSupporterFields(doc, isEditor)` helper now nulls those seven fields for non-editors across every reader (including the raw-doc `findByEmailHash`); editor/owner behavior is unchanged. Same Convex-bypass class the networks aggregates fix already closed. Encrypted PII blobs are untouched (org-key custody model). Pinned by `supporters-role-projection.test.ts` (member→null, editor→real).

## C-19 — clear org-key + device-keystore stores on logout (security)
`clearAllClientCaches` swept five IndexedDB stores but never `commons-org-keys` (wrapped org keys) or `commons-keystore` (device master), so on a shared browser the next user could re-derive and decrypt cached org PII. Logout now wipes both and nulls the in-memory master bytes. Pinned by `logout-keystore-sweep.test.ts`.

## C-21 — honest >10K supporter scan truncation (data integrity)
`list` capped at 10,000 rows then filtered in-memory, silently dropping the rest. It now surfaces `scanCapped`/`scanLimit` and the page shows a "showing the most recent 10,000" banner instead of pretending the list is complete. Pinned by `supporter-list-scan-cap.test.ts`.

## Evidence
- vitest: 4,532 passed / 0 failed (+21 from the three new suites)
- svelte-check: 0 errors
- No consumer regressions (page-server, export, client search verified; the page-server's own mask is now redundant defense-in-depth)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Supporter records now enforce role-based projection: editor-only fields (email-hash and consent evidence) are nulled for non-editors; list/get/search flows respect this and find-by-email is editor-restricted.
  * Supporter-list responses include scanLimit and truncated flags; UI shows a “scan-capped” notice when applicable.

* **Security**
  * Logout now reliably wipes device keystore and cached org keys to protect PII on shared devices.

* **Tests**
  * Expanded coverage for logout teardown, projection behavior, and scan-cap handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->