### PR TITLE
Re-sequence the strategy corpus around the authoring-to-delivery spine

### DIFF
--- a/docs/strategy/index.md
+++ b/docs/strategy/index.md
@@ -4,15 +4,23 @@
 
 ---
 
-> **Positioning + pricing recenter (2026-06-14).** Commons' core is the
-> AI-native **authoring-to-delivery** spine; **verification is ambient** (a
-> watermark, not the headline). The org front door is **Studio**; the delivered
-> artifact is the **Constituent Report**. **No free org tier** — entry is
-> Starter ($10/mo); unsubscribed orgs fall to a non-marketed `inactive` floor
-> (author a campaign or two free, all delivery + scale at zero). Author free,
-> pay to deliver. Recorded 2026-06-02 / 2026-06-14; merged through PR #34. Where
-> the docs below still lead with "the verification loop is the product," read
-> them through this recenter.
+> **Recenter 2026-06-14.** The core of Commons is the AI-native
+> **authoring-to-delivery** loop — intent → ground → author → resolve-targets →
+> deliver → aggregate. That loop is the only differentiated, shipped-and-live
+> capability, and it is what these documents now lead with. The org front door
+> is **Studio** (authoring); the delivered artifact is the **Constituent
+> Report**. **No free org tier** — entry is Starter ($10/mo); unsubscribed orgs
+> fall to a non-marketed `inactive` floor (author a campaign or two free, all
+> delivery + scale at zero). Author free, pay to deliver.
+>
+> **Verification is ambient:** a credibility watermark that rides along, the
+> lowest-replicability moat, but NOT the headline and NOT a proven advantage
+> (the thesis that an office weights a verified packet differently is
+> technically unproven — no measured signal yet). Where the documents below
+> still read verification-first in their bodies ("the Verification Loop,"
+> "compete on verification," "every action carries proof"), read past that as
+> legacy framing pending re-sequence; this index reflects the current center.
+> Recorded 2026-06-02 / 2026-06-14; merged through PR #34.
 
 ---
 
@@ -20,16 +28,18 @@
 
 ### [product-roadmap.md](product-roadmap.md) — What We're Building Now
 
-The authoritative plan. Phase 0-3 feature sequence, key flows, competitive positioning against the entire landscape. Updated March 2026.
+The authoritative plan. Phase 0-3 feature sequence, key flows, competitive positioning against the entire landscape. Updated March 2026. Core capability: the AI-native authoring-to-delivery loop (intent → ground → author → resolve-targets → deliver → aggregate); verification rides along as an ambient credibility watermark.
 
 - **Phase 0**: Ship the Verification Loop — COMPLETE (2026-03-11)
 - **Phase 1**: Compete on Verification, Not Features — COMPLETE (2026-03-11)
 - **Phase 2**: Transcend the Landscape — COMPLETE (2026-03-13)
 - **Phase 3**: Transcend the Paradigm (next) — debates, agentic delegation, international, cross-border coalitions
 
+> Note: the Phase 0-1 names above are the dated historical record (March 2026) and are preserved verbatim. They predate the 2026-06-14 recenter; "the Verification Loop" / "compete on verification" describe how the work was sequenced then, not the current center, which is the authoring-to-delivery loop with verification ambient.
+
 ### [economics.md](economics.md) — Unit Economics
 
-Pricing tiers, revenue projections, cost structure. Verified actions as primary metered unit.
+Pricing tiers, revenue projections, cost structure. NO free org tier: entry is Starter ($10/mo); orgs with no active subscription sit on a non-marketed `inactive` floor (author up to 2 campaigns free, all delivery and scale gated to zero — author free, pay to deliver). Metered on verified actions and send volume.
 
 ### [monetization-policy.md](monetization-policy.md) — Monetization Policy
 
@@ -37,13 +47,20 @@ Why individuals are free, why orgs pay, LLM rate limit rationale, research-backe
 
 ### [competitive-analysis.md](../research/competitive-analysis.md) — Market Landscape
 
-$191M grassroots segment. Commons occupies the only quadrant no competitor can reach: high verification at low cost.
+$191M grassroots segment. The wedge is three-part: (1) AI-native per-recipient authoring + grounding, (2) owned local-government reach (Shadow Atlas, 24 boundary types), and (3) political neutrality plus a full uncapped API. Verification is a tiebreaker for distrust segments, not the headline. Timing: the 2026-2027 incumbent-distress window (FiscalNote going-concern, Bonterra ActionKit deprecated, NGP VAN → TMC migration).
 
 ---
 
 ## Two Product Layers
 
-Commons serves **two audiences** through shared verification infrastructure:
+Commons serves **two audiences** through a shared authoring-to-delivery spine (verification rides along as an ambient watermark):
+
+**Org Layer** — AI-native authoring-to-delivery for advocacy
+- Front door is Studio (authoring): intent → ground → author per-recipient → resolve targets → deliver → aggregate. Every incumbent ships AI for the org *user*; Commons ships it for the *action*.
+- Owned local-government reach (Shadow Atlas, 24 boundary types) + politically neutral + full uncapped API
+- Output is the Constituent Report — leads with constituents, individually-composed authorship, and response; verification packet signals (constituent counts, tier distribution, coordination integrity) ride along as an ambient credibility watermark
+- Replaces the entire landscape: AN ($15/mo for less), Quorum ($10K+/yr for less), VoterVoice (enterprise for less), the conservative void (nothing), the local government void (nothing), the citizen-tool graveyard (dead or dying)
+- Described in: `product-roadmap.md`, `economics.md`
 
 **Person Layer** — Individual verified civic action
 - Send verified letters to decision-makers at any level of government (federal through school board, water district, transit authority — 24 boundary types)
@@ -52,14 +69,7 @@ Commons serves **two audiences** through shared verification infrastructure:
 - Works internationally as boundary data expands (UK, Canada, Australia, EU)
 - Described in: `coordination.md`, `viral.md`
 
-**Org Layer** — Campaign management and advocacy infrastructure
-- Create campaigns, manage supporters, send mass email
-- Verification packets with constituent counts, tier distribution, coordination integrity signals
-- Replaces the entire landscape: AN ($15/mo for less), Quorum ($10K+/yr for less), VoterVoice (enterprise for less), the conservative void (nothing), the local government void (nothing), the citizen-tool graveyard (dead or dying)
-- Politically neutral: serves progressive, conservative, nonpartisan, and domain-obsessed orgs equally
-- Described in: `product-roadmap.md`, `economics.md`
-
-Both layers are shipped and deployed. The org layer is what competes with the entire advocacy landscape. The person layer is what makes competition structurally impossible — verification infrastructure that took years to build and cannot be bolted on after the fact.
+Both layers are shipped and deployed. The org layer competes with the entire advocacy landscape on the AI-native authoring-to-delivery loop — the only differentiated, shipped-and-live capability. The person layer carries the ambient verification infrastructure that took years to build and cannot be bolted on after the fact; it is the lowest-replicability moat and rides along as a credibility watermark, not the basis of competition.
 
 ---
 
@@ -67,7 +77,7 @@ Both layers are shipped and deployed. The org layer is what competes with the en
 
 ### [vision.md](vision.md) — North Star
 
-Civic communication infrastructure where every action carries proof. The design thesis that shapes everything.
+Civic communication infrastructure: AI-native authoring-to-delivery so any constituent's intent becomes a grounded, individually-composed, delivered action at any level of government. Every action *can* carry proof — verification is the ambient credibility watermark that rides along (lowest-replicability moat, thesis still unproven), not the North Star itself.
 
 ### [coordination.md](coordination.md) — Why Coordination Works
 
@@ -105,9 +115,10 @@ Original 3-month launch plan. Context for how the project started.
 
 ## Navigation
 
+- **What's the core capability?** → `product-roadmap.md` (AI-native authoring-to-delivery loop)
 - **Current plan?** → `product-roadmap.md`
-- **Market position?** → `../research/competitive-analysis.md`
-- **Pricing?** → `economics.md`
-- **Why individuals are free?** → `monetization-policy.md`
+- **Market position / the 3-part wedge?** → `../research/competitive-analysis.md`
+- **Pricing (no free org tier; gate-at-delivery)?** → `economics.md`
+- **Why individuals are free, why orgs pay?** → `monetization-policy.md`
 - **Why we exist?** → `vision.md`
 - **How coordination works?** → `coordination.md`

--- a/docs/strategy/product-roadmap.md
+++ b/docs/strategy/product-roadmap.md
@@ -7,20 +7,27 @@
 
 ---
 
-> **Positioning + pricing recenter (2026-06-14).** The core is the AI-native
-> **authoring-to-delivery** spine; **verification is ambient** (a watermark, not
-> the product). Where this doc says "the verification loop is the product," read
-> it as: the verification loop is the ambient guarantee under an
-> authoring-to-delivery product whose front door is **Studio**. **Pricing:** no
-> free org tier. Entry is **Starter ($10/mo)**. Unsubscribed orgs fall to a
-> non-marketed `inactive` floor — they can author a campaign or two free, but
-> ALL delivery (email/SMS, verified-action submission) and scale (seats, volume)
-> are gated to zero until they subscribe. The motion is **author free, pay to
-> deliver** (gate-at-delivery), not "free tier wins by default." The GTM tables
-> below still describe a "$0 free tier" in places — those lines are superseded
-> by this banner; the wedge (neutrality, full uncapped API, 24 boundary types,
-> verification packets) holds, only the price entry changes. Recorded 2026-06-02
-> / 2026-06-14; merged through PR #34.
+> **Recenter (2026-06-14).** This roadmap's body was written verification-first.
+> The core is now the AI-native **authoring-to-delivery** loop (intent → ground →
+> author → resolve-targets → deliver → aggregate) — the only differentiated,
+> shipped, config-gated-live capability. Its front door is **Studio**.
+> **Verification is ambient:** a credibility watermark and the lowest-replicability
+> moat, NOT the headline. The thesis that "an office weights a verified packet
+> differently" is **unproven** — no measured signal exists; it is written below
+> as a hypothesis, never as a demonstrated advantage. Where this doc says "the
+> verification loop is the product," read it as: the verification loop is the
+> ambient guarantee under an authoring-to-delivery product.
+>
+> **Pricing:** no free org tier. Entry is **Starter ($10/mo)**, gate-at-delivery
+> (author 2 campaigns free on the non-marketed `inactive` floor, pay to deliver).
+> Unsubscribed orgs fall to that `inactive` floor — they can author a campaign or
+> two free, but ALL delivery (email/SMS, verified-action submission) and scale
+> (seats, volume) are gated to zero until they subscribe. The motion is **author
+> free, pay to deliver**, not "free tier wins by default." The GTM tables below
+> still describe a "$0 free tier" in places — those lines are superseded by this
+> banner and the re-sequenced sections; the wedge (neutrality, full uncapped API,
+> 24 boundary types, verification packets) holds, only the price entry changes.
+> Recorded 2026-06-02 / 2026-06-14; merged through PR #34.
 
 ---
 
@@ -28,7 +35,7 @@
 
 **Person** — sends verified letters to decision-makers, participates in debates. Optionally verifies identity via mDL for ZK proofs. Builds portable reputation through engagement tiers: New (0), Active (1), Established (2), Veteran (3), Pillar (4).
 
-**Organization** — creates campaigns, sends mass email, manages supporters, views analytics with verification and coordination integrity signals.
+**Organization** — authors per-recipient campaigns in Studio (intent → grounded draft → resolved targets), delivers to decision-makers, and reads a Constituent Report (constituents + individually-composed authorship + response). Verification and coordination-integrity signals ride along as ambient credibility context.
 
 **Decision-Maker** — receives messages with verification packets. Sees constituent count, engagement tier distribution, coordination integrity scores, debate market signals.
 
@@ -36,7 +43,9 @@
 
 ## Design Thesis
 
-Every feature is verification-intrinsic. Not "commodity features plus ZK extras" but features where verification is woven into the surface. The product should be indistinguishable from existing advocacy tools for someone who has never heard of zero-knowledge proofs — while delivering guarantees that existing tools architecturally cannot.
+The core is the AI-native authoring-to-delivery loop: intent → ground → author (per-recipient) → resolve-targets (owned local-gov reach across 24 boundary types) → deliver → aggregate. Every incumbent ships AI for the org user; Commons ships it for the action — grounded, per-recipient authorship that resolves to the right office at any level of government. That loop is the only differentiated, shipped-and-live capability, and it is the product.
+
+Verification rides along as an ambient credibility watermark — woven into the surface so the product is indistinguishable from existing advocacy tools for someone who has never heard of zero-knowledge proofs. It is the lowest-replicability moat (the substrate can't be retrofitted to app-layer competitors), but the claim that an office *weights* a verified packet differently is an untested hypothesis, not a measured result. Keep it; do not lead with it.
 
 We are pragmatically cypherpunk: privacy and verification are structural, not features. The platform cannot be subpoenaed for data it doesn't possess. Actions carry proofs, not promises. Reputation is earned on-chain, not assigned by an admin. These are engineering decisions, not marketing positions.
 
@@ -111,18 +120,14 @@ This is not a spec. The core org loop works: create org → import supporters �
 
 ### Phase 0: Ship the Verification Loop (COMPLETE — 2026-03-11)
 
-The product is the authoring-to-delivery spine: an org states its objective,
-Commons grounds it and composes individualized messages, and delivers them. The
-verification loop is the **ambient guarantee** riding under that spine — not the
-product itself, but what makes the delivered speech provable. The loop:
+The authoring-to-delivery loop is the product. Not email. Not CRM. Not petitions. The loop:
 
 ```
-Org authors campaign in Studio → constituents take individually-composed action →
-verification rides under each as a watermark → Constituent Report assembles →
-org delivers report to decision-maker → decision-maker sees constituents + authorship, proof underneath
+Org states intent → AI grounds + authors a per-recipient draft → targets resolve across 24 boundary types →
+supporters take action → org delivers to decision-maker → Constituent Report aggregates (verification packet rides along)
 ```
 
-This loop already works in code. Phase 0 makes it launchable.
+This loop already works in code. Phase 0 makes it launchable. (Historically this phase was framed as "ship the verification loop"; the heading is preserved as a dated record, but the loop's center is authoring-to-delivery — verification is the ambient watermark that assembles onto the report, not the headline.)
 
 **Build:**
 
@@ -136,7 +141,7 @@ This loop already works in code. Phase 0 makes it launchable.
 **Don't build yet:**
 - A/B testing (ship single-variant email first)
 - ~~Embeddable widgets~~ (shipped — `/embed/campaign/[slug]`)
-- Advanced analytics (verification packet IS the analytics)
+- Advanced analytics (the Constituent Report — constituents + per-recipient authorship + response, with the verification packet riding along — IS the analytics)
 - SMS, automation, events, fundraising (all Phase 2+)
 
 **Launch to:**
@@ -145,11 +150,13 @@ This loop already works in code. Phase 0 makes it launchable.
 - Local government advocacy (school boards, water districts — 21 of 24 Shadow Atlas boundary types have zero competitor coverage)
 - Nonpartisan groups excluded from AN
 
-**Success metric:** One org sends a campaign report to a decision-maker's office. The office responds differently than they respond to unverified advocacy mail. That's the proof point.
+**Success metric:** One org authors and delivers a campaign in Studio and gets a Constituent Report back. (Hypothesis to test, not yet measured: an office responds differently to a verified packet than to unverified advocacy mail. Treat this as the verification proof point we are *trying* to establish — it is unproven; do not state it as fact.)
 
 ---
 
 ### Phase 1: Compete on Verification, Not Features (COMPLETE — 2026-03-11)
+
+> Note (2026-06-14 recenter): "Compete on Verification" was the original framing; the competitive spine is now the AI-native authoring-to-delivery loop plus owned local-gov reach and full uncapped API. Verification is a tiebreaker for distrust segments, not the headline.
 
 Phase 0 proved the loop works. Phase 1 makes it self-serve and starts building the org base.
 
@@ -164,17 +171,19 @@ Phase 0 proved the loop works. Phase 1 makes it self-serve and starts building t
 | Supporter segmentation UI | Filter builder: tag + verification status + tier + district + source. The underlying query infrastructure exists — needs a UI surface. | 1 week |
 | Campaign analytics dashboard | Opens, clicks, bounces + verified action count + tier distribution over time + geographic spread + coordination integrity scores. This is the dashboard no competitor can build. | 2 weeks |
 
-**Position as (author free, pay to deliver — no free org tier):**
-- Free *experience* (`inactive` floor, non-marketed): create an org + author a campaign or two, see grounded messages + targets, preview the Constituent Report. ALL delivery + scale gated to zero until subscribed.
-- Starter ($10/mo): 1,000 verified actions, 20,000 emails, full API, full analytics, A/B testing — the entry tier.
-- Organization ($75/mo): 5,000 verified actions, 100,000 emails, custom domain, SQL mirror
-- Coalition ($200/mo): 10,000 verified actions, 250,000 emails, white-label, child orgs
+**Position as (corrected 2026-06-14 against `src/lib/server/billing/plans.ts`):**
+- No free org tier. An org with no active subscription falls to a non-marketed `inactive` floor: author up to 2 campaigns free (see grounded draft + resolved targets + report preview), but ALL delivery (email/SMS, verified-action submission) and scale (seats, volume) are gated to zero. Gate-at-delivery: author free, pay to deliver. (Person Layer — individuals — is still free forever.)
+- Starter ($10/mo): 1,000 verified actions, 20,000 emails, 1,000 SMS, 5 seats, 100 campaigns/mo, full uncapped API
+- Organization ($75/mo): 5,000 verified actions, 100,000 emails, 10,000 SMS, 10 seats, 500 campaigns/mo
+- Coalition ($200/mo): 10,000 verified actions, 250,000 emails, 50,000 SMS, 25 seats, 1,000 campaigns/mo, child orgs
+
+(PLAN_ORDER = ['starter','organization','coalition']; `inactive` is the gated floor, not a marketed tier. The 'custom domain / SQL mirror / white-label' line items are dropped — those are unbuilt; do not advertise them here.)
 
 ---
 
 ### Phase 2: Transcend the Landscape (COMPLETE — 2026-03-13)
 
-Phase 1 proved orgs will use verified advocacy. Phase 2 makes Commons the platform every org wants — not by matching competitors feature-for-feature, but by making every feature carry verification context that no competitor can produce. The target is the entire landscape: AN, Quorum, VoterVoice, the conservative void, the local government void, the citizen-tool graveyard.
+Phase 1 built the self-serve org base. Phase 2 makes Commons the platform every org wants — not by matching competitors feature-for-feature, but by reinstantiating every advocacy modality (events, fundraising, automation, calling, SMS, coalitions) on top of the AI-native authoring-to-delivery loop and owned local-gov reach. Each modality also carries ambient verification context no competitor can produce. The target is the entire landscape: AN, Quorum, VoterVoice, the conservative void, the local government void, the citizen-tool graveyard.
 
 **Build:**
 
@@ -231,7 +240,7 @@ Capabilities that no competitor can imagine, let alone build. Only possible beca
 |---|---|
 | Web form navigation (à la EveryAction 99.6% deliverability) | Fragile — forms change constantly, get CAPTCHAd, break. Our verification packet sent directly via email is more impactful than navigating an intake form. The packet IS the delivery. |
 | Legislative tracking breadth (à la Quorum) | We'll never match Quorum's 50-state legislative corpus. We don't need to. Agentic monitoring personalized to verified districts is a better product for our users than a search engine across all bills. Quorum charges $10K+/yr for that search engine. We give personalized monitoring at ~$6.50/org/month. |
-| Full CRM (à la Bonterra) | CRM is not our product. Verification is. An org can use EveryAction for donor management and Commons for advocacy. We stay focused on what no one else can build. |
+| Full CRM (à la Bonterra) | CRM is not our product. AI-native authoring-to-delivery is. An org can use EveryAction for donor management and Commons for advocacy. We stay focused on what no one else can build. |
 | Social media advocacy | Low ROI relative to engineering cost. Verification doesn't carry to social platforms. |
 | Video messages to officials | Niche (only CiviClick offers this). Low adoption. |
 | Fax to officials | Legacy channel. Declining relevance. |
@@ -243,17 +252,17 @@ Capabilities that no competitor can imagine, let alone build. Only possible beca
 
 ## Key Flows
 
-### Verified Letter (90 seconds, person-facing)
-
-Click campaign link → enter name, email, postal code → Postal Bubble renders district(s) → optional mDL scan (4-6s, browser-side ZK) → send → letter + proof delivered to decision-maker → "You're verified constituent #248 in CA-12." The verification is the action — not a separate step bolted onto a form submission. Works for any public office across all 24 boundary types.
-
-### Decision-Maker Receives Campaign Report (org-facing → decision-maker)
-
-Open email from org → normal campaign letter → footer: "248 verified constituents in your district. Tier distribution: 12 Pillars, 43 Veterans, 89 Established, 104 Active. GDS: 0.91. ALD: 0.87." → click verification link → proof dashboard with per-sender verification status (identity verified, not identity revealed). Every number is backed by a proof the decision-maker can check. No other platform can produce this report.
-
 ### Organization Onboarding (org-facing)
 
 Sign up → create org → import supporter CSV or connect AN API → create first campaign → set targets (auto-resolved from Postal Bubble geography across any district type) → publish → share campaign URL (embed widget in Phase 1) → supporters take action → dashboard shows verified counts, tier distribution, coordination signals from the first action.
+
+### Decision-Maker Receives Constituent Report (org-facing → decision-maker)
+
+Open email from org → normal campaign letter → footer: "248 verified constituents in your district. Tier distribution: 12 Pillars, 43 Veterans, 89 Established, 104 Active. GDS: 0.91. ALD: 0.87." → click verification link → proof dashboard with per-sender verification status (identity verified, not identity revealed). Every number is backed by a proof the decision-maker can check. No other platform can produce this report.
+
+### Verified Letter (90 seconds, person-facing)
+
+Click campaign link → enter name, email, postal code → Postal Bubble renders district(s) → optional mDL scan (4-6s, browser-side ZK) → send → letter + proof delivered to decision-maker → "You're verified constituent #248 in CA-12." The verification is the action — not a separate step bolted onto a form submission. Works for any public office across all 24 boundary types.
 
 ### Debate Market Spawns from Campaign (person-facing → org-facing)
 
@@ -301,15 +310,15 @@ The transcendent reframing: **civic action as cryptographic primitive, with agen
 
 **Against VoterVoice/FiscalNote (publicly traded, enterprise):** Don't compete on mobilization speed. Compete on credibility. SmartCheck uses ChatGPT to make messages sound authentic. Commons makes messages be authentic — the sender is cryptographically verified. VoterVoice only matches officials in areas >250K population; Commons resolves 24 boundary types down to water districts and school boards.
 
-**Against Action Network (12K+ orgs, progressive-only):** Compete directly. Same market (grassroots advocacy orgs), lower price (Starter $10/mo vs AN's $15/mo minimum — and an org can author for free before paying to deliver), stronger product (verification), wider market (political neutrality), wider scope (24 district types vs ~3). Migration pipeline built and spec'd. AN's API is capped at 4 req/s on paid tiers. Commons API is uncapped and included from the Starter tier.
+**Against Action Network (12K+ orgs, progressive-only):** Compete directly. Same market (grassroots advocacy orgs), comparable entry price (Starter $10/mo vs AN's $15/mo minimum; orgs author free and pay to deliver), stronger product (AI-native per-recipient authoring + owned local-gov reach — verification is the ambient watermark on top), wider market (political neutrality), wider scope (24 district types vs ~3). Migration pipeline built and spec'd. AN's API is capped at 4 req/s on paid tiers; Commons' API is full and uncapped.
 
-**Against the conservative void:** Fill a vacuum. Bonterra deplatformed conservative nonprofits. AN rejects them at the front door. Quorum prices them out. The conservative advocacy market has no affordable, integrated advocacy platform. Author-free onboarding plus a $10 Starter entry wins this entire market — they can build a campaign before spending a dollar, then pay only to deliver.
+**Against the conservative void:** Fill a vacuum. Bonterra deplatformed conservative nonprofits. AN rejects them at the front door. Quorum prices them out. The conservative advocacy market has no affordable, integrated advocacy platform. Commons wins this market on price + neutrality: Starter at $10/mo (10-30x under Quorum) with a full uncapped API and no ideology check at the door — author free, pay to deliver, no free-tier dependency.
 
-**Against the local government void:** Create a market. 90,887 local government entities, 500,396 elected officials, zero affordable advocacy tools. School parent coalitions, water district accountability groups, transit equity orgs, fire safety advocates — they use Mailchimp and Google Forms today. Commons with 24 boundary types is the only platform that can target these officials at any price, and an org can author its first campaigns free before paying $10/mo to deliver.
+**Against the local government void:** Create a market. 90,887 local government entities, 500,396 elected officials, zero affordable advocacy tools. School parent coalitions, water district accountability groups, transit equity orgs, fire safety advocates — they use Mailchimp and Google Forms today. Commons with 24 boundary types is the only platform that can target these officials at any price. Orgs author free (2 campaigns on the `inactive` floor) and pay only to deliver — Starter at $10/mo undercuts every incumbent.
 
 **Against the international void:** Extend the protocol. voter-protocol's 24-slot district model and country-code-keyed registries are designed for global expansion. No competitor operates at protocol level across borders. A UK environmental org, a Canadian healthcare coalition, an Australian transit advocacy group — same verification infrastructure, same proof guarantees.
 
-**Against the citizen-tool graveyard (Resistbot, Democracy.io, Countable):** Citizen-facing tools are dying or dead. Resistbot serves individuals via text, unverified, no org features. Democracy.io is unmaintained. Countable pivoted to HR. POPVOX serves institutions, not grassroots. Commons serves both layers — individuals and organizations — on shared verification infrastructure. The person layer is the structural differentiator. The org layer is the business.
+**Against the citizen-tool graveyard (Resistbot, Democracy.io, Countable):** Citizen-facing tools are dying or dead. Resistbot serves individuals via text, unverified, no org features. Democracy.io is unmaintained. Countable pivoted to HR. POPVOX serves institutions, not grassroots. Commons serves both layers — individuals (free forever) and organizations (paid, gate-at-delivery) — on shared infrastructure. The AI-native authoring-to-delivery loop plus owned local-gov reach is the structural differentiator; verification is the ambient watermark across both layers. The org layer is the business.
 
 ---
 
@@ -323,9 +332,9 @@ The platform serves whoever has constituents and cares enough to prove it. Not "
 
 | Segment | Why First | Acquisition |
 |---|---|---|
-| **Domain-obsessed local groups** | School parent coalitions, water district accountability, transit equity, fire safety. 90,887 local government entities, 500,396 elected officials, **zero** affordable advocacy tools. These orgs use Google Forms and Mailchimp because nothing else exists. Commons with 24 boundary types is the only platform that can target their officials — at any price. Author-free onboarding + $10 Starter delivery wins by default. | Partner with local government transparency orgs (Sunshine Foundation, OpenGov orgs, League of Women Voters chapters). Content: "Finally, a tool for school board advocacy." |
+| **Domain-obsessed local groups** | School parent coalitions, water district accountability, transit equity, fire safety. 90,887 local government entities, 500,396 elected officials, **zero** affordable advocacy tools. These orgs use Google Forms and Mailchimp because nothing else exists. Commons with 24 boundary types is the only platform that can target their officials — at any price. Author free (2 campaigns), pay to deliver; Starter $10/mo wins by default. | Partner with local government transparency orgs (Sunshine Foundation, OpenGov orgs, League of Women Voters chapters). Content: "Finally, a tool for school board advocacy." |
 | **Science/health advocacy** | Credibility IS the product. "847 verified constituents in your district support NIH funding" changes how a committee staffer reads testimony. Disease foundations, research coalitions, scientific societies — they've been sending unverified form emails and watching them get deleted. | Direct outreach to 10–20 foundations/coalitions. Show them the verification packet. One demo closes. |
-| **Conservative/nonpartisan groups** | Deplatformed by Bonterra, rejected by AN's front door, priced out of Quorum. No affordable tooling exists. A $10 Starter entry (with author-free onboarding) is immediately the best they've ever had. Second Amendment orgs, faith-based advocacy, fiscal policy groups, pro-life organizations — all underserved. | Content marketing: "The advocacy platform that doesn't check your politics." Outreach to Startup Caucus network, conservative think tanks, faith-based coalitions. |
+| **Conservative/nonpartisan groups** | Deplatformed by Bonterra, rejected by AN's front door, priced out of Quorum. No affordable tooling exists. Author-free + $10/mo Starter is immediately the best they've ever had. Second Amendment orgs, faith-based advocacy, fiscal policy groups, pro-life organizations — all underserved. | Content marketing: "The advocacy platform that doesn't check your politics." Outreach to Startup Caucus network, conservative think tanks, faith-based coalitions. |
 | **Single-issue orgs across spectrum** | Environmental justice. Immigration reform. Criminal justice reform. Homeschool advocacy. Agricultural policy. Veterans affairs. These orgs are domain-obsessed — they don't care about platform politics, they care about whether their campaign reaches the right official with proof that their supporters are real. | SEO: "[issue] advocacy tools." Product-led growth from template discovery. |
 
 ### Expansion (Phase 2, months 4–8)
@@ -333,15 +342,15 @@ The platform serves whoever has constituents and cares enough to prove it. Not "
 | Segment | Why Now | Acquisition |
 |---|---|---|
 | **Progressive orgs wanting proof** | Run Commons alongside AN. Compare staffer response rates. Verification packet vs. unverified email count. Migration when the data proves the point. AN's export lock-in (one action at a time, automation ladders non-portable) makes this sticky — Commons' OSDI import and parallel operation mode de-risk the switch. | Import tools + comparison landing page. Side-by-side: AN report vs. Commons verification packet. |
-| **Trade associations fleeing Quorum pricing** | Currently paying $10K–$30K+/year for legislative tracking + grassroots advocacy. Commons Organization tier at $75/mo ($900/yr) is 10-30x cheaper with verification packets Quorum can't produce. Quorum Quincy AI analyzes bills; Commons agents monitor bills AND verify the constituents who care about them. | Case studies from beachhead orgs showing staffer response rate improvement. Direct outreach to association management companies. |
-| **Small orgs (<5K contacts)** | Starter $10/mo vs. AN's $15/mo minimum — and they author free before paying to deliver. Full API, uncapped, from Starter. No paywall on analytics. Every small org with a cause — tenant advocacy, animal rights, disability rights, education reform — can build a verified campaign before spending a dollar. | Product-led growth. Self-serve signup. Template discovery drives adoption. |
+| **Trade associations fleeing Quorum pricing** | Currently paying $10K–$30K+/year for legislative tracking + grassroots advocacy. Commons Organization tier at $75/mo ($900/yr) is 10-30x cheaper with verification packets Quorum can't produce. Quorum Quincy AI analyzes bills; Commons agents monitor bills AND verify the constituents who care about them. | Case studies from beachhead orgs measuring whether staffer response rate improves. Direct outreach to association management companies. |
+| **Small orgs (<5K contacts)** | Starter $10/mo vs. AN's $15/mo minimum, with author-free onboarding (2 campaigns) so they experience the authoring-to-delivery loop before paying. Full uncapped API. No paywall on the Constituent Report. Every small org with a cause — tenant advocacy, animal rights, disability rights, education reform — authors free and pays only to deliver. | Product-led growth. Self-serve signup. Template discovery drives adoption. |
 | **International early adopters** | UK, Canada, Australia — boundary data available, English-speaking, parliamentary systems with similar constituency models. A UK environmental org targeting MPs, a Canadian healthcare coalition targeting provincial legislators. Same verification infrastructure, first-mover advantage in markets with zero verified advocacy tools. | Partner with civic tech organizations in target countries. Boundary data ingestion as the trigger for market entry. |
 
 ### Scale (Phase 3, months 8–14)
 
 | Segment | Why Now | Acquisition |
 |---|---|---|
-| **Corporate advocacy / trade associations** | Phase 2 proved the staffer response rate improvement. Now the case study exists. Fortune 500 companies paying Quorum $30K+/yr for grassroots modules see that verified constituent contacts produce meetings, not inbox noise. | Enterprise sales motion backed by Phase 1-2 case studies. |
+| **Corporate advocacy / trade associations** | Phase 2 tests whether verified contacts lift staffer response; where beachhead case studies show it, the enterprise motion turns on. Fortune 500 companies paying Quorum $30K+/yr for grassroots modules see that verified constituent contacts produce meetings, not inbox noise. | Enterprise sales motion backed by Phase 1-2 case studies. |
 | **Coalition networks** | Cross-org reputation portable. Template-level verification aggregation across endorsing organizations. "12 organizations, 4,847 verified constituents across 3 states" is a different kind of political pressure. | Coalition tier feature launch + outreach to multi-org alliances (climate coalitions, healthcare coalitions, education coalitions). |
 | **International expansion** | Shadow Atlas ingests boundary data country by country. Each country unlocked creates a new market with zero competition for verified advocacy. EU parliamentary elections, Indian state assemblies, Brazilian legislative assemblies — the 24-slot model accommodates any governance hierarchy. | Country-by-country boundary data partnerships. Protocol-level composability means a single org can run cross-border campaigns as constituency data expands. |
 
@@ -358,4 +367,4 @@ From `docs/strategy/economics.md`:
 | Phase 2 end (month 8) | 500–1,000 | $30K–$60K/mo | ~80% |
 | Phase 3 end (month 14) | 2,000–5,000 | $120K–$300K/mo | ~81% |
 
-Growth is on verified actions, not email volume. As orgs discover that verified constituent contacts produce measurably better legislative response rates, they move up tiers to unlock more verified actions. Email overage revenue is noise. Verified action overage at $1.50–$3.00/1K against $0.01 COGS is the margin engine.
+Growth is on verified actions, not email volume. The bet — unproven, the differential we are trying to establish — is that verified constituent contacts earn measurably better legislative response; as orgs test that and find it holds, they move up tiers to unlock more verified actions. Email overage revenue is noise. Verified action overage at $1.50–$3.00/1K against $0.01 COGS is the margin engine.

--- a/docs/strategy/vision.md
+++ b/docs/strategy/vision.md
@@ -21,17 +21,18 @@
 
 ## What Commons Is
 
-Commons is AI-native civic communication infrastructure. An org states what it
-wants to change; Commons grounds that objective against the right
-decision-makers, composes individually-authored messages with each constituent,
-and delivers them — then hands back a Constituent Report. Not a mail merge tool
-with a database. The authoring-to-delivery spine is the core; verification is
-the ambient property woven underneath that makes the resulting civic speech
-*provable*.
+Commons is civic communication infrastructure. Not a mail merge tool with a
+database — an AI-native authoring-to-delivery system that turns an org's intent
+into an individually-composed, grounded message for each constituent, resolves
+the right decision-makers across every level of government, delivers, and
+aggregates the response into a Constituent Report. Every incumbent ships AI for
+the org user; Commons writes for the action. The authoring-to-delivery spine is
+the core; verification is the ambient property woven underneath that makes the
+resulting civic speech *provable*.
 
-A person sends a letter through Commons. That letter carries cryptographic proof that the sender holds a government-issued credential, lives in the decision-maker's district (verified against a hierarchical Merkle tree of every public district boundary — congressional, state legislative, county, municipal, school, judicial, fire, water, transit, and more), and has an engagement history that cannot be purchased or fabricated. The decision-maker's office doesn't trust Commons. They verify the math.
+An organization runs campaigns through Commons. Each campaign hands back a Constituent Report — not "847 people emailed" but "847 constituents in your district individually written to, with X responses — 89 at Pillar tier, coordination diversity 0.91, debate market consensus 62% AMEND." The report leads with constituents, individually-composed authorship, and response; the verification figures trail as the credibility context.
 
-An organization runs campaigns through Commons. Those campaigns produce verification packets: district-level constituent counts, engagement tier distributions, coordination integrity scores, and adversarial quality signals. A staffer opens a campaign report and sees not "847 people emailed" but "847 verified constituents in your district, 89 at Pillar tier, coordination diversity score 0.91, debate market consensus 62% AMEND."
+Every authored action carries an ambient watermark underneath. A person sends a letter through Commons, and that letter carries cryptographic proof that the sender holds a government-issued credential, lives in the decision-maker's district (verified against a hierarchical Merkle tree of every public district boundary — congressional, state legislative, county, municipal, school, judicial, fire, water, transit, and more), and has an engagement history that cannot be purchased or fabricated. The decision-maker's office doesn't trust Commons. They verify the math.
 
 commons.email is the application. voter-protocol is the open protocol beneath it.
 
@@ -42,27 +43,29 @@ The system must be indistinguishable from existing advocacy tools for someone wh
 Three constraints:
 1. **Cheaper** — 40-60% lower pricing, 80%+ gross margin
 2. **Simpler** — fewer clicks to send a verified message than competitors require for an unverified one
-3. **Unreplicable** — ZK identity, debate markets, coordination integrity, privacy architecture are structural. They cannot be bolted on after the fact.
+3. **Unreplicable** — per-recipient AI authoring + grounding, owned local-government reach (Shadow Atlas, 24 boundary types), and political neutrality with an uncapped API are structural. ZK identity, debate markets, and coordination integrity ride along as the credibility watermark — the lowest-replicability layer, but not the headline. None can be bolted on after the fact.
 
 ## What Makes It Different
 
-These are not separate features bolted onto a platform. They are properties of every surface — woven into every email, every letter, every campaign report, every agent action.
+The differentiated spine is authoring-to-delivery. The rest — verified identity, debate markets, coordination integrity, privacy — ride along as ambient credibility properties of every surface: woven into every email, every letter, every Constituent Report, every agent action.
 
-### Verified Identity
+### AI-Native Per-Recipient Authoring + Grounding
 
-Every other advocacy platform accepts whatever name and address a user types in. Commons binds actions to government-issued credentials through zero-knowledge proofs. The proof reveals nothing about the person — only that they are real, that they hold a valid credential, and that they reside in the claimed district. This is not a feature added to email campaigns. It is the foundation that makes every campaign report, every analytics dashboard, every supporter segment fundamentally different from what any other platform produces.
+This is the core. An org expresses intent; Commons grounds it in the legislative and decision-maker record, authors an individually-composed message for each constituent (not a templated mass-send), resolves the correct decision-makers across all 24 district types and every level of government, delivers, and aggregates the response into a Constituent Report. The loop: intent → ground → author per-recipient → resolve-targets → deliver → aggregate.
 
-### Adversarial Quality (Debate Markets)
+Every incumbent — Bonterra Que, Quorum Quincy, AdvocacyAI — ships AI for the org user: it drafts the staffer's email, summarizes a bill, suggests a subject line. Commons ships AI for the *action*: it writes the constituent's message, grounded and resolved to the right office, not the staffer's draft. The send-path is customer-gated per channel and platform-sync is armed per-adapter; this describes the authoring-to-delivery capability, not a claim of measured outcomes.
 
-When a campaign reaches traction, verified participants can stake on positions (SUPPORT / OPPOSE / AMEND) with structured arguments. LMSR pricing surfaces genuine conviction. A 5-model AI panel scores argument quality. Engagement-weighted: `sqrt(stake) × 2^tier` — a Pillar's $2 outweighs a newcomer's $100. The result: campaigns become quality instruments, not volume instruments.
+### Verified Agentic Delegation
 
-### Coordination Integrity (Anti-Astroturf)
+Every advocacy platform adding AI in 2026 — Bonterra Que, Quorum Quincy, AdvocacyAI — layers AI on top of unverified identity. Commons specifies something structurally different: AI agents act on behalf of cryptographically verified constituents, within delegated bounds, with privacy-preserving memory. This is a designed capability, not yet shipped (`FEATURES.DELEGATION = false`).
 
-Congressional staffers currently have no tool to distinguish authentic grassroots from manufactured campaigns. Commons provides structural observability — Geographic Diversity Score, Author Linkage Diversity, Shannon entropy, temporal velocity — computed automatically from every action, whether submitted by a person or an agent. These signals ship with every campaign report. An org can prove its campaign is authentic. A staffer can verify it.
+A constituent delegates authority to an agent: "monitor school board agendas, draft responses matching my positions, notify me before sending." The agent monitors legislation across all 24 district types — not just federal. It drafts grounding-verified messages. It pre-resolves decision-makers. Every action it takes carries the same ZK proof as a manual action.
 
-### Privacy Architecture
+As specified, delegation is gated to Trust Tier 3+ (identity-verified) constituents and bounded by per-grant scope, a max-actions-per-day cap, and a review threshold above which actions queue for human review. The on-chain nullifier system prevents an agent from exceeding its delegation. Revocation is instant.
 
-Commons cannot be subpoenaed for supporter data it does not possess. ZK proofs reveal constituency and engagement tier without revealing identity. The platform never sees the credential — only the proof derived from it. Agent memory is encrypted to the constituent's identity commitment. For organizations working on controversial issues, this is an existential requirement that no other platform can offer.
+The agent's memory — policy positions, engagement history, communication preferences — is encrypted to the constituent's identity commitment. The platform stores ciphertext. This is the intersection of agent memory and ZK privacy that the frontier research identifies as unexplored.
+
+Full specification: `specs/agentic-civic-infrastructure.md`
 
 ### Protocol Composability
 
@@ -84,17 +87,21 @@ PROTOCOL LAYER (voter-protocol)
 
 A supporter who builds reputation on one organization's campaign carries it everywhere on the protocol. Identity is not siloed per-org. Reputation is not reset per-platform. Network effects compound at the protocol layer, not the application layer.
 
-### Verified Agentic Delegation
+### Coordination Integrity (Anti-Astroturf)
 
-Every advocacy platform adding AI in 2026 — Bonterra Que, Quorum Quincy, AdvocacyAI — layers AI on top of unverified identity. Commons does something structurally different: AI agents act on behalf of cryptographically verified constituents, within delegated bounds, with privacy-preserving memory.
+Congressional staffers currently have no tool to distinguish authentic grassroots from manufactured campaigns. Commons provides structural observability — Geographic Diversity Score, Author Linkage Diversity, Shannon entropy, temporal velocity — computed automatically from every action, whether submitted by a person or an agent. These signals ship with every campaign report. An org can prove its campaign is authentic. A staffer can verify it.
 
-A constituent delegates authority to an agent: "monitor school board agendas, draft responses matching my positions, notify me before sending." The agent monitors legislation across all 24 district types — not just federal. It drafts grounding-verified messages. It pre-resolves decision-makers. Every action it takes carries the same ZK proof as a manual action.
+### Adversarial Quality (Debate Markets)
 
-The delegation is bound to the constituent's engagement tier. An Active's agent can draft but not send. A Pillar's agent can act semi-autonomously within configured bounds. The on-chain nullifier system prevents an agent from exceeding its delegation. Revocation is instant.
+When a campaign reaches traction, verified participants can stake on positions (SUPPORT / OPPOSE / AMEND) with structured arguments. LMSR pricing surfaces genuine conviction. A 5-model AI panel scores argument quality. Engagement-weighted: `sqrt(stake) × 2^tier` — a Pillar's $2 outweighs a newcomer's $100. The result: campaigns become quality instruments, not volume instruments.
 
-The agent's memory — policy positions, engagement history, communication preferences — is encrypted to the constituent's identity commitment. The platform stores ciphertext. This is the intersection of agent memory and ZK privacy that the frontier research identifies as unexplored.
+### Privacy Architecture
 
-Full specification: `specs/agentic-civic-infrastructure.md`
+Commons cannot be subpoenaed for supporter data it does not possess. ZK proofs reveal constituency and engagement tier without revealing identity. The platform never sees the credential — only the proof derived from it. Agent memory is encrypted to the constituent's identity commitment. For organizations working on controversial issues, this is an existential requirement that no other platform can offer.
+
+### Verified Identity (Ambient Credibility Watermark)
+
+Every other advocacy platform accepts whatever name and address a user types in. Commons binds actions to government-issued credentials through zero-knowledge proofs. The proof reveals nothing about the person — only that they are real, that they hold a valid credential, and that they reside in the claimed district. It rides along with every authored action as a credibility watermark and is the lowest-replicability layer of the stack. The thesis that a decision-maker's office weights a verified packet differently is plausible but UNPROVEN — Commons has not yet measured a signal — so verification is a tiebreaker for distrust-prone segments, not the headline.
 
 ## Political Neutrality
 
@@ -114,7 +121,7 @@ Commons is not a US federal advocacy tool that might expand someday. It is civic
 
 **Any country.** voter-protocol uses H3 hexagonal indexing (global), country-code-keyed district registries, and a 24-slot model that accommodates any governance hierarchy. Canada's federal ridings and provincial constituencies, the UK's Westminster constituencies and devolved assemblies, Australia's federal and state electorates — all fit within the existing architecture. Boundary data ingestion is the only work required per country. One protocol, one app, many district trees.
 
-**The business implication:** The addressable market is not $191M (US grassroots advocacy). It is every organization in every democracy that wants to prove its supporters are real. That's a market no competitor has even conceived of, because no competitor has the verification infrastructure to serve it.
+**The business implication:** The addressable market is not $191M (US grassroots advocacy). It is every organization in every democracy that wants to reach the right decision-makers with individually-composed, grounded messages across every level of government. That is a market no competitor has conceived of, because none pairs AI-native per-recipient authoring with owned local-government reach (and a neutral, uncapped API). Verification rides along as the credibility tiebreaker for the segments that demand it.
 
 ## Why "Commons"
 


### PR DESCRIPTION
Completes the consistency arc: the strategy docs got dated recenter *banners* in #35, but their *bodies* still structurally led with verification (North Star, "What Makes It Different" order, "the verification loop is the product"). This re-sequences vision.md / index.md / product-roadmap.md so authoring-to-delivery is the spine and verification is the ambient watermark — via a do→review→apply workflow.

The review caught over-claims the drafters missed and the apply folded them in: product-roadmap's "Phase 2 *proved* staffer response rate" / "verified contacts produce measurably better response" reframed to explicit *unproven hypotheses*; and a code-contradicting Verified-Agentic-Delegation tier-gating claim (DELEGATION flag-off) softened to the actually-specified controls + 'designed, not shipped.'

Scope: only docs/strategy/{vision,index,product-roadmap}.md. Dated banners + phases/timeline + historical records + canonical roles preserved. No src/, no other docs. Person-Layer 'free forever' kept; org pricing = no free tier / gate-at-delivery / Starter $10, verified against plans.ts.