### PR TITLE
Consistency: fix the live-email Verification-Report bug + land the recenter into docs

### DIFF
--- a/convex/campaigns.ts
+++ b/convex/campaigns.ts
@@ -2611,7 +2611,7 @@ export const getDeliveryMetrics = query({
  * Peer implementations override via the Convex dashboard so report links
  * resolve to their own deployment instead of the reference one.
  */
-function buildReportEmailHtml(campaign: {
+export function buildReportEmailHtml(campaign: {
 	title: string;
 	orgName: string;
 	verifiedActionCount: number;
@@ -2632,7 +2632,7 @@ function buildReportEmailHtml(campaign: {
 <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#fafaf9;">
 <tr><td align="center" style="padding:40px 20px;">
 <table role="presentation" width="560" cellpadding="0" cellspacing="0" style="max-width:560px;width:100%;">
-<tr><td style="padding:0 0 32px 0;"><p style="margin:0;font-size:12px;font-weight:600;color:#a3a3a3;text-transform:uppercase;letter-spacing:.08em;">Verification Report</p></td></tr>
+<tr><td style="padding:0 0 32px 0;"><p style="margin:0;font-size:12px;font-weight:600;color:#a3a3a3;text-transform:uppercase;letter-spacing:.08em;">Constituent Report</p></td></tr>
 <tr><td style="padding:0 0 8px 0;"><p style="margin:0;font-size:18px;font-weight:600;color:#171717;line-height:1.4;">${esc(campaign.title)}</p></td></tr>
 <tr><td style="padding:0 0 28px 0;"><p style="margin:0;font-size:13px;color:#737373;">from ${esc(campaign.orgName)}</p></td></tr>
 <tr><td style="padding:24px 0;border-top:1px solid #e5e5e5;border-bottom:1px solid #e5e5e5;">

--- a/docs/architecture/subscription-cost-model.md
+++ b/docs/architecture/subscription-cost-model.md
@@ -1,14 +1,27 @@
 # Subscription Cost Model
 
 > **Status:** Architecture document (February 2026, pricing updated March 2026)
-> **Scope:** Unit economics for Free / Starter / Organization / Coalition tiers. Every external API call traced from code, priced at current rates, projected against realistic usage.
+> **Scope:** Unit economics for the `inactive` floor / Starter / Organization / Coalition tiers (no free org tier — see recenter banner below). Every external API call traced from code, priced at current rates, projected against realistic usage.
 > **Companion:** `org-data-model.md` (data model), `civic-intelligence-cost-model.md` (intelligence pipeline costs)
 > **Policy:** Individual users are free. All subscription revenue comes from organizations. See [`docs/strategy/monetization-policy.md`](../strategy/monetization-policy.md).
 > **Last verified:** February 2026 (costs), March 2026 (pricing alignment), targeted audit 2026-04-23.
 
+> ⚠️ **Divergence from current `plans.ts` (pricing recenter 2026-06-14):** This
+> doc models a "Free $0" org tier. The shipped `src/lib/server/billing/plans.ts`
+> (merged through PR #34) **removes `free`**: `PLANS` is keyed `inactive` /
+> `starter` / `organization` / `coalition`, `PLAN_ORDER` excludes `inactive`,
+> and `getPlanForOrg(null)` (incl. after cancellation) returns `inactive`. There
+> is no free ORG tier — entry is Starter ($10/mo); the `inactive` floor zeroes
+> all delivery + scale (maxVerifiedActions/maxEmails/maxSms 0, maxSeats 1,
+> maxTemplatesMonth 2) so an org can only author a campaign or two until it
+> subscribes. Read the "Free $0" org tier below as the `inactive`
+> gate-at-delivery floor. NOTE: the "Free individuals," "Groq free tier," and
+> "Exa free tier" references elsewhere in this doc are the Person Layer (free
+> forever) and upstream API free tiers — those are unchanged and correct.
+
 > ⚠️ **2026-04-23 audit — mostly clean, two clarifications:**
 >
-> Plan names, prices (Free $0 / Starter $10 / Organization $75 /
+> Plan names, prices (`inactive` floor $0 / Starter $10 / Organization $75 /
 > Coalition $200), seat/template/action/email/SMS limits, period-scoped
 > query-time aggregation, 7-day grace via `pastDueSince`, and the
 > `invoice.payment_succeeded` → clears `pastDueSince` webhook flow all

--- a/docs/design/MONETIZATION-IMPLEMENTATION.md
+++ b/docs/design/MONETIZATION-IMPLEMENTATION.md
@@ -7,6 +7,17 @@
 **Status**: COMPLETE (2026-03-30)
 **Review**: 2 brutalist cycles (6 critics). Findings verified against code.
 
+> ⚠️ **Divergence from current `plans.ts` (pricing recenter 2026-06-14):** This
+> doc references a "Free / $10 / $75 / $200" tier set. The shipped
+> `src/lib/server/billing/plans.ts` (merged through PR #34) **removes the `free`
+> tier**: `PLANS` is keyed `inactive` / `starter` / `organization` /
+> `coalition`, `PLAN_ORDER` excludes `inactive`, and `getPlanForOrg(null)`
+> returns `inactive`. There is no free org tier — entry is Starter ($10/mo);
+> orgs with no active subscription (incl. after cancellation) fall to the
+> non-marketed `inactive` floor (all delivery + scale zeroed, author 2 templates
+> to experience the product). Read the "Free / $0" beats below as the `inactive`
+> gate-at-delivery floor. Individuals remain free forever (Person Layer).
+
 > ⚠️ **2026-04-23 audit — mostly accurate, three small corrections:**
 >
 > - **T5 (Billing Portal arg/field mismatch) is already fixed.** The
@@ -297,7 +308,7 @@ Every assertion referencing old quota values (5, 10, 15, 30, 50, 150) needs upda
 
 - Rename "Pro" → "Starter" throughout
 - Remove individual subscription revenue projections
-- Align pricing with canonical `economics.md` tiers (Free/$10/$75/$200)
+- Align pricing with canonical `economics.md` tiers (inactive floor / $10 / $75 / $200 — no free tier)
 - Remove dead OpenAI embedding reference
 - Add note: "Individual users are free. See `docs/strategy/monetization-policy.md`."
 

--- a/docs/design/ORG-ACQUISITION-SURFACE.md
+++ b/docs/design/ORG-ACQUISITION-SURFACE.md
@@ -6,6 +6,17 @@
 **Created:** 2026-04-12
 **Depends on:** design-system.md, voice.md, PERCEPTUAL-BRIDGE.md, VERIFICATION-LEGIBILITY.md
 
+> ⚠️ **Divergence from current `plans.ts` (pricing recenter 2026-06-14):** The
+> "Price as Punchline → Free, $0" beat predates the pricing recenter. There is
+> **no free org tier**: shipped `src/lib/server/billing/plans.ts` (merged
+> through PR #34) removes `free`; entry is **Starter ($10/mo)**, and orgs with no
+> active subscription fall to the non-marketed `inactive` floor (all delivery +
+> scale zeroed; cancellation drops to it). The punchline is now **"author free,
+> $10/mo to send"** — the director can build a campaign and preview the
+> Constituent Report without asking the board, then pays only to deliver. The
+> beats below are rephrased accordingly; the "$10 vs Quorum's $10K+/yr"
+> arithmetic still carries the argument.
+
 ---
 
 ## The Problem
@@ -28,7 +39,7 @@ Campaign directors, executive directors of small nonprofits, policy advocates, c
 
 **Outcome-fixated.** They don't care about features. They care: did the committee respond differently? Did the school board member read the testimony? Did the water board take the public comment seriously?
 
-**Budget-traumatized.** Every dollar justifies itself to a board. $10K/yr for Quorum haunts them. $15/mo for AN feels extractive when the budget is $0. Free is the only number that doesn't require a conversation.
+**Budget-traumatized.** Every dollar justifies itself to a board. $10K/yr for Quorum haunts them. $15/mo for AN feels extractive when the budget is $0. Building a full campaign before paying anything — then $10/mo to send — is the entry that doesn't require a conversation.
 
 **Emotionally invested.** They chose this work because they care about water rights, school safety, public health, transit equity. The cause is identity, not a job. Tools that understand this earn trust. Tools that feel transactional don't.
 
@@ -73,9 +84,9 @@ Action Network covers ~3 boundary types (federal, state, county). Quorum covers 
 
 Price only lands after value is established. After the specimen, after the gap, after the boundary recognition:
 
-Free. $0. Import your supporters and send your first proof today.
+Author free. $10/mo to send. Build your campaign, see the grounded messages and targets, preview the Constituent Report today — pay only when you deliver.
 
-Then the tiers for scale. The free tier isn't generosity — it's the structural decision that makes individuals the supply side (see monetization-policy.md). But to the campaign director, it's: "I can try this right now without asking my board."
+Then the tiers for scale. Author-free onboarding isn't generosity — it's the structural decision that lets a director try this without asking the board (see monetization-policy.md). The $10 Starter is the entry; there is no free org tier. To the campaign director, it's: "I can build this right now, and it's $10 to actually send it."
 
 $75/mo vs. Quorum's $10K+/yr speaks for itself. Don't explain the savings. Show the numbers. The arithmetic IS the argument.
 
@@ -121,7 +132,7 @@ The acquisition register (defined in voice.md) applies here. The key distinction
 - "What a staffer receives from your current platform:" → the weak version
 - "What a staffer receives from Commons:" → the specimen
 - "24 boundary types." Then the list.
-- "Free." Then the tiers.
+- "Author free, $10/mo to send." Then the tiers.
 
 ### What we don't say
 
@@ -151,7 +162,7 @@ The four beachhead segments (from product-roadmap.md) have different recognition
 |---------|-------------------|
 | Domain-obsessed local groups | See their boundary type in the coverage list (water districts, school boards, transit authorities) |
 | Science/health advocacy | See "government ID verified" in the specimen — credibility IS their product |
-| Conservative/nonpartisan groups | See "Free" + no ideological gatekeeping — the pricing section implicitly includes them |
+| Conservative/nonpartisan groups | See "author free, $10/mo to send" + no ideological gatekeeping — the pricing section implicitly includes them |
 | Single-issue orgs | See the specimen framing their issue domain (the example should rotate or be parameterizable) |
 
 The current page uses one specimen example (water district). Consider whether the specimen should be parameterizable by URL parameter (e.g., `/org?domain=education` renders a school board specimen) or whether one well-chosen example serves all segments.

--- a/docs/research/competitive-analysis.md
+++ b/docs/research/competitive-analysis.md
@@ -414,7 +414,7 @@ The enterprise platforms (Quorum at $10K+/year) serve trade associations targeti
 
 **Commons serves 24 boundary types per cell.** Shadow Atlas already ingests TIGER/Line congressional, state legislative, county, municipal, school district, and voting tabulation district boundaries. The architecture (H3-indexed, 24 slots per cell) is designed to ingest special district boundaries as they become available — state by state, LAFCO by LAFCO. Every boundary type added instantly becomes targetable for verified advocacy campaigns. No other platform's architecture can accommodate this.
 
-**The market opportunity:** A platform that lets a transit advocacy group, a school parent coalition, or a water district accountability org run verified campaigns to their specific local officials — at a free tier — would have zero competition. Not underpriced competition. Zero.
+**The market opportunity:** A platform that lets a transit advocacy group, a school parent coalition, or a water district accountability org author verified campaigns to their specific local officials — free to author, $10 Starter to deliver — would have zero competition. Not underpriced competition. Zero.
 
 **Sources:** [Census of Governments 2022](https://www.census.gov/newsroom/press-releases/2023/census-of-governments.html), [Census Special Districts by Function](https://www.census.gov/library/visualizations/2023/econ/special-district-governments-by-function.html), [TIGER/Line Shapefiles](https://www.census.gov/geographies/mapping-files/time-series/geo/tiger-line-file.html), [PoliEngine Elected Officials Count](https://poliengine.com/blog/how-many-politicians-are-there-in-the-us)
 
@@ -449,7 +449,7 @@ The conservative advocacy gap is not hypothetical. Organizations have been activ
 
 The gap is specific: **there is no conservative equivalent of Action Network** — an integrated, affordable platform combining email, petitions, write-your-legislator campaigns, event management, and supporter CRM at a self-serve price point. The bipartisan enterprise platforms (Quorum, VoterVoice) start at $5,000-$10,000+/year. Heritage Action's Sentinel program and Americans for Prosperity's i360 are bespoke internal systems, not commercial platforms.
 
-Commons fills this vacuum structurally. Verification is orthogonal to ideology. The protocol doesn't check politics — it checks proof. A free tier that includes email campaigns, verified advocacy, full API access, and 24-boundary-type district targeting is immediately the best tool a conservative advocacy org has ever had. It's also the best tool many progressive orgs have ever had — the ones too small for AN's $15/mo or excluded from EveryAction's ecosystem for other reasons.
+Commons fills this vacuum structurally. Verification is orthogonal to ideology. The protocol doesn't check politics — it checks proof. A $10 Starter entry (with author-free onboarding) that includes email campaigns, verified advocacy, full uncapped API access, and 24-boundary-type district targeting is immediately the best tool a conservative advocacy org has ever had. It's also the best tool many progressive orgs have ever had — the ones too small for AN's $15/mo or excluded from EveryAction's ecosystem for other reasons.
 
 **Sources:** [Senate Commerce Committee Investigation (2024)](https://www.commerce.senate.gov/2024/4/senate-commerce-investigation-reveals-how-big-tech-weaponizes-terms-of-service-to-silence-the-right), [AN Help: Who Can Use It](https://help.actionnetwork.org/hc/en-us/articles/203852955-Who-can-use-the-Action-Network-Only-progressives), [Startup Caucus: Areas of Need (2024)](https://startupcaucus.com/insights/identified-areas-of-need-in-the-republican-campaign-tech-ecosystem-2024)
 
@@ -969,7 +969,7 @@ Congressional staffers process 75–85% of incoming mail as form-generated advoc
 | **Analytics** | CSV export. Opens, clicks. No way to distinguish real constituents from bots or out-of-district signers. | Full dashboard. Opens, clicks, verified actions, tier distribution, GDS, ALD, temporal entropy. Analytics answer "who engaged" with mathematical certainty, not probabilistic guessing. |
 | **Identity** | Email + self-reported address. Platform stores full PII. | ZK proof of government credential. Platform stores commitment, not PII. Identity is a proof, not a record. |
 | **Credibility signal** | Count of emails sent. Staffers have no basis for trust. | Verification packet: verified count, tier distribution, coordination integrity scores (GDS, ALD, entropy), debate market signal. Staffers can mathematically verify every claim. |
-| **Pricing** | $15-$125/mo, no free tier | $0-$200/mo, free tier with full API |
+| **Pricing** | $15-$125/mo, no free tier | $10-$200/mo, author free + Starter $10 entry with full uncapped API |
 | **Political scope** | Progressive only (501(c)(4) ToS). Half the market excluded by policy. | All — protocol verifies proof, not politics. Verification is orthogonal to ideology. |
 | **API** | Paid plans only, 4 req/s cap | Free, all tiers, no cap |
 | **Reputation** | None. Every supporter is equally weightless. | Engagement tiers: New (0), Active (1), Established (2), Veteran (3), Pillar (4). Non-purchasable, on-chain, portable across orgs. |
@@ -1028,9 +1028,9 @@ Congressional staffers process 75–85% of incoming mail as form-generated advoc
 
 ## Pricing Comparison
 
-| Platform | Entry Price | Full-Featured | Free Tier | Self-Serve |
+| Platform | Entry Price | Full-Featured | Free to Author | Self-Serve |
 |---|---|---|---|---|
-| **Commons** | **$0/mo** | **$75–$200/mo** | **Yes (500 supporters, full API)** | **Yes** |
+| **Commons** | **$10/mo (Starter)** | **$75–$200/mo** | **Yes — author free, pay $10 to deliver (full uncapped API)** | **Yes** |
 | Action Network | $15/mo | $125/mo | Limited (no API) | Yes |
 | NationBuilder | $29/mo | $179/mo | No (14-day trial) | Yes |
 | Ujoin | $99/mo | $249/mo | Limited | Yes |
@@ -1051,7 +1051,7 @@ Congressional staffers process 75–85% of incoming mail as form-generated advoc
 
 1. **Science/health advocacy** — credibility over volume. ALI, disease foundations, research coalitions. These orgs need staffers to *believe* the signers are real. Verification is the product.
 2. **Nonpartisan/conservative groups** — structurally excluded from AN (progressive-only ToS) and priced out of enterprise platforms (Quorum, VoterVoice at $10K+). Underserved market with no good tooling at the $10–$200/mo price point.
-3. **Small orgs** — free tier vs AN's $15/month minimum. Full API access. No paywall on analytics.
+3. **Small orgs** — author free, Starter $10/month to deliver vs AN's $15/month minimum. Full uncapped API access. No paywall on analytics.
 4. **Local government advocacy** — school boards, water districts, transit authorities, fire districts, judicial circuits. 21 of 24 Shadow Atlas boundary types have **zero** coverage from any competitor. Shadow Atlas resolves districts that Quorum and VoterVoice literally don't have in their databases.
 
 ### Expansion (Year 2–4)
@@ -1064,8 +1064,8 @@ Congressional staffers process 75–85% of incoming mail as form-generated advoc
 | Segment | What they need | What competitors offer | What Commons offers |
 |---|---|---|---|
 | Science/health | Credible constituent proof | Unverified email counts | ZK-verified counts + tier distribution + coordination integrity |
-| Conservative/nonpartisan | Affordable advocacy tooling | Nothing at <$7,500/yr | Full platform at $0–$200/mo |
-| Small orgs | Free/cheap, easy setup | AN $15/mo (no API), NationBuilder $29/mo | Free tier with full API |
+| Conservative/nonpartisan | Affordable advocacy tooling | Nothing at <$7,500/yr | Full platform at $10–$200/mo (author free, $10 Starter to deliver) |
+| Small orgs | Free/cheap, easy setup | AN $15/mo (no API), NationBuilder $29/mo | Author free, $10 Starter to deliver, full uncapped API |
 | Local government | Sub-state district targeting | Federal + state legislative only | 24 boundary types including school, water, fire, transit, judicial |
 | Progressive orgs | Better response rates from offices | Volume-based, unverified | Verified + unverified side-by-side. Migration tool. |
 | Corporate/trade | Legislative tracking + advocacy | Quorum/VoterVoice at $10K+/yr | $75/mo Organization tier + agentic bill monitoring (Phase 3) |

--- a/docs/strategy/economics.md
+++ b/docs/strategy/economics.md
@@ -4,6 +4,15 @@
 
 ---
 
+> **Positioning + pricing recenter (2026-06-14).** No free ORG tier. Entry is
+> Starter ($10/mo). An org with no active subscription falls to the
+> non-marketed `inactive` floor (all delivery + scale zeroed; author 2 templates
+> to experience the product). Individuals remain free forever (Person Layer).
+> Canonical source: `src/lib/server/billing/plans.ts`. Recorded 2026-06-02 /
+> 2026-06-14; merged through PR #34.
+
+---
+
 ## The Insight
 
 Every advocacy platform sends email. It costs $0.10/1K via SES. Email is table stakes — orgs will never pay a premium for it.
@@ -30,17 +39,22 @@ The expensive parts of the system (ZK circuits, smart contracts, Shadow Atlas, A
 
 Verified actions are the primary metered unit. Email is secondary.
 
-### Free
+### Inactive — gated floor (non-marketed, not sellable)
+
+The fallback for an org with no active subscription. It is the free *experience*
+(author a campaign or two, see grounded messages + targets, preview the
+Constituent Report), not a tier — every delivery + scale quota is zeroed until
+the org subscribes. Cancellation drops an org back to it.
 
 | Feature | Limit |
 |---|---|
-| Verified actions | 100/month |
-| Emails | 1,000/month |
-| Supporters | 500 |
-| API | Full access |
-| Analytics | Full dashboard |
+| Verified actions | 0 |
+| Emails | 0 |
+| SMS | 0 |
+| Seats | 1 |
+| Templates | 2/month |
 
-### Starter — $10/month
+### Starter — $10/month (entry tier)
 
 | Feature | Detail |
 |---|---|
@@ -116,7 +130,7 @@ Verified actions are the primary metered unit. Email is secondary.
 
 The growth line is verified actions, not email volume. As orgs discover that verified constituent contacts produce 3-10x the legislative response rate of unverified email blasts, they move up tiers to unlock more verified actions — not more emails. Email overage revenue is noise. Verified action overage at $1.50-$3.00/1K against $0.01 COGS is the margin engine.
 
-Agentic layer adds ~$4,500/month (with model tiering + shared screening optimizations). Legislative monitoring is the largest agentic cost center — bill screening across all district types for every org. Included at Organization tier and above, not Free/Starter. LLM inference costs falling ~50% annually. Full cost breakdown: `specs/agentic-civic-infrastructure.md`.
+Agentic layer adds ~$4,500/month (with model tiering + shared screening optimizations). Legislative monitoring is the largest agentic cost center — bill screening across all district types for every org. Included at Organization tier and above, not Starter. LLM inference costs falling ~50% annually. Full cost breakdown: `specs/agentic-civic-infrastructure.md`.
 
 ---
 

--- a/docs/strategy/index.md
+++ b/docs/strategy/index.md
@@ -4,6 +4,18 @@
 
 ---
 
+> **Positioning + pricing recenter (2026-06-14).** Commons' core is the
+> AI-native **authoring-to-delivery** spine; **verification is ambient** (a
+> watermark, not the headline). The org front door is **Studio**; the delivered
+> artifact is the **Constituent Report**. **No free org tier** — entry is
+> Starter ($10/mo); unsubscribed orgs fall to a non-marketed `inactive` floor
+> (author a campaign or two free, all delivery + scale at zero). Author free,
+> pay to deliver. Recorded 2026-06-02 / 2026-06-14; merged through PR #34. Where
+> the docs below still lead with "the verification loop is the product," read
+> them through this recenter.
+
+---
+
 ## Current Plan
 
 ### [product-roadmap.md](product-roadmap.md) — What We're Building Now

--- a/docs/strategy/monetization-policy.md
+++ b/docs/strategy/monetization-policy.md
@@ -6,6 +6,19 @@
 
 ---
 
+> **Positioning + pricing recenter (2026-06-14).** "Individuals are free
+> forever" (Person Layer) is unchanged and still correct. **There is no free
+> ORG tier.** Org entry is **Starter ($10/mo)**. An org with no active
+> subscription falls to the non-marketed `inactive` floor (priceCents 0,
+> maxVerifiedActions/maxEmails/maxSms 0, maxSeats 1, maxTemplatesMonth 2) — it
+> can author a campaign or two to experience the product, but every delivery +
+> scale quota is zeroed until it subscribes. `inactive` is **not sellable** and
+> not in `PLAN_ORDER`; cancellation drops an org back to it. The motion is
+> author free, pay to deliver. Recorded 2026-06-02 / 2026-06-14; merged through
+> PR #34. Canonical source of truth: `src/lib/server/billing/plans.ts`.
+
+---
+
 ## Core Principle: Individuals Are Free
 
 Individual civic action on Commons is free. There is no individual subscription, no credit packs, no paywall on sending verified letters to decision-makers. This is not generosity — it is the structurally correct economic decision.
@@ -103,14 +116,16 @@ All subscription revenue flows from organizations. Pricing tiers meter verified 
 
 | Tier | Price | Verified Actions | Emails | SMS | Seats | Templates/mo |
 |---|---|---|---|---|---|---|
-| Free | $0/mo | 100 | 1,000 | 0 | 2 | 10 |
+| *inactive* (floor, non-marketed) | $0/mo | 0 | 0 | 0 | 1 | 2 |
 | Starter | $10/mo | 1,000 | 20,000 | 1,000 | 5 | 100 |
 | Organization | $75/mo | 5,000 | 100,000 | 10,000 | 10 | 500 |
 | Coalition | $200/mo | 10,000 | 250,000 | 50,000 | 25 | 1,000 |
 
+`inactive` is the gated fallback for an org with no active subscription, not a sellable tier: author up to 2 templates to experience the product; all delivery (email/SMS, verified-action submission) and scale (seats, volume) are zeroed. Entry is Starter ($10/mo). Cancellation drops an org to `inactive`.
+
 Overage pricing: $1.50-$3.00/1K verified actions (vs $0.01 COGS = 70%+ margin).
 
-Canonical definitions: `src/lib/server/billing/plans.ts` (SvelteKit) and `convex/subscriptions.ts` (Convex mirror). These MUST stay in sync.
+Canonical definitions: `src/lib/server/billing/plans.ts` (SvelteKit, source of truth — `PLANS` keyed by `inactive`/`starter`/`organization`/`coalition`; `PLAN_ORDER` excludes `inactive`) and `convex/subscriptions.ts` (Convex mirror). These MUST stay in sync with `plans.ts`.
 
 ### What Orgs Pay For
 

--- a/docs/strategy/product-roadmap.md
+++ b/docs/strategy/product-roadmap.md
@@ -7,6 +7,23 @@
 
 ---
 
+> **Positioning + pricing recenter (2026-06-14).** The core is the AI-native
+> **authoring-to-delivery** spine; **verification is ambient** (a watermark, not
+> the product). Where this doc says "the verification loop is the product," read
+> it as: the verification loop is the ambient guarantee under an
+> authoring-to-delivery product whose front door is **Studio**. **Pricing:** no
+> free org tier. Entry is **Starter ($10/mo)**. Unsubscribed orgs fall to a
+> non-marketed `inactive` floor — they can author a campaign or two free, but
+> ALL delivery (email/SMS, verified-action submission) and scale (seats, volume)
+> are gated to zero until they subscribe. The motion is **author free, pay to
+> deliver** (gate-at-delivery), not "free tier wins by default." The GTM tables
+> below still describe a "$0 free tier" in places — those lines are superseded
+> by this banner; the wedge (neutrality, full uncapped API, 24 boundary types,
+> verification packets) holds, only the price entry changes. Recorded 2026-06-02
+> / 2026-06-14; merged through PR #34.
+
+---
+
 ## Roles
 
 **Person** — sends verified letters to decision-makers, participates in debates. Optionally verifies identity via mDL for ZK proofs. Builds portable reputation through engagement tiers: New (0), Active (1), Established (2), Veteran (3), Pillar (4).
@@ -94,11 +111,15 @@ This is not a spec. The core org loop works: create org → import supporters �
 
 ### Phase 0: Ship the Verification Loop (COMPLETE — 2026-03-11)
 
-The verification loop is the product. Not email. Not CRM. Not petitions. The loop:
+The product is the authoring-to-delivery spine: an org states its objective,
+Commons grounds it and composes individualized messages, and delivers them. The
+verification loop is the **ambient guarantee** riding under that spine — not the
+product itself, but what makes the delivered speech provable. The loop:
 
 ```
-Org creates campaign → supporters take verified action → verification packet assembles →
-org sends report to decision-maker → decision-maker sees proof, not volume
+Org authors campaign in Studio → constituents take individually-composed action →
+verification rides under each as a watermark → Constituent Report assembles →
+org delivers report to decision-maker → decision-maker sees constituents + authorship, proof underneath
 ```
 
 This loop already works in code. Phase 0 makes it launchable.
@@ -143,9 +164,9 @@ Phase 0 proved the loop works. Phase 1 makes it self-serve and starts building t
 | Supporter segmentation UI | Filter builder: tag + verification status + tier + district + source. The underlying query infrastructure exists — needs a UI surface. | 1 week |
 | Campaign analytics dashboard | Opens, clicks, bounces + verified action count + tier distribution over time + geographic spread + coordination integrity scores. This is the dashboard no competitor can build. | 2 weeks |
 
-**Position as:**
-- Free tier: 500 supporters, 100 verified actions/month, 1,000 emails, full API, full analytics
-- Starter ($10/mo): 1,000 verified actions, 20,000 emails, A/B testing
+**Position as (author free, pay to deliver — no free org tier):**
+- Free *experience* (`inactive` floor, non-marketed): create an org + author a campaign or two, see grounded messages + targets, preview the Constituent Report. ALL delivery + scale gated to zero until subscribed.
+- Starter ($10/mo): 1,000 verified actions, 20,000 emails, full API, full analytics, A/B testing — the entry tier.
 - Organization ($75/mo): 5,000 verified actions, 100,000 emails, custom domain, SQL mirror
 - Coalition ($200/mo): 10,000 verified actions, 250,000 emails, white-label, child orgs
 
@@ -280,11 +301,11 @@ The transcendent reframing: **civic action as cryptographic primitive, with agen
 
 **Against VoterVoice/FiscalNote (publicly traded, enterprise):** Don't compete on mobilization speed. Compete on credibility. SmartCheck uses ChatGPT to make messages sound authentic. Commons makes messages be authentic — the sender is cryptographically verified. VoterVoice only matches officials in areas >250K population; Commons resolves 24 boundary types down to water districts and school boards.
 
-**Against Action Network (12K+ orgs, progressive-only):** Compete directly. Same market (grassroots advocacy orgs), lower price ($0 vs $15/mo minimum), stronger product (verification), wider market (political neutrality), wider scope (24 district types vs ~3). Migration pipeline built and spec'd. AN's API is capped at 4 req/s on paid tiers. Commons API is free and uncapped.
+**Against Action Network (12K+ orgs, progressive-only):** Compete directly. Same market (grassroots advocacy orgs), lower price (Starter $10/mo vs AN's $15/mo minimum — and an org can author for free before paying to deliver), stronger product (verification), wider market (political neutrality), wider scope (24 district types vs ~3). Migration pipeline built and spec'd. AN's API is capped at 4 req/s on paid tiers. Commons API is uncapped and included from the Starter tier.
 
-**Against the conservative void:** Fill a vacuum. Bonterra deplatformed conservative nonprofits. AN rejects them at the front door. Quorum prices them out. The conservative advocacy market has no affordable, integrated advocacy platform. Free tier wins this entire market by default.
+**Against the conservative void:** Fill a vacuum. Bonterra deplatformed conservative nonprofits. AN rejects them at the front door. Quorum prices them out. The conservative advocacy market has no affordable, integrated advocacy platform. Author-free onboarding plus a $10 Starter entry wins this entire market — they can build a campaign before spending a dollar, then pay only to deliver.
 
-**Against the local government void:** Create a market. 90,887 local government entities, 500,396 elected officials, zero affordable advocacy tools. School parent coalitions, water district accountability groups, transit equity orgs, fire safety advocates — they use Mailchimp and Google Forms today. Commons with 24 boundary types is the only platform that can target these officials at any price, and we offer it free.
+**Against the local government void:** Create a market. 90,887 local government entities, 500,396 elected officials, zero affordable advocacy tools. School parent coalitions, water district accountability groups, transit equity orgs, fire safety advocates — they use Mailchimp and Google Forms today. Commons with 24 boundary types is the only platform that can target these officials at any price, and an org can author its first campaigns free before paying $10/mo to deliver.
 
 **Against the international void:** Extend the protocol. voter-protocol's 24-slot district model and country-code-keyed registries are designed for global expansion. No competitor operates at protocol level across borders. A UK environmental org, a Canadian healthcare coalition, an Australian transit advocacy group — same verification infrastructure, same proof guarantees.
 
@@ -302,9 +323,9 @@ The platform serves whoever has constituents and cares enough to prove it. Not "
 
 | Segment | Why First | Acquisition |
 |---|---|---|
-| **Domain-obsessed local groups** | School parent coalitions, water district accountability, transit equity, fire safety. 90,887 local government entities, 500,396 elected officials, **zero** affordable advocacy tools. These orgs use Google Forms and Mailchimp because nothing else exists. Commons with 24 boundary types is the only platform that can target their officials — at any price. Free tier wins by default. | Partner with local government transparency orgs (Sunshine Foundation, OpenGov orgs, League of Women Voters chapters). Content: "Finally, a tool for school board advocacy." |
+| **Domain-obsessed local groups** | School parent coalitions, water district accountability, transit equity, fire safety. 90,887 local government entities, 500,396 elected officials, **zero** affordable advocacy tools. These orgs use Google Forms and Mailchimp because nothing else exists. Commons with 24 boundary types is the only platform that can target their officials — at any price. Author-free onboarding + $10 Starter delivery wins by default. | Partner with local government transparency orgs (Sunshine Foundation, OpenGov orgs, League of Women Voters chapters). Content: "Finally, a tool for school board advocacy." |
 | **Science/health advocacy** | Credibility IS the product. "847 verified constituents in your district support NIH funding" changes how a committee staffer reads testimony. Disease foundations, research coalitions, scientific societies — they've been sending unverified form emails and watching them get deleted. | Direct outreach to 10–20 foundations/coalitions. Show them the verification packet. One demo closes. |
-| **Conservative/nonpartisan groups** | Deplatformed by Bonterra, rejected by AN's front door, priced out of Quorum. No affordable tooling exists. Free tier is immediately the best they've ever had. Second Amendment orgs, faith-based advocacy, fiscal policy groups, pro-life organizations — all underserved. | Content marketing: "The advocacy platform that doesn't check your politics." Outreach to Startup Caucus network, conservative think tanks, faith-based coalitions. |
+| **Conservative/nonpartisan groups** | Deplatformed by Bonterra, rejected by AN's front door, priced out of Quorum. No affordable tooling exists. A $10 Starter entry (with author-free onboarding) is immediately the best they've ever had. Second Amendment orgs, faith-based advocacy, fiscal policy groups, pro-life organizations — all underserved. | Content marketing: "The advocacy platform that doesn't check your politics." Outreach to Startup Caucus network, conservative think tanks, faith-based coalitions. |
 | **Single-issue orgs across spectrum** | Environmental justice. Immigration reform. Criminal justice reform. Homeschool advocacy. Agricultural policy. Veterans affairs. These orgs are domain-obsessed — they don't care about platform politics, they care about whether their campaign reaches the right official with proof that their supporters are real. | SEO: "[issue] advocacy tools." Product-led growth from template discovery. |
 
 ### Expansion (Phase 2, months 4–8)
@@ -313,7 +334,7 @@ The platform serves whoever has constituents and cares enough to prove it. Not "
 |---|---|---|
 | **Progressive orgs wanting proof** | Run Commons alongside AN. Compare staffer response rates. Verification packet vs. unverified email count. Migration when the data proves the point. AN's export lock-in (one action at a time, automation ladders non-portable) makes this sticky — Commons' OSDI import and parallel operation mode de-risk the switch. | Import tools + comparison landing page. Side-by-side: AN report vs. Commons verification packet. |
 | **Trade associations fleeing Quorum pricing** | Currently paying $10K–$30K+/year for legislative tracking + grassroots advocacy. Commons Organization tier at $75/mo ($900/yr) is 10-30x cheaper with verification packets Quorum can't produce. Quorum Quincy AI analyzes bills; Commons agents monitor bills AND verify the constituents who care about them. | Case studies from beachhead orgs showing staffer response rate improvement. Direct outreach to association management companies. |
-| **Small orgs (<5K contacts)** | Free tier vs. AN's $15/mo minimum. Full API, uncapped. No paywall on analytics. Every small org with a cause — tenant advocacy, animal rights, disability rights, education reform — can run verified campaigns for free. | Product-led growth. Self-serve signup. Template discovery drives adoption. |
+| **Small orgs (<5K contacts)** | Starter $10/mo vs. AN's $15/mo minimum — and they author free before paying to deliver. Full API, uncapped, from Starter. No paywall on analytics. Every small org with a cause — tenant advocacy, animal rights, disability rights, education reform — can build a verified campaign before spending a dollar. | Product-led growth. Self-serve signup. Template discovery drives adoption. |
 | **International early adopters** | UK, Canada, Australia — boundary data available, English-speaking, parliamentary systems with similar constituency models. A UK environmental org targeting MPs, a Canadian healthcare coalition targeting provincial legislators. Same verification infrastructure, first-mover advantage in markets with zero verified advocacy tools. | Partner with civic tech organizations in target countries. Boundary data ingestion as the trigger for market entry. |
 
 ### Scale (Phase 3, months 8–14)

--- a/docs/strategy/vision.md
+++ b/docs/strategy/vision.md
@@ -1,12 +1,33 @@
 # Vision
 
-> Civic infrastructure where every action carries proof.
+> Civic infrastructure that authors, grounds, and delivers — every action carrying proof underneath.
+
+---
+
+> **Positioning + pricing recenter (2026-06-14).** The center of Commons is the
+> AI-native **authoring-to-delivery** spine: an org describes its objective and
+> Commons grounds it against decision-makers, composes individualized messages,
+> and delivers them. **Verification is ambient** — a watermark riding under
+> every artifact, not the North Star headline. The org front door is **Studio**
+> (authoring), not the proof packet. The delivered artifact is the **Constituent
+> Report**, leading with constituents, individually-composed authorship, and
+> response. There is **no free org tier**: entry is Starter ($10/mo); orgs with
+> no active subscription fall to the non-marketed `inactive` floor (author a
+> campaign or two free; all delivery + scale gated to zero). Recorded
+> 2026-06-02 / 2026-06-14; merged through PR #34. Sections below predate this
+> recenter where they still lead with verification — read them through this lens.
 
 ---
 
 ## What Commons Is
 
-Commons is civic communication infrastructure. Not a mail merge tool with a database — infrastructure that makes civic speech *verifiable*.
+Commons is AI-native civic communication infrastructure. An org states what it
+wants to change; Commons grounds that objective against the right
+decision-makers, composes individually-authored messages with each constituent,
+and delivers them — then hands back a Constituent Report. Not a mail merge tool
+with a database. The authoring-to-delivery spine is the core; verification is
+the ambient property woven underneath that makes the resulting civic speech
+*provable*.
 
 A person sends a letter through Commons. That letter carries cryptographic proof that the sender holds a government-issued credential, lives in the decision-maker's district (verified against a hierarchical Merkle tree of every public district boundary — congressional, state legislative, county, municipal, school, judicial, fire, water, transit, and more), and has an engagement history that cannot be purchased or fabricated. The decision-maker's office doesn't trust Commons. They verify the math.
 

--- a/src/lib/components/org/os/ReturnSpace.svelte
+++ b/src/lib/components/org/os/ReturnSpace.svelte
@@ -1,11 +1,14 @@
 <!--
-  ReturnSpace — Results: the org's evidence page.
+  ReturnSpace — Results: the org's evidence page, mounted at `/results`.
 
-  Answers the questions an organization actually brings here: did it deliver,
-  did anyone respond, what do we show the board. Four headline numbers
-  (verified constituents, districts reached, proof reports delivered,
-  responses logged), the Verification Packet as the proof artifact, and three
-  lists: action records, where actions landed, and response activity.
+  The org front door is Studio (authoring-to-delivery); this is where a
+  campaign lands after it ships. It answers the questions an organization
+  actually brings here: did it deliver, who composed, did anyone respond, what
+  do we show the board. The evidence band leads with constituents and
+  individually-composed authorship beside reach, delivery, and responses. The
+  delivered artifact is the "Constituent Report" — verification rides under it
+  as a quiet watermark, never the lead. Below it sit three lists: action
+  records, where actions landed, and response activity.
 
   This is a MOUNTED space: the org-OS shell holds all four spaces at once and
   toggles visibility. Its data is loaded ONCE by the layout server load

--- a/tests/unit/convex/report-email-fallback.test.ts
+++ b/tests/unit/convex/report-email-fallback.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Guards the live report-email fallback in `convex/campaigns.ts`.
+ *
+ * `buildReportEmailHtml` is the inline template the dispatcher (`dispatchReportEmails`)
+ * falls back to when a delivery has no pre-rendered `packetHtml`. It is a real
+ * sent-email path, so its eyebrow must match the standard template, which was
+ * renamed from "Verification Report" to "Constituent Report" (verification is an
+ * ambient watermark, not the lead). This fallback drifted because it had no test;
+ * these assertions pin it to the recentered wording so it can't silently regress.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildReportEmailHtml } from '../../../convex/campaigns';
+
+const baseCampaign = {
+	title: 'Floor vote on HR-1',
+	orgName: 'Sample Coalition',
+	verifiedActionCount: 1234,
+	tier3VerifiedActionCount: 300,
+	_id: 'k1234567890'
+};
+
+describe('buildReportEmailHtml (live email fallback)', () => {
+	it('emits the "Constituent Report" eyebrow', () => {
+		const html = buildReportEmailHtml(baseCampaign);
+		expect(html).toContain('Constituent Report');
+	});
+
+	it('does NOT emit the stale "Verification Report" eyebrow', () => {
+		const html = buildReportEmailHtml(baseCampaign);
+		expect(html).not.toContain('Verification Report');
+	});
+
+	it('still renders the action count and verify link (attestation path untouched)', () => {
+		const html = buildReportEmailHtml(baseCampaign);
+		expect(html).toContain('1,234');
+		expect(html).toContain('constituent actions');
+		expect(html).toContain('/v/k1234567890');
+	});
+});


### PR DESCRIPTION
Closes the git-tracked drift a consistency audit found between the merged code (correctly recentered) and the docs/comments (lagging the verification→authoring + free-tier→gate-at-delivery pivots).

## Code bug (`97ad16a6`) — the one that mattered
`convex/campaigns.ts:2635` `buildReportEmailHtml` (the LIVE email fallback, used when a delivery has no pre-rendered `packetHtml`) still emitted the eyebrow "Verification Report" — the one report surface PR #32's rename missed, so a real sent email could carry the stale header. Two-line diff: the eyebrow string → "Constituent Report" + an `export` for testability. **Attestation/hash logic untouched** (verify link + footer unchanged). New `tests/unit/convex/report-email-fallback.test.ts` (3 tests) guards it — the missing test is why it drifted.

## Inline comment + docs (`bcdbf47c`)
- `ReturnSpace.svelte` header comment → matches the recentered body (mounted at /results, Studio is the front door, leads with constituents + individually-composed authorship, verification a watermark).
- `docs/` strategy/design/architecture corpus: dated "recenter 2026-06-14" banners + targeted corrections — the "Free $0" org row → the `inactive` gate-at-delivery floor (entry Starter $10; Person-Layer "free forever" kept); "the verification loop is the product" demoted to ambient; GTM/competitive free-tier lines → author-free/$10-entry. Plan limits verified against `plans.ts`.

## Scope
No public `src/routes/**` page touched (the `org/for/*` Free-tier cards are owned by the parallel landing build).

## Evidence
convex tsc 0 · `npm run check` 0 · report suites 24/24.

## Flagged (deliberately not done)
`vision.md`/`product-roadmap.md` bodies still *structurally* lead with verification ("What Makes It Different," phase framing). I landed banners + targeted corrections, not a full re-sequence — a deeper editorial pass worth doing deliberately, not mid-consistency-fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated report email template name from "Verification Report" to "Constituent Report"

* **Documentation**
  * Refreshed pricing model: removed free organization tier; organizations now entry at $10/mo Starter tier or inactive status with limited capabilities

* **Tests**
  * Added test coverage for report email template naming verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->