### PR TITLE
Delivery gate: subscribe-to-send prompt, not a raw quota error

### DIFF
--- a/src/lib/components/org/DeliveryGateNotice.svelte
+++ b/src/lib/components/org/DeliveryGateNotice.svelte
@@ -1,0 +1,74 @@
+<!--
+	Conversion prompt shown at the moment of peak intent: the operator has
+	authored a campaign and tried to deliver it, but the org has no active
+	plan (the gated `inactive` floor sets every delivery quota to zero). Instead
+	of a raw quota error, this presents a focused subscribe-to-send prompt with
+	loss-aversion framing — the work is done, only sending needs a plan — and a
+	primary CTA to the in-app pricing grid.
+
+	This is presentation only. The 0-quota floor is enforced server-side; this
+	component never relaxes it.
+-->
+<script lang="ts">
+	let {
+		planHref,
+		headline = "Your campaign's ready — choose a plan to send it"
+	}: {
+		/** In-app pricing grid anchor, e.g. `/org/<slug>/settings#plan-feature-boundary`. */
+		planHref: string;
+		headline?: string;
+	} = $props();
+</script>
+
+<div class="delivery-gate" role="status">
+	<h2 class="delivery-gate__headline">{headline}</h2>
+	<p class="delivery-gate__line">Authoring is free; sending to your people needs a plan.</p>
+	<a class="delivery-gate__cta" href={planHref}>Choose a plan</a>
+</div>
+
+<style>
+	.delivery-gate {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 0.625rem;
+		border: 1px solid color-mix(in oklch, var(--accent-teal, oklch(0.7 0.12 180)) 40%, transparent);
+		background: color-mix(in oklch, var(--accent-teal, oklch(0.7 0.12 180)) 6%, transparent);
+		border-radius: 0.5rem;
+		padding: 1.25rem 1.5rem;
+	}
+	.delivery-gate__headline {
+		margin: 0;
+		font-family: 'Satoshi', system-ui, sans-serif;
+		font-size: 1.0625rem;
+		font-weight: 600;
+		line-height: 1.4;
+		color: var(--text-primary, oklch(0.25 0.02 60));
+	}
+	.delivery-gate__line {
+		margin: 0;
+		font-family: 'Satoshi', system-ui, sans-serif;
+		font-size: 0.875rem;
+		line-height: 1.5;
+		color: var(--text-secondary, oklch(0.42 0.015 60));
+	}
+	.delivery-gate__cta {
+		display: inline-flex;
+		align-items: center;
+		min-height: 44px;
+		box-sizing: border-box;
+		margin-top: 0.125rem;
+		padding: 0 1rem;
+		border-radius: 0.5rem;
+		background: var(--accent-teal-strong, oklch(0.6 0.13 185));
+		color: #fff;
+		font-family: 'Satoshi', system-ui, sans-serif;
+		font-size: 0.875rem;
+		font-weight: 600;
+		text-decoration: none;
+		transition: background-color 150ms ease-out;
+	}
+	.delivery-gate__cta:hover {
+		background: var(--accent-teal, oklch(0.66 0.13 185));
+	}
+</style>

--- a/src/lib/data/org-limit-sentences.ts
+++ b/src/lib/data/org-limit-sentences.ts
@@ -31,6 +31,27 @@ export function isClientDirectEmailCount(
 export const MAX_DECRYPTED_SMS_DISPATCH = 100;
 
 /**
+ * Boundary code a delivery action returns when the org has no active plan and
+ * therefore no send quota (the gated `inactive` floor zeroes maxEmails /
+ * maxSms / maxVerifiedActions). The UI keys the subscribe-to-send conversion
+ * prompt on this exact code — never on a generic send failure — so an
+ * unrelated error never offers a plan as the fix. Server actions return it as
+ * `errorCode` alongside the existing plain-language `error` string (which
+ * stays a correct fallback for any surface that hasn't adopted the prompt).
+ */
+export const DELIVERY_QUOTA_SUBSCRIBE_GATE = 'delivery_quota_subscribe_gate';
+
+/**
+ * The in-app pricing grid anchor inside org settings. The settings page renders
+ * the Starter / Organization / Coalition comparison grid (with per-plan
+ * checkout) under `id="plan-feature-boundary"`; the conversion prompt links
+ * straight to it.
+ */
+export function deliveryPlanGridHref(orgSlug: string): string {
+	return `/org/${orgSlug}/settings#plan-feature-boundary`;
+}
+
+/**
  * Every boundary code that carries a limit sentence. The first seven are
  * boundary codes returned by the org server routes; `authoring_runtime` and
  * `congressional_delivery` are keyed explicitly because their readiness

--- a/src/routes/org/[slug]/campaigns/[id]/report/+page.server.ts
+++ b/src/routes/org/[slug]/campaigns/[id]/report/+page.server.ts
@@ -7,6 +7,7 @@ import type { Id } from '$convex/_generated/dataModel';
 import { computeVerificationPacketCached } from '$lib/server/verification-packet';
 import { renderReport } from '$lib/server/email/report-template';
 import { computeProofWeight } from '$lib/server/legislation/receipts/proof-weight';
+import { DELIVERY_QUOTA_SUBSCRIBE_GATE } from '$lib/data/org-limit-sentences';
 
 const baseUrl = env.PUBLIC_BASE_URL?.replace(/\/$/, '') ?? 'https://commons.email';
 
@@ -164,9 +165,20 @@ export const actions: Actions = {
 			return fail(400, { error: 'One or more target emails are too long' });
 		}
 
-		// Check usage limits via Convex
+		// Check usage limits via Convex. An org with no active plan sits on the
+		// gated `inactive` floor (maxEmails === 0): it authored the report for
+		// free but has never bought the ability to deliver it. That is a
+		// conversion moment, so return the subscribe-to-send gate code and let
+		// the page show the prompt. An active plan that exhausted its period
+		// quota (maxEmails > 0) keeps the plain upgrade sentence with no code.
 		const limits = await serverQuery(api.subscriptions.checkPlanLimits, { orgSlug: params.slug });
 		if (limits && limits.current && limits.current.emailsSent >= limits.limits.maxEmails) {
+			if (limits.limits.maxEmails <= 0) {
+				return fail(403, {
+					error: 'Delivering this report needs a plan. Authoring stays free.',
+					errorCode: DELIVERY_QUOTA_SUBSCRIBE_GATE
+				});
+			}
 			return fail(403, {
 				error:
 					'Email send limit reached for the current billing period. Upgrade your plan to send more.'

--- a/src/routes/org/[slug]/campaigns/[id]/report/+page.svelte
+++ b/src/routes/org/[slug]/campaigns/[id]/report/+page.svelte
@@ -2,9 +2,23 @@
 	import { enhance } from '$app/forms';
 	import { invalidateAll } from '$app/navigation';
 	import { Datum } from '$lib/design';
+	import DeliveryGateNotice from '$lib/components/org/DeliveryGateNotice.svelte';
+	import {
+		DELIVERY_QUOTA_SUBSCRIBE_GATE,
+		deliveryPlanGridHref
+	} from '$lib/data/org-limit-sentences';
 	import type { PageData, ActionData } from './$types';
 
 	let { data, form }: { data: PageData; form: ActionData } = $props();
+
+	// The org has no active plan, so it has no send quota for delivering the
+	// report. Show the subscribe-to-send conversion prompt instead of a raw
+	// quota error. Gated on the exact code so an unrelated send failure never
+	// offers a plan as the fix.
+	const showDeliveryGate = $derived(
+		!!form && 'errorCode' in form && form.errorCode === DELIVERY_QUOTA_SUBSCRIBE_GATE
+	);
+	const planGridHref = $derived(deliveryPlanGridHref(data.org.slug));
 
 	let selectedTargets = $state<Set<string>>(new Set());
 	let logResponseDeliveryId = $state<string | null>(null);
@@ -210,7 +224,12 @@
 	</nav>
 
 	<!-- Error/success messages -->
-	{#if form?.error}
+	{#if showDeliveryGate}
+		<DeliveryGateNotice
+			planHref={planGridHref}
+			headline="Your report's ready — choose a plan to deliver it"
+		/>
+	{:else if form?.error}
 		<div class="rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-400">
 			{form.error}
 		</div>

--- a/src/routes/org/[slug]/emails/compose/+page.server.ts
+++ b/src/routes/org/[slug]/emails/compose/+page.server.ts
@@ -14,7 +14,7 @@ import {
 } from '$lib/server/email/compiler';
 import { sanitizeEmailBody } from '$lib/server/email/sanitize';
 import { getEmailServerDispatchReadiness } from '$lib/server/email/server-dispatch-readiness';
-import { orgLimitSentence } from '$lib/data/org-limit-sentences';
+import { orgLimitSentence, DELIVERY_QUOTA_SUBSCRIBE_GATE } from '$lib/data/org-limit-sentences';
 import { getRateLimiter } from '$lib/core/security/rate-limiter';
 import { FEATURES } from '$lib/config/features';
 import type { PageServerLoad, Actions } from './$types';
@@ -79,6 +79,28 @@ function requireRole(role: string, required: string): void {
 
 function canEdit(role: string): boolean {
 	return role === 'owner' || role === 'editor';
+}
+
+/**
+ * Build the 403 payload for an email-send block. An org with no active plan
+ * sits on the gated `inactive` floor where `maxEmails === 0` — authoring is
+ * free but it has never bought the ability to send. That is a conversion
+ * moment, not a failure: the payload carries `errorCode` so the UI shows a
+ * subscribe-to-send prompt. An active plan that genuinely exhausted its
+ * period quota (`maxEmails > 0`) gets the existing upgrade sentence with no
+ * gate code, so the prompt never fires for that distinct case.
+ */
+function emailQuotaFailBody(maxEmails: number): { error: string; errorCode?: string } {
+	if (maxEmails <= 0) {
+		return {
+			error: 'Sending to your people needs a plan. Authoring stays free.',
+			errorCode: DELIVERY_QUOTA_SUBSCRIBE_GATE
+		};
+	}
+	return {
+		error:
+			'Email send limit reached for the current billing period. Upgrade your plan to send more.'
+	};
 }
 
 async function countRecipientsByFilter(
@@ -321,10 +343,7 @@ export const actions: Actions = {
 		// Billing usage check via Convex
 		const limits = await serverQuery(api.subscriptions.checkPlanLimits, { orgSlug: params.slug });
 		if (limits?.current && limits.current.emailsSent >= limits.limits.maxEmails) {
-			return fail(403, {
-				error:
-					'Email send limit reached for the current billing period. Upgrade your plan to send more.'
-			});
+			return fail(403, emailQuotaFailBody(limits.limits.maxEmails));
 		}
 
 		const formData = await request.formData();
@@ -472,10 +491,7 @@ export const actions: Actions = {
 		// Billing usage check via Convex
 		const abLimits = await serverQuery(api.subscriptions.checkPlanLimits, { orgSlug: params.slug });
 		if (abLimits?.current && abLimits.current.emailsSent >= abLimits.limits.maxEmails) {
-			return fail(403, {
-				error:
-					'Email send limit reached for the current billing period. Upgrade your plan to send more.'
-			});
+			return fail(403, emailQuotaFailBody(abLimits.limits.maxEmails));
 		}
 
 		const formData = await request.formData();
@@ -622,10 +638,7 @@ export const actions: Actions = {
 
 		const limits = await serverQuery(api.subscriptions.checkPlanLimits, { orgSlug: params.slug });
 		if (limits?.current && limits.current.emailsSent >= limits.limits.maxEmails) {
-			return fail(403, {
-				error:
-					'Email send limit reached for the current billing period. Upgrade your plan to send more.'
-			});
+			return fail(403, emailQuotaFailBody(limits.limits.maxEmails));
 		}
 
 		const formData = await request.formData();

--- a/src/routes/org/[slug]/emails/compose/+page.svelte
+++ b/src/routes/org/[slug]/emails/compose/+page.svelte
@@ -8,9 +8,12 @@
 	import { Datum } from '$lib/design';
 	import { FEATURES } from '$lib/config/features';
 	import BoundedNotice from '$lib/components/org/BoundedNotice.svelte';
+	import DeliveryGateNotice from '$lib/components/org/DeliveryGateNotice.svelte';
 	import {
 		CLIENT_DIRECT_EMAIL_THRESHOLD,
+		DELIVERY_QUOTA_SUBSCRIBE_GATE,
 		buildOrgLimitNotice,
+		deliveryPlanGridHref,
 		emailDeliveryLimitNotice,
 		isClientDirectEmailCount
 	} from '$lib/data/org-limit-sentences';
@@ -355,6 +358,11 @@
 	const errorDraftHref = $derived(
 		form && 'draftHref' in form ? (form as { draftHref: string }).draftHref : null
 	);
+	// The org has no active plan, so it has no send quota. Show the
+	// subscribe-to-send conversion prompt instead of a raw quota error. Gated
+	// on the exact code so an unrelated send failure never offers a plan.
+	const showDeliveryGate = $derived(errorCode === DELIVERY_QUOTA_SUBSCRIBE_GATE);
+	const planGridHref = $derived(deliveryPlanGridHref(data.org.slug));
 	const errorLimitNotice = $derived(
 		errorCode === 'email_server_dispatch_dependency_missing'
 			? buildOrgLimitNotice('email_server_dispatch_dependency_missing', {
@@ -714,7 +722,9 @@
 		</div>
 	</div>
 
-	{#if errorLimitNotice}
+	{#if showDeliveryGate}
+		<DeliveryGateNotice planHref={planGridHref} />
+	{:else if errorLimitNotice}
 		<div class="border-surface-border bg-surface-base rounded-md border px-4 py-3">
 			<BoundedNotice notice={errorLimitNotice} />
 			{#if errorDraftHref}

--- a/tests/unit/components/DeliveryGateNotice.test.ts
+++ b/tests/unit/components/DeliveryGateNotice.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/svelte';
+import DeliveryGateNotice from '$lib/components/org/DeliveryGateNotice.svelte';
+import DeliveryGateHarness from './fixtures/DeliveryGateHarness.svelte';
+import {
+	DELIVERY_QUOTA_SUBSCRIBE_GATE,
+	deliveryPlanGridHref
+} from '$lib/data/org-limit-sentences';
+
+describe('DeliveryGateNotice', () => {
+	it('renders the loss-aversion conversion prompt with a CTA to the in-app pricing grid', () => {
+		const slug = 'climate-action-now';
+		const { getByText, getByRole } = render(DeliveryGateNotice, {
+			props: { planHref: deliveryPlanGridHref(slug) }
+		});
+
+		// Loss-aversion headline: the work is done, only sending needs a plan.
+		expect(getByText("Your campaign's ready — choose a plan to send it")).toBeTruthy();
+		expect(getByText('Authoring is free; sending to your people needs a plan.')).toBeTruthy();
+
+		// Primary CTA points at the settings plan-comparison grid anchor.
+		const cta = getByRole('link', { name: /choose a plan/i });
+		expect(cta.getAttribute('href')).toBe(`/org/${slug}/settings#plan-feature-boundary`);
+	});
+
+	it('does not leak a raw error code into the visible copy', () => {
+		const { container } = render(DeliveryGateNotice, {
+			props: { planHref: deliveryPlanGridHref('voter-rights-coalition') }
+		});
+		expect(container.textContent).not.toContain('QUOTA');
+		expect(container.textContent).not.toContain(DELIVERY_QUOTA_SUBSCRIBE_GATE);
+	});
+});
+
+describe('delivery gate surface selection', () => {
+	const slug = 'local-first-sf';
+
+	it('shows the subscribe-to-send prompt when the send action returns the quota-gate code', () => {
+		const { getByRole, getByText, queryByTestId } = render(DeliveryGateHarness, {
+			props: {
+				slug,
+				form: {
+					error: 'Sending to your people needs a plan. Authoring stays free.',
+					errorCode: DELIVERY_QUOTA_SUBSCRIBE_GATE
+				}
+			}
+		});
+
+		// Conversion prompt is shown...
+		expect(getByText("Your campaign's ready — choose a plan to send it")).toBeTruthy();
+		expect(getByRole('link', { name: /choose a plan/i }).getAttribute('href')).toBe(
+			`/org/${slug}/settings#plan-feature-boundary`
+		);
+		// ...and the raw error box is NOT.
+		expect(queryByTestId('raw-error')).toBeNull();
+	});
+
+	it('does NOT show the subscribe CTA for a non-quota send error', () => {
+		const { getByTestId, queryByRole, queryByText } = render(DeliveryGateHarness, {
+			props: {
+				slug,
+				form: { error: 'No recipients match your filters. Adjust filters and try again.' }
+			}
+		});
+
+		// The generic error renders as the raw error box...
+		expect(getByTestId('raw-error').textContent).toContain('No recipients match your filters');
+		// ...and the conversion prompt / subscribe CTA is absent.
+		expect(queryByText("Your campaign's ready — choose a plan to send it")).toBeNull();
+		expect(queryByRole('link', { name: /choose a plan/i })).toBeNull();
+	});
+
+	it('does NOT show the subscribe CTA for an active-plan mid-period quota exhaustion', () => {
+		// maxEmails > 0 path returns the upgrade sentence WITHOUT the gate code,
+		// so the conversion prompt must not fire for that distinct case.
+		const { getByTestId, queryByRole } = render(DeliveryGateHarness, {
+			props: {
+				slug,
+				form: {
+					error:
+						'Email send limit reached for the current billing period. Upgrade your plan to send more.'
+				}
+			}
+		});
+
+		expect(getByTestId('raw-error').textContent).toContain('Email send limit reached');
+		expect(queryByRole('link', { name: /choose a plan/i })).toBeNull();
+	});
+});

--- a/tests/unit/components/fixtures/DeliveryGateHarness.svelte
+++ b/tests/unit/components/fixtures/DeliveryGateHarness.svelte
@@ -1,0 +1,35 @@
+<!--
+	Test-only harness that reproduces the exact in-app delivery surfaces'
+	branch: when a send action returns the subscribe-gate code, show the
+	conversion prompt; otherwise fall back to the raw error box. Mirrors the
+	`{#if showDeliveryGate} ... {:else if errorMsg}` logic in the email compose
+	and campaign-report pages so the test exercises the live selection rule,
+	not a duplicated string.
+-->
+<script lang="ts">
+	import DeliveryGateNotice from '$lib/components/org/DeliveryGateNotice.svelte';
+	import {
+		DELIVERY_QUOTA_SUBSCRIBE_GATE,
+		deliveryPlanGridHref
+	} from '$lib/data/org-limit-sentences';
+
+	let {
+		form,
+		slug
+	}: {
+		form: { error?: string; errorCode?: string } | null;
+		slug: string;
+	} = $props();
+
+	const showDeliveryGate = $derived(
+		!!form && 'errorCode' in form && form.errorCode === DELIVERY_QUOTA_SUBSCRIBE_GATE
+	);
+	const errorMsg = $derived(form && 'error' in form ? form.error : null);
+	const planGridHref = $derived(deliveryPlanGridHref(slug));
+</script>
+
+{#if showDeliveryGate}
+	<DeliveryGateNotice planHref={planGridHref} />
+{:else if errorMsg}
+	<div data-testid="raw-error">{errorMsg}</div>
+{/if}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -94,6 +94,9 @@ export default defineConfig({
 			// Behavioral first-paint test for the Datum spring primitive —
 			// needs the components-lane browser runtime to mount.
 			'tests/unit/components/datum-first-paint.test.ts',
+			// Behavioral test for the delivery-gate conversion prompt — requires
+			// the components-lane config for @testing-library/svelte rendering.
+			'tests/unit/components/DeliveryGateNotice.test.ts',
 			// Post-Convex migration: these tests reference deleted source files,
 			// missing Convex URL config, or stale assertions. Need rewriting against Convex.
 			'tests/integration/analytics-aggregate.test.ts',


### PR DESCRIPTION
The in-app expression of gate-at-delivery. An unsubscribed org (gated `inactive` floor, delivery quotas at 0) that authors a campaign and tries to send now hits a **conversion prompt** at peak intent — *"Your campaign's ready — choose a plan to send it"* → the in-app plan grid — instead of a raw `Upgrade your plan` 403 string.

## Change (presentation only — enforcement unchanged)
- `DeliveryGateNotice.svelte` — loss-aversion headline + "Authoring is free; sending to your people needs a plan." + CTA "Choose a plan" → `/org/<slug>/settings#plan-feature-boundary` (the actual plan-comparison grid anchor).
- `org-limit-sentences.ts` — `DELIVERY_QUOTA_SUBSCRIBE_GATE` code + `deliveryPlanGridHref`.
- compose (`send`/`sendAbTest`/`createClientDraft`) + report (`send`) server actions emit the gate `errorCode` **only when `maxEmails <= 0`** (the no-plan floor). An active plan that exhausts its *period* quota keeps the plain upgrade sentence with **no** gate code — so a paying org never sees "subscribe." Both pages render the notice ahead of the raw-error branch, gated on the exact code.

## Scope
Authenticated org-OS delivery surfaces only. **No landing/marketing files touched** (`+page`/`org/for`/`developers` are owned by the parallel landing build). SMS dispatch deliberately left — it's blocked by the "not armed" boundary, not a billing quota, so there's no quota dead-end to convert there yet.

## Evidence
- `npm run check` 0 errors; main suite 4,686 passed; component lane 62 passed (+1). New `DeliveryGateNotice.test.ts` (5): quota-gate → prompt w/ correct CTA; non-quota error → raw, no CTA; active-plan exhaustion → no CTA.