### PR TITLE
Reframe public pages off the removed free tier to gate-at-delivery

### DIFF
--- a/src/routes/developers/+page.svelte
+++ b/src/routes/developers/+page.svelte
@@ -936,15 +936,16 @@ for supporter in client.supporters.list():
 	<section class="section">
 		<h2 class="section-title">Rate Limits</h2>
 		<p class="section-desc">
-			Rate limits are applied per API key based on your organization's plan. When rate limited,
-			you'll receive a <code>429</code> response.
+			Rate limits are applied per API key based on your organization's plan. Reads stay open
+			while you're building -- a plan lifts the write ceiling and unlocks delivery. When rate
+			limited, you'll receive a <code>429</code> response.
 		</p>
 		<table class="rate-table">
 			<thead>
 				<tr><th>Plan</th><th>Requests / min</th></tr>
 			</thead>
 			<tbody>
-				<tr><td>Free</td><td>100</td></tr>
+				<tr><td>No plan yet</td><td>Reads uncapped &middot; writes 100</td></tr>
 				<tr><td>Starter</td><td>300</td></tr>
 				<tr><td>Organization</td><td>1,000</td></tr>
 				<tr><td>Coalition</td><td>3,000</td></tr>

--- a/src/routes/migrate/+page.svelte
+++ b/src/routes/migrate/+page.svelte
@@ -172,10 +172,11 @@
 				</p>
 			</div>
 			<div class="space-y-2">
-				<h3 class="text-text-primary text-sm font-semibold">Is there a free tier?</h3>
+				<h3 class="text-text-primary text-sm font-semibold">Do I pay before I migrate?</h3>
 				<p class="text-text-secondary text-sm leading-relaxed">
-					Yes. You can create an org, import supporters, and run campaigns at no cost. Usage-based
-					pricing applies only when you need proof report delivery at scale.
+					No. Create the org, import your supporters, and author and preview a campaign or two for
+					free. A plan starts at $10/mo and unlocks delivery &mdash; sending to your people and
+					verified action at scale.
 				</p>
 			</div>
 		</div>
@@ -204,7 +205,7 @@
 			href="/org/new"
 			class="inline-block rounded-lg bg-white px-6 py-3 text-sm font-semibold text-black transition-opacity hover:opacity-90"
 		>
-			Start your free org
+			Start authoring &mdash; $10/mo to send
 		</a>
 	</section>
 

--- a/src/routes/org/for/agency-rulemaking/+page.svelte
+++ b/src/routes/org/for/agency-rulemaking/+page.svelte
@@ -337,13 +337,11 @@
 					<span class="pricing__anchor-text">Not <span class="pricing__anchor-num">$40,000</span>/yr with a year-long implementation.</span>
 				</div>
 				<div class="pricing__anchor-line pricing__anchor-line--punchline">
-					<span class="pricing__free">$0.</span>
+					<span class="pricing__free">$0 to author.</span>
 					<span class="pricing__free-scope">
-						<span class="pricing__free-scope-num">100</span> verified actions
+						Ground a comment or two, draft them, see the targets &mdash; free.
 						<span class="pricing__free-scope-sep">&middot;</span>
-						<span class="pricing__free-scope-num">2</span> seats
-						<span class="pricing__free-scope-sep">&middot;</span>
-						no time limit
+						<span class="pricing__free-scope-num">$10</span>/mo to file with the agency.
 					</span>
 				</div>
 			</div>
@@ -358,9 +356,9 @@
 
 			<div class="pricing-grid">
 				<div class="pricing-row">
-					<span class="pricing-name">Free</span>
+					<span class="pricing-name">Author</span>
 					<span class="pricing-price">$0</span>
-					<span class="pricing-limits"><span class="pricing-num">100</span> verified actions &middot; <span class="pricing-num">1,000</span> emails &middot; <span class="pricing-num">2</span> seats</span>
+					<span class="pricing-limits">Build a comment or two, ground them, preview the targets &mdash; free. Filing starts at Starter.</span>
 				</div>
 				<div class="pricing-row">
 					<span class="pricing-name">Starter</span>

--- a/src/routes/org/for/local-government/+page.svelte
+++ b/src/routes/org/for/local-government/+page.svelte
@@ -310,13 +310,11 @@
 					<span class="pricing__anchor-text">Not <span class="pricing__anchor-num">$40,000</span>/yr with a year-long implementation.</span>
 				</div>
 				<div class="pricing__anchor-line pricing__anchor-line--punchline">
-					<span class="pricing__free">$0.</span>
+					<span class="pricing__free">$0 to author.</span>
 					<span class="pricing__free-scope">
-						<span class="pricing__free-scope-num">100</span> verified actions
+						Ground a campaign or two, draft them, see the targets &mdash; free.
 						<span class="pricing__free-scope-sep">&middot;</span>
-						<span class="pricing__free-scope-num">2</span> seats
-						<span class="pricing__free-scope-sep">&middot;</span>
-						no time limit
+						<span class="pricing__free-scope-num">$10</span>/mo to send to your board.
 					</span>
 				</div>
 			</div>
@@ -331,9 +329,9 @@
 
 			<div class="pricing-grid">
 				<div class="pricing-row">
-					<span class="pricing-name">Free</span>
+					<span class="pricing-name">Author</span>
 					<span class="pricing-price">$0</span>
-					<span class="pricing-limits"><span class="pricing-num">100</span> verified actions &middot; <span class="pricing-num">1,000</span> emails &middot; <span class="pricing-num">2</span> seats</span>
+					<span class="pricing-limits">Build a campaign or two, ground them, preview the targets &mdash; free. Sending starts at Starter.</span>
 				</div>
 				<div class="pricing-row">
 					<span class="pricing-name">Starter</span>

--- a/src/routes/org/for/state-legislature/+page.svelte
+++ b/src/routes/org/for/state-legislature/+page.svelte
@@ -295,13 +295,11 @@
 					<span class="pricing__anchor-text">Not <span class="pricing__anchor-num">$40,000</span>/yr with a year-long implementation.</span>
 				</div>
 				<div class="pricing__anchor-line pricing__anchor-line--punchline">
-					<span class="pricing__free">$0.</span>
+					<span class="pricing__free">$0 to author.</span>
 					<span class="pricing__free-scope">
-						<span class="pricing__free-scope-num">100</span> verified actions
+						Ground a campaign or two, draft them, see the targets &mdash; free.
 						<span class="pricing__free-scope-sep">&middot;</span>
-						<span class="pricing__free-scope-num">2</span> seats
-						<span class="pricing__free-scope-sep">&middot;</span>
-						no time limit
+						<span class="pricing__free-scope-num">$10</span>/mo to send to the chamber.
 					</span>
 				</div>
 			</div>
@@ -316,9 +314,9 @@
 
 			<div class="pricing-grid">
 				<div class="pricing-row">
-					<span class="pricing-name">Free</span>
+					<span class="pricing-name">Author</span>
 					<span class="pricing-price">$0</span>
-					<span class="pricing-limits"><span class="pricing-num">100</span> verified actions &middot; <span class="pricing-num">1,000</span> emails &middot; <span class="pricing-num">2</span> seats</span>
+					<span class="pricing-limits">Build a campaign or two, ground them, preview the targets &mdash; free. Sending starts at Starter.</span>
 				</div>
 				<div class="pricing-row">
 					<span class="pricing-name">Starter</span>


### PR DESCRIPTION
The public marketing pages still advertised a Free org tier ("$0 · 100 verified actions · 1,000 emails · 2 seats"), contradicting the no-free-tier billing (#33). Reframes the pricing blocks on the five public pages to gate-at-delivery, matching the in-app DeliveryGateNotice ("author free, pay to deliver") and plans.ts.

do→review→apply workflow. The review caught + fixed a residual overpromise (the draft implied *unbounded* free authoring; tightened to "a campaign or two" to match the inactive floor's `maxTemplatesMonth:2`) and stripped "no time limit" filler.

- org/for/{local-government,agency-rulemaking,state-legislature}: the "$0" punchline + grid "Free" row → "$0 to author / $10/mo to send," with the send object localized per sector ("file with the agency" / "send to your board" / "send to the chamber"); grid row renamed "Author $0 — build a campaign or two free, sending starts at Starter."
- migrate: FAQ + CTA reframed off "free tier."
- developers: API rate-limit row aligned to the real tiers (no free).

Person-Layer 'free for individuals' untouched. svelte-check 0 errors (147 baseline). Prices verified vs plans.ts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified rate-limit behavior documentation with updated limits per API key/plan
  * Updated pricing tier naming from "Free" to "Author" at $0 across plans
  * Clarified that authoring and drafting are free while sending/filing requires paid plans starting at $10/mo
  * Updated migration FAQ to specify that migration itself is free

<!-- end of auto-generated comment: release notes by coderabbit.ai -->