### PR TITLE
Land the org front door on Studio (authoring), not the proof packet

### DIFF
--- a/src/lib/components/org/os/ReturnSpace.svelte
+++ b/src/lib/components/org/os/ReturnSpace.svelte
@@ -88,11 +88,14 @@
 		}
 	]);
 
-	const actionRecordsHref = $derived(`${base}#action-records`);
+	// Results is mounted at `/results` (the org root is now the authoring front
+	// door). These intra-Results anchors target sections on THIS surface, so they
+	// must point at the Results path — not the bare base, which now mounts Studio.
+	const actionRecordsHref = $derived(`${base}/results#action-records`);
 	const packetHref = $derived(
 		data?.topCampaignId
 			? `${base}/campaigns/${data.topCampaignId}/report#proof-preview`
-			: `${base}#results-packet`
+			: `${base}/results#results-packet`
 	);
 	const proofDeliveryHref = $derived(
 		data?.topCampaignId

--- a/src/lib/components/org/os/orgOS.svelte.ts
+++ b/src/lib/components/org/os/orgOS.svelte.ts
@@ -60,20 +60,11 @@ export const SPACE_LABELS: Record<SpaceId, 'Studio' | 'People' | 'Power' | 'Resu
 };
 
 /** Map a deep-link pathname suffix to the space that owns it, for addressability
- * + SSR fallback. The org root, Results, is the default. */
+ * + SSR fallback. The org root is the AUTHORING front door — the bare base mounts
+ * STUDIO. Results lives at `/results`; the bare base no longer routes there. */
 export function spaceForPath(pathname: string, base: string): SpaceId {
 	const rest = pathname.startsWith(base) ? pathname.slice(base.length) : pathname;
-	if (
-		rest.startsWith('/studio') ||
-		rest.startsWith('/campaigns') ||
-		rest.startsWith('/emails') ||
-		rest.startsWith('/sms') ||
-		rest.startsWith('/events') ||
-		rest.startsWith('/fundraising') ||
-		rest.startsWith('/workflows') ||
-		rest.startsWith('/calls')
-	)
-		return 'studio';
+	if (rest.startsWith('/results')) return 'return';
 	if (rest.startsWith('/supporters')) return 'base';
 	if (
 		rest.startsWith('/representatives') ||
@@ -81,30 +72,34 @@ export function spaceForPath(pathname: string, base: string): SpaceId {
 		rest.startsWith('/scorecards')
 	)
 		return 'landscape';
-	return 'return';
+	// The bare base, /studio, and every authoring deep route fall to STUDIO — the
+	// front door lands on the authoring loop, not the proof packet.
+	return 'studio';
 }
 
 /** The canonical deep-link route for a space (used to update the URL on switch
- * via shallow routing, and as the SSR fallback target). */
+ * via shallow routing, and as the SSR fallback target). STUDIO owns the bare
+ * base (the authoring front door); Results is the destination at `/results`. */
 export function pathForSpace(space: SpaceId, base: string): string {
 	switch (space) {
 		case 'studio':
-			return `${base}/studio`;
+			return base;
 		case 'base':
 			return `${base}/supporters`;
 		case 'landscape':
 			return `${base}/representatives`;
 		case 'return':
-			return base;
+			return `${base}/results`;
 	}
 }
 
-/** True when the pathname IS one of the four canonical space paths (the org
- * root, /studio, /supporters, /representatives) — i.e. a path OWNED by a mounted
- * OrgShell space. Deep routes the OS hasn't absorbed yet (/campaigns, /settings,
- * /legislation, …) are NOT space paths: those still render their own page. The
- * org root + /studio support a trailing segment-free match; deep routes under a
- * space (e.g. /supporters/import) are treated as their own pages. */
+/** True when the pathname IS one of the canonical space paths (the org root +
+ * authoring front door, /studio, /supporters, /representatives, /results) —
+ * i.e. a path OWNED by a mounted OrgShell space. Deep routes the OS hasn't
+ * absorbed yet (/campaigns, /settings, /legislation, …) are NOT space paths:
+ * those still render their own page. The org root + /studio + /results support a
+ * trailing segment-free match; deep routes under a space (e.g. /supporters/import)
+ * are treated as their own pages. */
 export function isSpacePath(pathname: string, base: string): boolean {
 	const rest = pathname.startsWith(base) ? pathname.slice(base.length) : pathname;
 	const normalized = rest.replace(/\/$/, '');
@@ -112,7 +107,8 @@ export function isSpacePath(pathname: string, base: string): boolean {
 		normalized === '' ||
 		normalized === '/studio' ||
 		normalized === '/supporters' ||
-		normalized === '/representatives'
+		normalized === '/representatives' ||
+		normalized === '/results'
 	);
 }
 

--- a/src/routes/org/[slug]/+layout.svelte
+++ b/src/routes/org/[slug]/+layout.svelte
@@ -9,6 +9,7 @@
 	import {
 		setOrgOS,
 		spaceForPath,
+		pathForSpace,
 		rendersSpaceForUrl,
 		fullViewHref
 	} from '$lib/components/org/os/orgOS.svelte';
@@ -91,8 +92,10 @@
 	const marks = $derived<WorkspaceMark[]>([
 		{
 			id: 'studio',
+			// STUDIO owns the bare org URL — the authoring front door. The mark's
+			// href is the canonical space path so open-in-new-tab / no-JS land here.
 			label: 'Studio',
-			href: `${base}/studio`,
+			href: pathForSpace('studio', base),
 			secondary: [
 				{
 					href: `${base}/campaigns`,
@@ -168,15 +171,16 @@
 		{
 			id: 'return',
 			label: 'Results',
-			// Results routes to the org root, where delivery metrics, responses,
-			// and the Verification Packet live as artifact.
-			href: base,
+			// Results is the destination at `/results`, where delivery metrics,
+			// responses, and the Verification Packet live as artifact — demoted from
+			// the front door so authoring leads.
+			href: pathForSpace('return', base),
 			count: data.spaces.return?.stats.activeCampaigns ?? null,
 			secondary: [
 				{
 					href: data.spaces.return?.topCampaignId
 						? `${base}/campaigns/${data.spaces.return.topCampaignId}/report#proof-preview`
-						: `${base}#results-packet`,
+						: `${pathForSpace('return', base)}#results-packet`,
 					label: 'Proof packet'
 				}
 			]

--- a/src/routes/org/[slug]/+page.server.ts
+++ b/src/routes/org/[slug]/+page.server.ts
@@ -3,21 +3,21 @@ import type { PageServerLoad } from './$types';
 /**
  * Org-root route — server context.
  *
- * RETURN ("what came back") is now a MOUNTED space in the OS shell, hydrated by
- * the org `+layout.server.ts` (which loads every space's slice ONCE, since a
- * space switch is a pure state toggle, not a navigation). The dashboard queries
- * that used to live here — getDashboard, getDashboardStats, the verification
- * packet — moved UP to the layout so they hydrate the mounted ReturnSpace and
- * are NOT re-run when the operator toggles between spaces.
+ * The org root is the AUTHORING front door: it resolves to STUDIO, a MOUNTED
+ * space in the OS shell. Every space's slice (including STUDIO and the Results
+ * verification packet) is hydrated ONCE by the org `+layout.server.ts`, since a
+ * space switch is a pure state toggle, not a navigation. No per-space dashboard
+ * query lives here — those moved UP to the layout so a space toggle never
+ * re-fetches.
  *
  * Auth + org-membership are already enforced by the layout load (it redirects
  * unauthenticated users and non-members). This load only keeps the route
  * addressable — a hard load of the org root resolves and the layout shows the
- * mounted ReturnSpace, suppressing the (intentionally empty) page render.
+ * mounted StudioSpace, suppressing the (intentionally empty) page render.
  */
 export const load: PageServerLoad = async ({ parent }) => {
-	// Inherit org/membership from the layout; surface nothing extra. The RETURN
-	// space reads its data from the layout's `spaces` slice, not from here.
+	// Inherit org/membership from the layout; surface nothing extra. Each space
+	// reads its data from the layout's `spaces` slice, not from here.
 	const { org } = await parent();
 	return { orgSlug: org.slug };
 };

--- a/src/routes/org/[slug]/+page.svelte
+++ b/src/routes/org/[slug]/+page.svelte
@@ -1,21 +1,22 @@
 <!--
   Org-root route — superseded by the mounted OS shell.
 
-  RETURN ("what came back") is now a MOUNTED space in OrgShell (the org layout),
-  rendered by `$lib/components/org/os/ReturnSpace.svelte` from data the layout
-  load hydrates ONCE. The org root (`/org/[slug]`) is a canonical space path, so
-  the layout detects it, shows OrgShell's ReturnSpace, and suppresses this page.
+  The org root (`/org/[slug]`) is the AUTHORING front door: it is a canonical
+  space path that resolves to STUDIO. The STUDIO interior is a MOUNTED space in
+  OrgShell (the org layout), driven by the OS process registry, so the layout
+  detects the root, shows OrgShell's StudioSpace, and suppresses this page.
 
   This route still exists purely for addressability — a hard load of the org root
-  must land on the RETURN space. The layout's `isSpacePath` check makes that
+  must land on the STUDIO space. The layout's `isSpacePath` check makes that
   happen and renders nothing from here, so this component intentionally renders
-  nothing. Rendering the dashboard here too would double-render it.
+  nothing. Rendering a space here too would double-render it. (Results — the
+  Verification Packet — lives at `/org/[slug]/results`.)
 -->
 <script lang="ts">
 	import type { PageData } from './$types';
 
 	// Data still loads via the server load (auth/role flow through the layout),
-	// but the page renders nothing: the mounted OrgShell ReturnSpace is the real
+	// but the page renders nothing: the mounted OrgShell StudioSpace is the real
 	// surface, fed by the layout's per-space data.
 	let { data: _data }: { data: PageData } = $props();
 </script>

--- a/src/routes/org/[slug]/results/+page.server.ts
+++ b/src/routes/org/[slug]/results/+page.server.ts
@@ -1,0 +1,22 @@
+import type { PageServerLoad } from './$types';
+
+/**
+ * Org Results route — server context.
+ *
+ * RETURN ("what came back") is a MOUNTED space in the OS shell, hydrated by the
+ * org `+layout.server.ts` (which loads every space's slice ONCE, since a space
+ * switch is a pure state toggle, not a navigation). The dashboard queries —
+ * getDashboard, getDashboardStats, the verification packet — live in the layout
+ * so they hydrate the mounted ReturnSpace and are NOT re-run on a space toggle.
+ *
+ * Auth + org-membership are already enforced by the layout load (it redirects
+ * unauthenticated users and non-members). This load only keeps the route
+ * addressable — a hard load of `/org/[slug]/results` resolves and the layout
+ * shows the mounted ReturnSpace, suppressing the (intentionally empty) page.
+ */
+export const load: PageServerLoad = async ({ parent }) => {
+	// Inherit org/membership from the layout; surface nothing extra. The RETURN
+	// space reads its data from the layout's `spaces` slice, not from here.
+	const { org } = await parent();
+	return { orgSlug: org.slug };
+};

--- a/src/routes/org/[slug]/results/+page.svelte
+++ b/src/routes/org/[slug]/results/+page.svelte
@@ -1,0 +1,22 @@
+<!--
+  Org Results route — superseded by the mounted OS shell.
+
+  RETURN ("what came back") is a MOUNTED space in OrgShell (the org layout),
+  rendered by `$lib/components/org/os/ReturnSpace.svelte` from data the layout
+  load hydrates ONCE. `/org/[slug]/results` is a canonical space path, so the
+  layout detects it, shows OrgShell's ReturnSpace, and suppresses this page.
+
+  This route exists for addressability — a hard load of `/results` must land on
+  the RETURN space (the delivery metrics, responses, and Verification Packet).
+  The layout's `isSpacePath` check makes that happen and renders nothing from
+  here, so this component intentionally renders nothing. Rendering the dashboard
+  here too would double-render it.
+-->
+<script lang="ts">
+	import type { PageData } from './$types';
+
+	// Data still loads via the server load (auth/role flow through the layout),
+	// but the page renders nothing: the mounted OrgShell ReturnSpace is the real
+	// surface, fed by the layout's per-space data.
+	let { data: _data }: { data: PageData } = $props();
+</script>

--- a/tests/unit/org-os-space-paths.test.ts
+++ b/tests/unit/org-os-space-paths.test.ts
@@ -12,6 +12,7 @@ import { describe, expect, it } from 'vitest';
 import {
 	fullViewHref,
 	isSpacePath,
+	pathForSpace,
 	rendersSpaceForUrl,
 	spaceForPath
 } from '$lib/components/org/os/orgOS.svelte';
@@ -23,11 +24,12 @@ function urlFor(path: string): URL {
 }
 
 describe('isSpacePath', () => {
-	it('claims exactly the four canonical space paths', () => {
+	it('claims exactly the canonical space paths', () => {
 		expect(isSpacePath(`${BASE}`, BASE)).toBe(true);
 		expect(isSpacePath(`${BASE}/studio`, BASE)).toBe(true);
 		expect(isSpacePath(`${BASE}/supporters`, BASE)).toBe(true);
 		expect(isSpacePath(`${BASE}/representatives`, BASE)).toBe(true);
+		expect(isSpacePath(`${BASE}/results`, BASE)).toBe(true);
 	});
 
 	it('leaves deep routes to their own pages', () => {
@@ -36,6 +38,55 @@ describe('isSpacePath', () => {
 		expect(isSpacePath(`${BASE}/campaigns`, BASE)).toBe(false);
 		expect(isSpacePath(`${BASE}/legislation`, BASE)).toBe(false);
 		expect(isSpacePath(`${BASE}/settings`, BASE)).toBe(false);
+	});
+});
+
+describe('spaceForPath — the authoring front door', () => {
+	it('lands the bare org URL on Studio, not the proof packet', () => {
+		expect(spaceForPath(BASE, BASE)).toBe('studio');
+		expect(spaceForPath(`${BASE}/`, BASE)).toBe('studio');
+	});
+
+	it('keeps /studio resolving to Studio', () => {
+		expect(spaceForPath(`${BASE}/studio`, BASE)).toBe('studio');
+	});
+
+	it('routes /results to the Results (return) space', () => {
+		expect(spaceForPath(`${BASE}/results`, BASE)).toBe('return');
+		expect(spaceForPath(`${BASE}/results#results-packet`, BASE)).toBe('return');
+	});
+
+	it('keeps People and Power on their own paths', () => {
+		expect(spaceForPath(`${BASE}/supporters`, BASE)).toBe('base');
+		expect(spaceForPath(`${BASE}/representatives`, BASE)).toBe('landscape');
+		expect(spaceForPath(`${BASE}/legislation`, BASE)).toBe('landscape');
+	});
+
+	it('falls authoring deep routes through to Studio', () => {
+		expect(spaceForPath(`${BASE}/campaigns`, BASE)).toBe('studio');
+		expect(spaceForPath(`${BASE}/emails`, BASE)).toBe('studio');
+		expect(spaceForPath(`${BASE}/settings`, BASE)).toBe('studio');
+	});
+});
+
+describe('pathForSpace — Studio owns the bare URL, Results lives at /results', () => {
+	it('maps Studio to the bare base (the front door)', () => {
+		expect(pathForSpace('studio', BASE)).toBe(BASE);
+	});
+
+	it('maps Results to /results', () => {
+		expect(pathForSpace('return', BASE)).toBe(`${BASE}/results`);
+	});
+
+	it('keeps People and Power on their canonical paths', () => {
+		expect(pathForSpace('base', BASE)).toBe(`${BASE}/supporters`);
+		expect(pathForSpace('landscape', BASE)).toBe(`${BASE}/representatives`);
+	});
+
+	it('round-trips every space through spaceForPath', () => {
+		for (const space of ['studio', 'base', 'landscape', 'return'] as const) {
+			expect(spaceForPath(pathForSpace(space, BASE), BASE)).toBe(space);
+		}
 	});
 });
 


### PR DESCRIPTION
Positioning-driven UX recenter (beachhead locked: authoring + reach + neutrality, broad market; verification ambient). A hard load of `/org/[slug]` was mounting the RETURN/Results space — the Verification Packet, "what the org shows its board" — dropping the operator into *admire-the-proof* instead of *do-the-work*, contradicting the OS-center-is-authoring thesis. This flips the front door.

## Change (routing only — no space internals touched)
- `/org/[slug]` → **Studio** (the authoring loop; its landing is the in-surface Subject/Core-message/Audience entry).
- `/org/[slug]/results` → **Results** (the packet) — now a destination you go *to*, not where you land.
- `orgOS.svelte.ts`: `spaceForPath` bare-base/authoring-routes → `'studio'`, added `/results`→`'return'`; `pathForSpace` `'studio'`→`base`, `'return'`→`${base}/results`; `isSpacePath` includes `/results`.
- New `/results` route (defer-to-shell stub mirroring `/studio`); nav marks route through `pathForSpace`; ReturnSpace's own `#results-packet`/`#action-records` self-anchors repointed to `/results` (content/IDs unchanged).

## Out of scope (separate fast-follows)
Report-content reframe (personalization/response over the ZK proof) and the `SUBSTRATE`/`SIGNAL` rail copy — front door alone here.

## Evidence
- vitest 4,665 passed (only the 2 pre-existing gemini-provider WIP-collateral failures, not in this branch); svelte-check 0 errors; 83/83 org-os space-path tests incl. a new round-trip contract (`spaceForPath(pathForSpace(s))===s`).
- Shell-mount path reasoned with evidence (OrgShell mounts all four spaces + visibility-toggles; layout drives off `spaceForPath`; space-routes are addressability stubs). Live render to confirm on the running dev server: hard-load `/org/[slug]` → Studio, `/org/[slug]/results` → packet.