### PR TITLE
Remove free org tier — gate delivery behind subscription

### DIFF
--- a/convex/_brandingGate.ts
+++ b/convex/_brandingGate.ts
@@ -14,10 +14,12 @@ export type SubscriptionLike = { status?: string; plan?: string } | null | undef
 /**
  * Resolve an org's effective billing plan from its subscription row. Only
  * `active`/`trialing` subscriptions count toward a paid tier; anything else
- * (canceled, past_due, none) reads as `free`.
+ * (canceled, past_due, none) reads as the gated `inactive` floor.
  */
 export function effectivePlan(sub: SubscriptionLike): string {
-	return sub?.status === 'active' || sub?.status === 'trialing' ? (sub.plan ?? 'free') : 'free';
+	return sub?.status === 'active' || sub?.status === 'trialing'
+		? (sub.plan ?? 'inactive')
+		: 'inactive';
 }
 
 /** True only when the org is on the Coalition plan. */

--- a/convex/_validators.ts
+++ b/convex/_validators.ts
@@ -99,7 +99,10 @@ export const eventStatus = v.union(
 );
 
 export const subscriptionPlan = v.union(
-	v.literal('free'),
+	// `inactive` is the gated floor for unsubscribed/canceled orgs — not a
+	// marketed tier (absent from PLAN_ORDER), but a persisted plan value the
+	// cancellation path writes, so it must validate.
+	v.literal('inactive'),
 	v.literal('starter'),
 	v.literal('organization'),
 	v.literal('coalition')

--- a/convex/backfill.ts
+++ b/convex/backfill.ts
@@ -842,7 +842,7 @@ const CANONICAL_VALUES: Record<string, ReadonlyArray<string>> = {
   "campaigns.status": ["DRAFT", "ACTIVE", "PAUSED", "COMPLETE"],
   "events.eventType": ["IN_PERSON", "VIRTUAL", "HYBRID"],
   "events.status": ["DRAFT", "PUBLISHED", "CANCELLED", "COMPLETED"],
-  "subscriptions.plan": ["free", "starter", "organization", "coalition"],
+  "subscriptions.plan": ["inactive", "starter", "organization", "coalition"],
   "subscriptions.status": ["active", "past_due", "canceled", "trialing"],
   "subscriptions.paymentMethod": ["stripe", "crypto"],
   // C15+C16 enums — added after brutalist caught the audit coverage gap

--- a/convex/organizations.ts
+++ b/convex/organizations.ts
@@ -925,8 +925,13 @@ export const create = mutation({
 			name: args.name,
 			slug: args.slug,
 			description: args.description ?? undefined,
-			maxSeats: 2,
-			maxTemplatesMonth: 10,
+			// A new org has no subscription, so it starts on the gated `inactive`
+			// floor: owner-only seat + 2 templates (author a campaign or two to
+			// experience the product). Delivery + scale unlock on subscribe; the
+			// Stripe webhook syncs these to the paid tier's limits. Mirrors
+			// PLANS.inactive at src/lib/server/billing/plans.ts.
+			maxSeats: 1,
+			maxTemplatesMonth: 2,
 			dmCacheTtlDays: 7,
 			countryCode: 'US',
 			isPublic: false,
@@ -1477,7 +1482,7 @@ export const getUserOrgPlan = query({
 		return {
 			orgId: org._id,
 			orgSlug: org.slug,
-			plan: sub?.plan ?? 'free'
+			plan: sub?.plan ?? 'inactive'
 		};
 	}
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2127,14 +2127,15 @@ export default defineSchema({
 
 		// Plan slug — canonical values at src/lib/server/billing/plans.ts.
 		// Tightened from v.string() to a closed union 2026-05-26 to catch
-		// silent free-tier downgrade at write time (the read-side fallback
-		// `PLANS[plan] ?? PLANS.free` at convex/subscriptions.ts:134
+		// silent downgrades at write time (the read-side fallback
+		// `PLANS[plan] ?? PLANS.inactive` at convex/subscriptions.ts
 		// degrades gracefully but observability is poor — a writer that
 		// silently passes 'Organization' (capitalized) would never be
 		// noticed by ops). Adding a new tier requires editing this union
-		// + plans.ts in lockstep; that's the right friction.
+		// + plans.ts in lockstep; that's the right friction. `inactive` is
+		// the gated floor (unsubscribed/canceled), not a marketed tier.
 		plan: v.union(
-			v.literal('free'),
+			v.literal('inactive'),
 			v.literal('starter'),
 			v.literal('organization'),
 			v.literal('coalition')

--- a/convex/seed.ts
+++ b/convex/seed.ts
@@ -2475,11 +2475,11 @@ export const insertUserDmRelations = internalMutation({
 // =============================================================================
 // PHASE 19: INSERT SUBSCRIPTIONS
 // =============================================================================
-// Seed orgs default to free tier unless a subscription row exists. Without
-// realistic plan assignments, `subscriptions.checkPlanLimits` returns the
-// free-tier ceiling for every seeded org — Climate Action Now (8
-// supporters, $1.25K raised, sent blast) looking free-tier is incoherent
-// with the rest of its activity. Plans canonical at
+// There is no free org tier. An org with no subscription row falls to the
+// gated `inactive` floor (2 templates, zero delivery). Every seeded dev/demo
+// org therefore gets an explicit active subscription so none lands on the
+// floor — Climate Action Now (8 supporters, $1.25K raised, sent blast) looking
+// gated would be incoherent with the rest of its activity. Plans canonical at
 // src/lib/server/billing/plans.ts.
 
 export const insertSubscriptions = internalMutation({
@@ -2489,12 +2489,13 @@ export const insertSubscriptions = internalMutation({
   handler: async (ctx, { orgIds }) => {
     const now = Date.now();
     // Realistic posture: a heavy-activity org pays Organization tier; a
-    // mid-activity org pays Starter; a low-activity org stays on free
-    // (no subscription row needed). priceCents mirror plans.ts exactly.
+    // mid-activity org pays Starter; the third demos the top Coalition tier.
+    // Every seeded org gets a row — none falls to the gated inactive floor.
+    // priceCents mirror plans.ts exactly.
     const subscriptionDefs = [
       { orgIdx: 0, plan: "organization", priceCents: 7_500 }, // Climate Action Now
       { orgIdx: 1, plan: "starter", priceCents: 1_000 },      // Voter Rights Coalition
-      // Local First SF (orgIds[2]) intentionally omitted — defaults to free tier.
+      { orgIdx: 2, plan: "coalition", priceCents: 20_000 },   // Local First SF (top tier demo)
     ];
 
     // 30-day billing cycle anchored so the seed represents an active
@@ -2503,7 +2504,7 @@ export const insertSubscriptions = internalMutation({
     for (const s of subscriptionDefs) {
       await ctx.db.insert("subscriptions", {
         orgId: orgIds[s.orgIdx],
-        plan: s.plan as "free" | "starter" | "organization" | "coalition",
+        plan: s.plan as "inactive" | "starter" | "organization" | "coalition",
         priceCents: s.priceCents,
         status: "active",
         currentPeriodStart: now - halfMonth,
@@ -2537,6 +2538,7 @@ export const insertSubscriptions = internalMutation({
 const PLANS_SEED: Record<string, { maxSeats: number; maxTemplatesMonth: number }> = {
   starter: { maxSeats: 5, maxTemplatesMonth: 100 },
   organization: { maxSeats: 10, maxTemplatesMonth: 500 },
+  coalition: { maxSeats: 25, maxTemplatesMonth: 1_000 },
 };
 
 // =============================================================================

--- a/convex/subscriptions.ts
+++ b/convex/subscriptions.ts
@@ -26,7 +26,9 @@ const PLANS: Record<
     maxSms: number;
   }
 > = {
-  free: { priceCents: 0, maxSeats: 2, maxTemplatesMonth: 10, maxVerifiedActions: 100, maxEmails: 1_000, maxSms: 0 },
+  // Gated floor for orgs with no active subscription — author a campaign or
+  // two (2 templates), zero delivery, owner-only. Not a marketed tier.
+  inactive: { priceCents: 0, maxSeats: 1, maxTemplatesMonth: 2, maxVerifiedActions: 0, maxEmails: 0, maxSms: 0 },
   starter: { priceCents: 1_000, maxSeats: 5, maxTemplatesMonth: 100, maxVerifiedActions: 1_000, maxEmails: 20_000, maxSms: 1_000 },
   organization: { priceCents: 7_500, maxSeats: 10, maxTemplatesMonth: 500, maxVerifiedActions: 5_000, maxEmails: 100_000, maxSms: 10_000 },
   coalition: { priceCents: 20_000, maxSeats: 25, maxTemplatesMonth: 1_000, maxVerifiedActions: 10_000, maxEmails: 250_000, maxSms: 50_000 },
@@ -45,8 +47,8 @@ const PLANS: Record<
  * to, so we only trust the O(1) path when it matches the period we're metering.
  *
  * Self-heal (no write — this runs in a query): if the baseline is missing or
- * belongs to a DIFFERENT period (a late/missed Stripe webhook, or a free-tier
- * calendar-month rollover that has no webhook), count THIS period's verified
+ * belongs to a DIFFERENT period (a late/missed Stripe webhook, or an inactive
+ * org's calendar-month rollover that has no webhook), count THIS period's verified
  * actions via the `by_orgId_verified_sentAt` range index — bounded to one
  * period's volume, never the lifetime table, so it can never throw the cap.
  *
@@ -94,8 +96,8 @@ async function verifiedActionsThisPeriod(
   // Exclude congressional rows: congressional deliveries are person-layer civic
   // actions, NOT org-metered usage — the lifetime path skips them via
   // createCampaignAction's metersOrgQuota:false, and this self-heal path (the one
-  // free-tier orgs always hit, since they have no Stripe baseline) MUST exclude
-  // them too or congressional traffic leaks back into the org's metered usage.
+  // inactive/unsubscribed orgs always hit, since they have no Stripe baseline)
+  // MUST exclude them too or congressional traffic leaks back into metered usage.
   const metered = rows.filter((r) => r.channel !== "congressional");
   // If the period's own metered volume exceeds the cap, clamp to the cap. Below
   // the cap this is the true count; above it the clamp is a floor that STILL
@@ -222,7 +224,7 @@ export const getByUser = query({
  *
  * Usage is computed at query time (not from denormalized counters) for
  * verifiedActions. Email/SMS use denormalized org counters.
- * Period: subscription's currentPeriodStart, or calendar month for free orgs.
+ * Period: subscription's currentPeriodStart, or calendar month for inactive orgs.
  */
 export const checkPlanLimits = query({
   args: {
@@ -247,17 +249,17 @@ export const checkPlanLimits = query({
       Date.now() - pastDueSince < GRACE_PERIOD_MS;
 
     // 'trialing' counts as active so trial orgs receive their plan tier limits
-    // — not free-tier — until Stripe transitions them to 'active' on first
-    // successful payment. Without this, an org granted a paid trial would hit
-    // free-tier quotas during the trial window.
+    // — not the inactive floor — until Stripe transitions them to 'active' on
+    // first successful payment. Without this, an org granted a paid trial would
+    // hit the gated floor during the trial window.
     const effectivelyActive =
       sub?.status === "active" || sub?.status === "trialing" || isWithinGrace;
-    const plan = effectivelyActive ? (sub?.plan ?? "free") : "free";
-    const limits = PLANS[plan] ?? PLANS.free;
+    const plan = effectivelyActive ? (sub?.plan ?? "inactive") : "inactive";
+    const limits = PLANS[plan] ?? PLANS.inactive;
 
     // Determine billing period start
     // For paid/grace orgs: subscription's currentPeriodStart
-    // For free orgs: start of current calendar month (UTC)
+    // For inactive (unsubscribed) orgs: start of current calendar month (UTC)
     let periodStart: number;
     if (effectivelyActive && sub?.currentPeriodStart) {
       periodStart = sub.currentPeriodStart;
@@ -330,13 +332,13 @@ export const checkPlanLimitsByOrgId = internalQuery({
       pastDueSince &&
       Date.now() - pastDueSince < GRACE_PERIOD_MS;
     // 'trialing' counts as active so trial orgs receive their plan tier limits
-    // — not free-tier — until Stripe transitions them to 'active' on first
-    // successful payment. Without this, an org granted a paid trial would hit
-    // free-tier quotas during the trial window.
+    // — not the inactive floor — until Stripe transitions them to 'active' on
+    // first successful payment. Without this, an org granted a paid trial would
+    // hit the gated floor during the trial window.
     const effectivelyActive =
       sub?.status === "active" || sub?.status === "trialing" || isWithinGrace;
-    const plan = effectivelyActive ? (sub?.plan ?? "free") : "free";
-    const limits = PLANS[plan] ?? PLANS.free;
+    const plan = effectivelyActive ? (sub?.plan ?? "inactive") : "inactive";
+    const limits = PLANS[plan] ?? PLANS.inactive;
 
     let periodStart: number;
     if (effectivelyActive && sub?.currentPeriodStart) {
@@ -514,16 +516,16 @@ export const cancel = mutation({
 
     await ctx.db.patch(args.subscriptionId, {
       status: "canceled",
-      plan: "free",
+      plan: "inactive",
       updatedAt: Date.now(),
     });
 
-    // Reset org limits to free tier if org-scoped
+    // Reset org limits to the gated inactive floor if org-scoped
     if (sub.orgId) {
-      const freeLimits = PLANS.free;
+      const floorLimits = PLANS.inactive;
       await ctx.db.patch(sub.orgId, {
-        maxSeats: freeLimits.maxSeats,
-        maxTemplatesMonth: freeLimits.maxTemplatesMonth,
+        maxSeats: floorLimits.maxSeats,
+        maxTemplatesMonth: floorLimits.maxTemplatesMonth,
         updatedAt: Date.now(),
       });
     }
@@ -819,8 +821,8 @@ export const backfillOrgLimits = internalMutation({
         .withIndex("by_orgId", (idx) => idx.eq("orgId", org._id))
         .first();
 
-      const plan = sub?.status === "active" ? sub.plan : "free";
-      const planDef = PLANS[plan] ?? PLANS.free;
+      const plan = sub?.status === "active" ? sub.plan : "inactive";
+      const planDef = PLANS[plan] ?? PLANS.inactive;
 
       // Only patch if limits differ from canonical values
       if (
@@ -957,12 +959,12 @@ export const updateByStripeId = internalMutation({
       }
     }
 
-    // Reset org limits to free tier on cancellation
+    // Reset org limits to the gated inactive floor on cancellation
     if (args.resetOrgLimits && sub.orgId) {
-      const freeLimits = PLANS.free;
+      const floorLimits = PLANS.inactive;
       await ctx.db.patch(sub.orgId, {
-        maxSeats: freeLimits.maxSeats,
-        maxTemplatesMonth: freeLimits.maxTemplatesMonth,
+        maxSeats: floorLimits.maxSeats,
+        maxTemplatesMonth: floorLimits.maxTemplatesMonth,
         updatedAt: now,
       });
     }

--- a/convex/v1api.ts
+++ b/convex/v1api.ts
@@ -51,7 +51,7 @@ export const authenticateApiKey = query({
 			keyId: apiKey._id,
 			orgId: apiKey.orgId,
 			scopes: apiKey.scopes,
-			planSlug: sub?.plan ?? 'free'
+			planSlug: sub?.plan ?? 'inactive'
 		};
 	}
 });

--- a/src/lib/server/api-v1/rate-limit.ts
+++ b/src/lib/server/api-v1/rate-limit.ts
@@ -11,7 +11,10 @@ import type { ApiKeyContext } from './auth';
 
 /** Per-plan API rate limits (requests per minute). */
 const API_PLAN_LIMITS: Record<string, { maxRequests: number; windowMs: number }> = {
-	free: { maxRequests: 100, windowMs: 60_000 },
+	// `inactive` is the gated floor for orgs with no active subscription — it
+	// gets the lowest ceiling (an org without a paid plan has no metered send
+	// volume anyway; this only governs read/introspection traffic).
+	inactive: { maxRequests: 100, windowMs: 60_000 },
 	starter: { maxRequests: 300, windowMs: 60_000 },
 	organization: { maxRequests: 1000, windowMs: 60_000 },
 	coalition: { maxRequests: 3000, windowMs: 60_000 }
@@ -22,7 +25,7 @@ const READ_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
 /**
  * Check plan-tiered rate limit for an API v1 request.
  *
- * Reads on the free plan are intentionally uncapped — aligns the "no rate
+ * Reads on the inactive floor are intentionally uncapped — aligns the "no rate
  * cap" marketing claim with code behavior. Writes (POST/PATCH/PUT/DELETE)
  * remain capped at the plan's request-per-minute limit. Higher plans keep
  * their flat ceilings across all methods. Pass the request method so the
@@ -34,11 +37,11 @@ export async function checkApiPlanRateLimit(
 ): Promise<Response | null> {
 	const method = opts?.method?.toUpperCase();
 	const isRead = method !== undefined && READ_METHODS.has(method);
-	if (ctx.planSlug === 'free' && isRead) {
+	if (ctx.planSlug === 'inactive' && isRead) {
 		return null;
 	}
 
-	const limits = API_PLAN_LIMITS[ctx.planSlug] ?? API_PLAN_LIMITS.free;
+	const limits = API_PLAN_LIMITS[ctx.planSlug] ?? API_PLAN_LIMITS.inactive;
 	const limiter = getRateLimiter();
 	const result = await limiter.check(`ratelimit:api-v1:plan:${ctx.keyId}`, limits);
 

--- a/src/lib/server/billing/plans.ts
+++ b/src/lib/server/billing/plans.ts
@@ -2,7 +2,14 @@
  * Plan definitions and limit constants for Commons billing.
  *
  * Stripe Price IDs are read from environment variables (set via wrangler pages secret).
- * The free tier has no Stripe Price — it's the default for orgs without a subscription.
+ *
+ * There is NO free org tier. Entry is Starter ($10/mo). Orgs with no active
+ * subscription fall to the non-marketed `inactive` floor: they can create the
+ * org and author a campaign or two (maxTemplatesMonth: 2 — the free *experience*:
+ * author, see grounded message + targets, preview the report) but ALL DELIVERY
+ * (email/SMS, verified-action submission) and scale (seats, volume) are gated to
+ * zero until they subscribe. `inactive` is NOT in PLAN_ORDER — it never renders
+ * as a tier in the plan grid; it is only the fallback floor.
  */
 
 export interface PlanLimits {
@@ -18,16 +25,19 @@ export interface PlanLimits {
 }
 
 export const PLANS: Record<string, PlanLimits> = {
-	free: {
-		slug: 'free',
-		name: 'Free',
+	// Non-marketed gated floor for orgs with no active subscription. Lets an org
+	// author a campaign or two (2 templates) to experience the product; every
+	// delivery + scale quota is zeroed until they subscribe. Not in PLAN_ORDER.
+	inactive: {
+		slug: 'inactive',
+		name: 'Inactive',
 		priceCents: 0,
 		stripePriceId: '',
-		maxVerifiedActions: 100,
-		maxEmails: 1_000,
+		maxVerifiedActions: 0,
+		maxEmails: 0,
 		maxSms: 0,
-		maxSeats: 2,
-		maxTemplatesMonth: 10
+		maxSeats: 1,
+		maxTemplatesMonth: 2
 	},
 	starter: {
 		slug: 'starter',
@@ -70,10 +80,13 @@ export const PLANS: Record<string, PlanLimits> = {
 	}
 };
 
-/** Plan slugs ordered by tier for upgrade/downgrade comparison */
-export const PLAN_ORDER = ['free', 'starter', 'organization', 'coalition'] as const;
+/**
+ * Marketed plan slugs ordered by tier for upgrade/downgrade comparison.
+ * `inactive` is deliberately excluded — it is the gated floor, not a tier.
+ */
+export const PLAN_ORDER = ['starter', 'organization', 'coalition'] as const;
 
 export function getPlanForOrg(subscription: { plan: string } | null): PlanLimits {
-	if (!subscription) return PLANS.free;
-	return PLANS[subscription.plan] ?? PLANS.free;
+	if (!subscription) return PLANS.inactive;
+	return PLANS[subscription.plan] ?? PLANS.inactive;
 }

--- a/src/routes/api/billing/checkout/+server.ts
+++ b/src/routes/api/billing/checkout/+server.ts
@@ -22,7 +22,10 @@ export const POST: RequestHandler = async ({ request, locals, url }) => {
 	const { orgSlug, plan } = body as { orgSlug: string; plan: string };
 
 	if (!orgSlug || !plan) throw error(400, 'orgSlug and plan required');
-	if (!PLANS[plan] || plan === 'free') throw error(400, 'Invalid plan');
+	// Only marketed tiers (PLAN_ORDER) are purchasable. The `inactive` floor is
+	// not a tier and has no Stripe price, so it (and any unknown slug) is rejected.
+	if (!PLANS[plan] || !PLAN_ORDER.includes(plan as (typeof PLAN_ORDER)[number]))
+		throw error(400, 'Invalid plan');
 
 	// Get org context + subscription + billing info via Convex (requires owner role)
 	const billing = await serverQuery(api.organizations.getBillingContext, { slug: orgSlug });

--- a/src/routes/org/[slug]/emails/compose/+page.server.ts
+++ b/src/routes/org/[slug]/emails/compose/+page.server.ts
@@ -151,8 +151,10 @@ export const load: PageServerLoad = async ({ parent, params }) => {
 			: Promise.resolve(null)
 	]);
 
-	// A/B testing allowed if org has starter+ plan
-	const abTestingAllowed = FEATURES.AB_TESTING && sub?.plan !== 'free';
+	// A/B testing allowed if org has an active marketed plan (Starter+).
+	// An org with no subscription falls to the gated `inactive` floor (sub is
+	// null here), so require a present, non-inactive plan.
+	const abTestingAllowed = FEATURES.AB_TESTING && sub != null && sub.plan !== 'inactive';
 	const serverDispatchReadiness = getEmailServerDispatchReadiness(emailServerDispatchEnv(), {
 		orgKeyConfigured: Boolean(orgKeyResult?.orgKeyVerifier)
 	});
@@ -455,7 +457,7 @@ export const actions: Actions = {
 
 		// Check plan via Convex
 		const sub = await serverQuery(api.subscriptions.getByOrg, { orgSlug: params.slug });
-		if (!FEATURES.AB_TESTING || sub?.plan === 'free') {
+		if (!FEATURES.AB_TESTING || sub == null || sub.plan === 'inactive') {
 			return fail(403, { error: 'A/B testing requires a Starter plan or above.' });
 		}
 

--- a/src/routes/org/[slug]/settings/+page.server.ts
+++ b/src/routes/org/[slug]/settings/+page.server.ts
@@ -100,14 +100,13 @@ export const load: PageServerLoad = async ({ parent, params }) => {
 					detail: 'Quota reserved for when bulk texting is fully available.'
 				});
 			}
-			if (slug !== 'free') {
-				features.push({
-					label: 'A/B test setup',
-					state: 'draft-only',
-					detail:
-						'Set up A/B tests with exact test groups and send the winner to the rest; automatic winner send-out is coming.'
-				});
-			}
+			// A/B test setup is available on every marketed tier (Starter+).
+			features.push({
+				label: 'A/B test setup',
+				state: 'draft-only',
+				detail:
+					'Set up A/B tests with exact test groups and send the winner to the rest; automatic winner send-out is coming.'
+			});
 			if (slug === 'organization' || slug === 'coalition') {
 				features.push(
 					{

--- a/src/routes/org/[slug]/settings/+page.svelte
+++ b/src/routes/org/[slug]/settings/+page.svelte
@@ -11,7 +11,7 @@
 	const isOwner = $derived(data.membership.role === 'owner');
 	const canEdit = $derived(data.membership.role === 'owner' || data.membership.role === 'editor');
 	const canInvite = $derived(data.membership.role === 'owner' || data.membership.role === 'editor');
-	const planName = $derived(data.usage.plan ?? data.subscription?.plan ?? 'free');
+	const planName = $derived(data.usage.plan ?? data.subscription?.plan ?? 'inactive');
 
 	// Invite form state
 	let inviteEmail = $state('');
@@ -1070,10 +1070,10 @@
 					transparency and aren't available yet.
 				</p>
 			</div>
-			<div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+			<div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
 				{#each plans as plan}
 					{@const isCurrent = planName === plan.slug}
-					{@const isUpgrade = !isCurrent && plan.slug !== 'free'}
+					{@const isUpgrade = !isCurrent}
 					<div
 						class="space-y-4 rounded-md border p-5 {isCurrent
 							? 'border-teal-500/40 bg-teal-500/5'

--- a/tests/unit/api-v1/auth.test.ts
+++ b/tests/unit/api-v1/auth.test.ts
@@ -7,7 +7,7 @@ function makeContext(scopes: string[]): ApiKeyContext {
 		orgId: 'org_test123' as Id<'organizations'>,
 		keyId: 'key_test123' as Id<'apiKeys'>,
 		scopes,
-		planSlug: 'free'
+		planSlug: 'inactive'
 	};
 }
 

--- a/tests/unit/api/api-rate-limit.test.ts
+++ b/tests/unit/api/api-rate-limit.test.ts
@@ -5,11 +5,11 @@
  * using the sliding-window rate limiter, keyed by API key ID.
  *
  * Test groups:
- * 1. Free plan — 100 req/min
+ * 1. Inactive floor — 100 req/min
  * 2. Starter plan — 300 req/min
  * 3. Organization plan — 1000 req/min
  * 4. Coalition plan — 3000 req/min
- * 5. Unknown plan defaults to free limits
+ * 5. Unknown plan defaults to inactive-floor limits
  * 6. 429 response envelope format
  * 7. Rate limit key uses keyId for isolation
  */
@@ -55,7 +55,7 @@ function makeCtx(overrides: Partial<ApiKeyContext> = {}): ApiKeyContext {
 		orgId: 'org-1' as Id<'organizations'>,
 		keyId: 'key-1' as Id<'apiKeys'>,
 		scopes: ['read', 'write'],
-		planSlug: 'free',
+		planSlug: 'inactive',
 		...overrides
 	};
 }
@@ -74,13 +74,13 @@ describe('checkApiPlanRateLimit', () => {
 	});
 
 	// =========================================================================
-	// Group 1: Free plan — 100 req/min
+	// Group 1: Inactive floor — 100 req/min
 	// =========================================================================
-	describe('free plan', () => {
+	describe('inactive floor', () => {
 		it('allows requests within the 100 req/min limit', async () => {
 			mockCheck.mockResolvedValueOnce({ allowed: true, remaining: 50, limit: 100, reset: Date.now() / 1000 + 60 });
 
-			const result = await checkApiPlanRateLimit(makeCtx({ planSlug: 'free' }));
+			const result = await checkApiPlanRateLimit(makeCtx({ planSlug: 'inactive' }));
 			expect(result).toBeNull();
 			expect(mockCheck).toHaveBeenCalledWith(
 				'ratelimit:api-v1:plan:key-1',
@@ -91,7 +91,7 @@ describe('checkApiPlanRateLimit', () => {
 		it('blocks the 101st request', async () => {
 			mockCheck.mockResolvedValueOnce({ allowed: false, remaining: 0, limit: 100, reset: Date.now() / 1000 + 30, retryAfter: 30 });
 
-			const result = await checkApiPlanRateLimit(makeCtx({ planSlug: 'free' }));
+			const result = await checkApiPlanRateLimit(makeCtx({ planSlug: 'inactive' }));
 			expect(result).toBeInstanceOf(Response);
 			expect(result!.status).toBe(429);
 		});
@@ -149,7 +149,7 @@ describe('checkApiPlanRateLimit', () => {
 	// Group 5: Unknown plan defaults to free limits
 	// =========================================================================
 	describe('unknown plan slug', () => {
-		it('falls back to free limits (100 req/min)', async () => {
+		it('falls back to inactive-floor limits (100 req/min)', async () => {
 			mockCheck.mockResolvedValueOnce({ allowed: true, remaining: 50, limit: 100, reset: Date.now() / 1000 + 60 });
 
 			const result = await checkApiPlanRateLimit(makeCtx({ planSlug: 'nonexistent-plan' }));
@@ -168,14 +168,14 @@ describe('checkApiPlanRateLimit', () => {
 		it('returns proper error envelope with RATE_LIMITED code', async () => {
 			mockCheck.mockResolvedValueOnce({ allowed: false, remaining: 0, limit: 100, reset: Date.now() / 1000 + 45, retryAfter: 45 });
 
-			const result = await checkApiPlanRateLimit(makeCtx({ planSlug: 'free' }));
+			const result = await checkApiPlanRateLimit(makeCtx({ planSlug: 'inactive' }));
 			expect(result).not.toBeNull();
 			expect(result!.status).toBe(429);
 
 			const body = await result!.json();
 			expect(body.data).toBeNull();
 			expect(body.error.code).toBe('RATE_LIMITED');
-			expect(body.error.message).toContain('free');
+			expect(body.error.message).toContain('inactive');
 			expect(body.error.message).toContain('100');
 			expect(body.error.message).toContain('45');
 		});
@@ -192,7 +192,7 @@ describe('checkApiPlanRateLimit', () => {
 		it('has Content-Type application/json', async () => {
 			mockCheck.mockResolvedValueOnce({ allowed: false, remaining: 0, limit: 100, reset: Date.now() / 1000 + 30, retryAfter: 30 });
 
-			const result = await checkApiPlanRateLimit(makeCtx({ planSlug: 'free' }));
+			const result = await checkApiPlanRateLimit(makeCtx({ planSlug: 'inactive' }));
 			expect(result!.headers.get('Content-Type')).toBe('application/json');
 		});
 	});

--- a/tests/unit/billing/inactive-floor.test.ts
+++ b/tests/unit/billing/inactive-floor.test.ts
@@ -1,0 +1,140 @@
+/**
+ * No free org tier — gated `inactive` floor contract.
+ *
+ * Decision (org-OS): orgs pay. Entry is Starter ($10/mo). An org with no active
+ * subscription is NOT free — it falls to the non-marketed `inactive` floor: it
+ * can create the org and author a campaign or two (2 templates — the free
+ * *experience*) but ALL DELIVERY (email/SMS, verified-action submission) and
+ * scale (seats, volume) are gated to zero until it subscribes.
+ *
+ * This pins the floor at three layers:
+ *   1. SvelteKit canonical `getPlanForOrg` (the read-side resolver).
+ *   2. The Convex `_brandingGate.effectivePlan` resolver (canceled/past_due/
+ *      missing → inactive, NOT free).
+ *   3. The plan-limit resolution logic the Convex `checkPlanLimits` paths use,
+ *      modeled against the canonical PLANS so the gated quotas are asserted
+ *      without a live Convex context (Convex server code can't be imported).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { PLANS, PLAN_ORDER, getPlanForOrg } from '$lib/server/billing/plans';
+import { effectivePlan } from '../../../convex/_brandingGate';
+
+/**
+ * Mirrors the plan-resolution expression in both `checkPlanLimits` and
+ * `checkPlanLimitsByOrgId` (convex/subscriptions.ts):
+ *   effectivelyActive ? (sub.plan ?? "inactive") : "inactive"
+ *   limits = PLANS[plan] ?? PLANS.inactive
+ * Grace period is folded into `effectivelyActive` by the caller.
+ */
+function resolveLimits(sub: { status?: string; plan?: string } | null, effectivelyActive: boolean) {
+	const plan = effectivelyActive ? (sub?.plan ?? 'inactive') : 'inactive';
+	return PLANS[plan] ?? PLANS.inactive;
+}
+
+describe('inactive floor — definition', () => {
+	it('there is NO free tier', () => {
+		expect(PLANS.free).toBeUndefined();
+		expect([...PLAN_ORDER]).not.toContain('free');
+	});
+
+	it('gates all delivery + scale to zero, allows 2 templates, owner-only', () => {
+		expect(PLANS.inactive).toMatchObject({
+			slug: 'inactive',
+			name: 'Inactive',
+			priceCents: 0,
+			maxTemplatesMonth: 2,
+			maxEmails: 0,
+			maxSms: 0,
+			maxVerifiedActions: 0,
+			maxSeats: 1
+		});
+	});
+
+	it('is not a marketed tier (absent from PLAN_ORDER)', () => {
+		expect([...PLAN_ORDER]).toEqual(['starter', 'organization', 'coalition']);
+		expect([...PLAN_ORDER]).not.toContain('inactive');
+	});
+});
+
+describe('inactive floor — getPlanForOrg (SvelteKit resolver)', () => {
+	it('an org with NO subscription resolves to the inactive floor', () => {
+		const plan = getPlanForOrg(null);
+		expect(plan.slug).toBe('inactive');
+		expect(plan.maxTemplatesMonth).toBe(2);
+		expect(plan.maxEmails).toBe(0);
+		expect(plan.maxSms).toBe(0);
+		expect(plan.maxVerifiedActions).toBe(0);
+		expect(plan.maxSeats).toBe(1);
+	});
+
+	it('an unknown plan slug falls to the inactive floor (not free)', () => {
+		expect(getPlanForOrg({ plan: 'free' }).slug).toBe('inactive');
+		expect(getPlanForOrg({ plan: 'whatever' }).slug).toBe('inactive');
+	});
+
+	it('a paying tier is unaffected', () => {
+		expect(getPlanForOrg({ plan: 'starter' }).slug).toBe('starter');
+		expect(getPlanForOrg({ plan: 'organization' }).slug).toBe('organization');
+		expect(getPlanForOrg({ plan: 'coalition' }).slug).toBe('coalition');
+	});
+});
+
+describe('inactive floor — effectivePlan (Convex branding resolver)', () => {
+	it('a canceled subscription reads as inactive, NOT free', () => {
+		expect(effectivePlan({ status: 'canceled', plan: 'coalition' })).toBe('inactive');
+	});
+
+	it('past_due / missing / no-plan read as inactive', () => {
+		expect(effectivePlan({ status: 'past_due', plan: 'coalition' })).toBe('inactive');
+		expect(effectivePlan(null)).toBe('inactive');
+		expect(effectivePlan(undefined)).toBe('inactive');
+		expect(effectivePlan({ status: 'active' })).toBe('inactive');
+	});
+
+	it('an active/trialing paying tier is unaffected', () => {
+		expect(effectivePlan({ status: 'active', plan: 'starter' })).toBe('starter');
+		expect(effectivePlan({ status: 'trialing', plan: 'coalition' })).toBe('coalition');
+	});
+});
+
+describe('inactive floor — checkPlanLimits resolution (modeled)', () => {
+	it('unsubscribed org (no sub) returns the gated floor', () => {
+		const limits = resolveLimits(null, false);
+		expect(limits.maxTemplatesMonth).toBe(2);
+		expect(limits.maxEmails).toBe(0);
+		expect(limits.maxSms).toBe(0);
+		expect(limits.maxVerifiedActions).toBe(0);
+		expect(limits.maxSeats).toBe(1);
+	});
+
+	it('canceled subscription returns the gated floor (not free)', () => {
+		const limits = resolveLimits({ status: 'canceled', plan: 'coalition' }, false);
+		expect(limits.maxTemplatesMonth).toBe(2);
+		expect(limits.maxEmails).toBe(0);
+	});
+
+	it('past_due past grace returns the gated floor', () => {
+		// effectivelyActive=false models a past_due sub past its 7-day grace window
+		const limits = resolveLimits({ status: 'past_due', plan: 'organization' }, false);
+		expect(limits.maxEmails).toBe(0);
+		expect(limits.maxVerifiedActions).toBe(0);
+	});
+
+	it('an active paying tier is unaffected and keeps its full quotas', () => {
+		const starter = resolveLimits({ status: 'active', plan: 'starter' }, true);
+		expect(starter.maxEmails).toBe(20_000);
+		expect(starter.maxVerifiedActions).toBe(1_000);
+		expect(starter.maxSeats).toBe(5);
+
+		const coalition = resolveLimits({ status: 'active', plan: 'coalition' }, true);
+		expect(coalition.maxEmails).toBe(250_000);
+		expect(coalition.maxSms).toBe(50_000);
+	});
+
+	it('a within-grace past_due org (effectivelyActive=true) keeps its paid tier', () => {
+		const limits = resolveLimits({ status: 'past_due', plan: 'organization' }, true);
+		expect(limits.maxEmails).toBe(100_000);
+		expect(limits.maxVerifiedActions).toBe(5_000);
+	});
+});

--- a/tests/unit/billing/plan-sync.test.ts
+++ b/tests/unit/billing/plan-sync.test.ts
@@ -17,12 +17,12 @@ import { PLANS } from '$lib/server/billing/plans';
  * If you change plans.ts, update both this test AND convex/subscriptions.ts.
  */
 const EXPECTED_CONVEX_MIRROR = {
-	free: {
+	inactive: {
 		priceCents: 0,
-		maxSeats: 2,
-		maxTemplatesMonth: 10,
-		maxVerifiedActions: 100,
-		maxEmails: 1_000,
+		maxSeats: 1,
+		maxTemplatesMonth: 2,
+		maxVerifiedActions: 0,
+		maxEmails: 0,
 		maxSms: 0
 	},
 	starter: {

--- a/tests/unit/billing/plans.test.ts
+++ b/tests/unit/billing/plans.test.ts
@@ -2,59 +2,63 @@ import { describe, it, expect } from 'vitest';
 import { PLANS, PLAN_ORDER, getPlanForOrg, type PlanLimits } from '$lib/server/billing/plans';
 
 describe('PLANS', () => {
-	it('should define four plan tiers', () => {
-		expect(Object.keys(PLANS)).toEqual(['free', 'starter', 'organization', 'coalition']);
+	it('should define three marketed tiers plus the gated inactive floor', () => {
+		expect(Object.keys(PLANS)).toEqual(['inactive', 'starter', 'organization', 'coalition']);
 	});
 
-	it('should have increasing prices across tiers', () => {
+	it('should NOT define a free tier', () => {
+		expect(PLANS.free).toBeUndefined();
+	});
+
+	it('should have increasing prices across marketed tiers', () => {
 		const prices = PLAN_ORDER.map((slug) => PLANS[slug].priceCents);
 		for (let i = 1; i < prices.length; i++) {
 			expect(prices[i]).toBeGreaterThan(prices[i - 1]);
 		}
 	});
 
-	it('should have increasing verified action limits across tiers', () => {
+	it('should have increasing verified action limits across marketed tiers', () => {
 		const limits = PLAN_ORDER.map((slug) => PLANS[slug].maxVerifiedActions);
 		for (let i = 1; i < limits.length; i++) {
 			expect(limits[i]).toBeGreaterThan(limits[i - 1]);
 		}
 	});
 
-	it('should have increasing email limits across tiers', () => {
+	it('should have increasing email limits across marketed tiers', () => {
 		const limits = PLAN_ORDER.map((slug) => PLANS[slug].maxEmails);
 		for (let i = 1; i < limits.length; i++) {
 			expect(limits[i]).toBeGreaterThan(limits[i - 1]);
 		}
 	});
 
-	it('should have increasing seat limits across tiers', () => {
+	it('should have increasing seat limits across marketed tiers', () => {
 		const limits = PLAN_ORDER.map((slug) => PLANS[slug].maxSeats);
 		for (let i = 1; i < limits.length; i++) {
 			expect(limits[i]).toBeGreaterThan(limits[i - 1]);
 		}
 	});
 
-	it('should have increasing template limits across tiers', () => {
+	it('should have increasing template limits across marketed tiers', () => {
 		const limits = PLAN_ORDER.map((slug) => PLANS[slug].maxTemplatesMonth);
 		for (let i = 1; i < limits.length; i++) {
 			expect(limits[i]).toBeGreaterThan(limits[i - 1]);
 		}
 	});
 
-	it('free tier should have no Stripe price ID', () => {
-		expect(PLANS.free.stripePriceId).toBe('');
+	it('inactive floor should have no Stripe price ID', () => {
+		expect(PLANS.inactive.stripePriceId).toBe('');
 	});
 
-	it('free tier should have specific limits', () => {
-		expect(PLANS.free).toMatchObject({
-			slug: 'free',
-			name: 'Free',
+	it('inactive floor should gate all delivery + scale (2 templates only)', () => {
+		expect(PLANS.inactive).toMatchObject({
+			slug: 'inactive',
+			name: 'Inactive',
 			priceCents: 0,
-			maxVerifiedActions: 100,
-			maxEmails: 1_000,
+			maxVerifiedActions: 0,
+			maxEmails: 0,
 			maxSms: 0,
-			maxSeats: 2,
-			maxTemplatesMonth: 10
+			maxSeats: 1,
+			maxTemplatesMonth: 2
 		});
 	});
 
@@ -66,7 +70,7 @@ describe('PLANS', () => {
 		expect(PLANS.coalition.maxTemplatesMonth).toBe(1_000);
 	});
 
-	it('should have increasing SMS limits across tiers', () => {
+	it('should have increasing SMS limits across marketed tiers', () => {
 		const limits = PLAN_ORDER.map((slug) => PLANS[slug].maxSms);
 		for (let i = 1; i < limits.length; i++) {
 			expect(limits[i]).toBeGreaterThan(limits[i - 1]);
@@ -75,22 +79,31 @@ describe('PLANS', () => {
 });
 
 describe('PLAN_ORDER', () => {
-	it('should list plans from lowest to highest tier', () => {
-		expect(PLAN_ORDER).toEqual(['free', 'starter', 'organization', 'coalition']);
+	it('should list marketed plans from lowest to highest tier (no free, no inactive)', () => {
+		expect(PLAN_ORDER).toEqual(['starter', 'organization', 'coalition']);
 	});
 
-	it('should contain exactly the same slugs as PLANS', () => {
+	it('should exclude the non-marketed inactive floor', () => {
+		expect([...PLAN_ORDER]).not.toContain('inactive');
+		expect([...PLAN_ORDER]).not.toContain('free');
+	});
+
+	it('marketed slugs are a subset of PLANS (inactive is the only extra)', () => {
 		const planSlugs = Object.keys(PLANS).sort();
-		const orderSlugs = [...PLAN_ORDER].sort();
-		expect(orderSlugs).toEqual(planSlugs);
+		expect(planSlugs).toEqual(['coalition', 'inactive', 'organization', 'starter']);
+		for (const slug of PLAN_ORDER) {
+			expect(PLANS[slug]).toBeDefined();
+		}
 	});
 });
 
 describe('getPlanForOrg', () => {
-	it('should return free plan when subscription is null', () => {
+	it('should return the inactive floor when subscription is null', () => {
 		const plan = getPlanForOrg(null);
-		expect(plan.slug).toBe('free');
+		expect(plan.slug).toBe('inactive');
 		expect(plan.priceCents).toBe(0);
+		expect(plan.maxTemplatesMonth).toBe(2);
+		expect(plan.maxEmails).toBe(0);
 	});
 
 	it('should return the correct plan for a valid subscription', () => {
@@ -111,13 +124,13 @@ describe('getPlanForOrg', () => {
 		expect(plan.maxEmails).toBe(250_000);
 	});
 
-	it('should fall back to free plan for unknown plan slug', () => {
+	it('should fall back to the inactive floor for an unknown plan slug', () => {
 		const plan = getPlanForOrg({ plan: 'nonexistent' });
-		expect(plan.slug).toBe('free');
+		expect(plan.slug).toBe('inactive');
 	});
 
-	it('should fall back to free plan for empty string plan', () => {
+	it('should fall back to the inactive floor for an empty string plan', () => {
 		const plan = getPlanForOrg({ plan: '' });
-		expect(plan.slug).toBe('free');
+		expect(plan.slug).toBe('inactive');
 	});
 });

--- a/tests/unit/billing/verified-action-metering.test.ts
+++ b/tests/unit/billing/verified-action-metering.test.ts
@@ -9,7 +9,7 @@
  * The fix meters via a monotonic lifetime tally minus a per-period baseline
  * snapshotted at rollover: period_count = lifetime - baseline. The baseline only
  * ever moves forward (no never-reset bug). A stale/missing baseline (late Stripe
- * webhook, or a free-tier calendar-month rollover with no webhook) self-heals via
+ * webhook, or an inactive org's calendar-month rollover with no webhook) self-heals via
  * a bounded sentAt-range count for THIS period only — never an unbounded scan.
  *
  * convex-test isn't wired in this repo, so these mirror the handler's pure

--- a/tests/unit/convex/branding-gate.test.ts
+++ b/tests/unit/convex/branding-gate.test.ts
@@ -33,12 +33,12 @@ describe('effectivePlan', () => {
 		expect(effectivePlan({ status: 'active', plan: 'organization' })).toBe('organization');
 	});
 
-	it('treats canceled/past_due/missing as free', () => {
-		expect(effectivePlan({ status: 'canceled', plan: 'coalition' })).toBe('free');
-		expect(effectivePlan({ status: 'past_due', plan: 'coalition' })).toBe('free');
-		expect(effectivePlan(null)).toBe('free');
-		expect(effectivePlan(undefined)).toBe('free');
-		expect(effectivePlan({ status: 'active' })).toBe('free');
+	it('treats canceled/past_due/missing as the gated inactive floor', () => {
+		expect(effectivePlan({ status: 'canceled', plan: 'coalition' })).toBe('inactive');
+		expect(effectivePlan({ status: 'past_due', plan: 'coalition' })).toBe('inactive');
+		expect(effectivePlan(null)).toBe('inactive');
+		expect(effectivePlan(undefined)).toBe('inactive');
+		expect(effectivePlan({ status: 'active' })).toBe('inactive');
 	});
 });
 
@@ -47,7 +47,7 @@ describe('isCoalitionPlan', () => {
 		expect(isCoalitionPlan('coalition')).toBe(true);
 		expect(isCoalitionPlan('organization')).toBe(false);
 		expect(isCoalitionPlan('starter')).toBe(false);
-		expect(isCoalitionPlan('free')).toBe(false);
+		expect(isCoalitionPlan('inactive')).toBe(false);
 	});
 });
 
@@ -67,8 +67,8 @@ describe('isValidAccentHex', () => {
 });
 
 describe('decideAccentWrite — Coalition gate', () => {
-	it('REJECTS a non-empty accent below Coalition tier (free)', () => {
-		const d = decideAccentWrite('free', '#0d9488');
+	it('REJECTS a non-empty accent below Coalition tier (inactive floor)', () => {
+		const d = decideAccentWrite('inactive', '#0d9488');
 		expect(d.ok).toBe(false);
 		if (!d.ok) expect(d.reason).toBe('tier');
 	});
@@ -92,7 +92,7 @@ describe('decideAccentWrite — Coalition gate', () => {
 	});
 
 	it('ALLOWS clearing (empty/null/undefined) at ANY tier', () => {
-		for (const plan of ['free', 'organization', 'coalition']) {
+		for (const plan of ['inactive', 'organization', 'coalition']) {
 			expect(decideAccentWrite(plan, '')).toEqual({ ok: true, cleared: true });
 			expect(decideAccentWrite(plan, null)).toEqual({ ok: true, cleared: true });
 			expect(decideAccentWrite(plan, undefined)).toEqual({ ok: true, cleared: true });
@@ -102,14 +102,14 @@ describe('decideAccentWrite — Coalition gate', () => {
 
 describe('logoWriteAllowed — Coalition gate', () => {
 	it('REJECTS setting a logo below Coalition tier', () => {
-		expect(logoWriteAllowed('free', false)).toBe(false);
+		expect(logoWriteAllowed('inactive', false)).toBe(false);
 		expect(logoWriteAllowed('organization', false)).toBe(false);
 	});
 	it('ALLOWS setting a logo at Coalition tier', () => {
 		expect(logoWriteAllowed('coalition', false)).toBe(true);
 	});
 	it('ALLOWS clearing a logo at ANY tier', () => {
-		expect(logoWriteAllowed('free', true)).toBe(true);
+		expect(logoWriteAllowed('inactive', true)).toBe(true);
 		expect(logoWriteAllowed('organization', true)).toBe(true);
 		expect(logoWriteAllowed('coalition', true)).toBe(true);
 	});
@@ -117,14 +117,14 @@ describe('logoWriteAllowed — Coalition gate', () => {
 
 describe('whiteLabelWriteAllowed — Coalition gate', () => {
 	it('REJECTS enabling white-label below Coalition tier', () => {
-		expect(whiteLabelWriteAllowed('free', true)).toBe(false);
+		expect(whiteLabelWriteAllowed('inactive', true)).toBe(false);
 		expect(whiteLabelWriteAllowed('organization', true)).toBe(false);
 	});
 	it('ALLOWS enabling white-label at Coalition tier', () => {
 		expect(whiteLabelWriteAllowed('coalition', true)).toBe(true);
 	});
 	it('ALLOWS disabling white-label at ANY tier (re-attach Commons branding)', () => {
-		expect(whiteLabelWriteAllowed('free', false)).toBe(true);
+		expect(whiteLabelWriteAllowed('inactive', false)).toBe(true);
 		expect(whiteLabelWriteAllowed('organization', false)).toBe(true);
 		expect(whiteLabelWriteAllowed('coalition', false)).toBe(true);
 	});

--- a/tests/unit/convex/congressional-hardening-r2.test.ts
+++ b/tests/unit/convex/congressional-hardening-r2.test.ts
@@ -6,7 +6,7 @@
  * that the unbounded recipientSubdivision multiplier could force-spawn a debate.
  *
  *   - Self-heal billing path: congressional rows MUST be excluded from the
- *     stale-baseline range scan too (free-tier orgs always hit this path), or
+ *     stale-baseline range scan too (inactive/unsubscribed orgs always hit this path), or
  *     congressional traffic leaks back into the org's metered usage.
  *   - Debate auto-spawn: a congressional emit MUST NOT count toward the debate
  *     threshold (until the recipientSubdivision multiplier is bounded), or an

--- a/tests/unit/sms/billing-limits.test.ts
+++ b/tests/unit/sms/billing-limits.test.ts
@@ -10,8 +10,8 @@ import { describe, it, expect } from 'vitest';
 import { PLANS, PLAN_ORDER } from '$lib/server/billing/plans';
 
 describe('SMS Plan Limits', () => {
-	it('free tier should have maxSms = 0', () => {
-		expect(PLANS.free.maxSms).toBe(0);
+	it('inactive floor should have maxSms = 0 (delivery gated)', () => {
+		expect(PLANS.inactive.maxSms).toBe(0);
 	});
 
 	it('starter tier should have maxSms = 1000', () => {


### PR DESCRIPTION
No free org tier (orgs pay; entry = Starter $10/mo), with **gate-at-delivery**: an org with no active subscription falls to a non-marketed `inactive` floor — it can create the org and author a campaign or two (`maxTemplatesMonth: 2` — the free *experience*), but all delivery + scale (`maxEmails`/`maxSms`/`maxVerifiedActions: 0`, `maxSeats: 1`) is locked until it subscribes.

## Why
Monetization policy (individuals free, orgs pay) + bootstrapping (no AI/send COGS for non-payers). Gate-at-delivery is the conversion-smart version: prospects reach the aha (author a grounded, targeted campaign + preview the report) before the paywall, which lands at peak intent (a campaign in hand they want to send).

## Change (plan definitions + the free→inactive fallback only)
- `plans.ts` + `subscriptions.ts` mirror: removed `free`, added `inactive` floor; `PLAN_ORDER` → `['starter','organization','coalition']`; every `?? PLANS.free` / `: "free"` fallback repointed to `inactive` (both `checkPlanLimits` paths, `cancel`, `updateByStripeId`, `backfillOrgLimits`).
- Fallback strings: `_brandingGate.effectivePlan`, `organizations.ts`, `v1api.ts`, `api-v1/rate-limit.ts`, `_validators`/`schema` plan union (`inactive` in validator, out of PLAN_ORDER), `backfill` drift-audit.
- Surfaces: checkout rejects anything not in PLAN_ORDER; settings grid → 3 columns (Starter/Org/Coalition), `inactive` never renders; compose A/B gates require a present non-inactive plan.
- **Org-creation default aligned to the floor** (`organizations.ts` insert was defaulting `maxSeats:2/maxTemplatesMonth:10` — the old free values; now `1`/`2`) so a new unsubscribed org is actually gated at the enforcement layer.
- Seed: all dev orgs get explicit subs (climate=org, voter-rights=starter, local-first-sf=coalition).

## Preserved
- **D-04 billing scale-fix UNTOUCHED** — `verifiedActionsThisPeriod`/lifetime-baseline/`by_orgId_verified_sentAt` self-heal unchanged (only plan definitions + the fallback string changed; metering math is identical). Congressional/email enforcement gates unchanged.

## Evidence
- vitest **4,686 passed / 0 failed** on a clean checkout (+ `tests/unit/billing/inactive-floor.test.ts`: no-sub → floor, canceled → inactive, past-grace → floor, paying tiers unaffected). convex tsc 0 · svelte-check 0 · codegen clean.

## Follow-ups (NOT in this PR — need a copy decision)
1. **Marketing pages still advertise a Free tier** — `org/for/{local-government,agency-rulemaking,state-legislature}` + `developers` hardcode "Free $0 · 100 verified actions". These now contradict billing and must be reframed (gate-at-delivery messaging).
2. **Conversion UX** — the delivery gate should surface "Your campaign's ready — choose a plan to send it" (not a raw quota error); `/org/new` should set the "author free, subscribe to deliver" expectation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Plan Structure**
  * Replaced "free" tier with "inactive" baseline for unsubscribed and canceled organizations
  * Inactive accounts now have stricter limits: 1 seat, 2 templates/month, and no verified actions or email delivery
* **API Changes**
  * Read-only API operations uncapped for inactive plans
* **Feature Updates**
  * A/B testing now requires an active paid subscription

<!-- end of auto-generated comment: release notes by coderabbit.ai -->