### PR TITLE
Monetization: close Coalition bypass + honest report label + L1 individual authoring cap (3/mo)

### DIFF
--- a/convex/_individualAuthoringCap.ts
+++ b/convex/_individualAuthoringCap.ts
@@ -1,0 +1,71 @@
+/**
+ * Pure helpers for the L1 individual AI-authoring cap.
+ *
+ * Individuals are free forever to ACT on existing messages (send, sign,
+ * personalize-and-deliver). What carries real LLM COGS is AI-AUTHORING a NEW
+ * template (the person-layer TemplateCreator runs the subject + grounded
+ * decision-maker resolution + grounded message generation, ~$0.12–0.22 each).
+ * So the free tier is bounded on GENERATION, not action: an individual may
+ * author up to FREE_INDIVIDUAL_TEMPLATES_PER_MONTH new templates per calendar
+ * month. Acting on / sending templates is never gated by this.
+ *
+ * These functions live here (not inline in the mutation) so the cap's count
+ * math + message are unit-testable without a live Convex context, mirroring
+ * `_brandingGate.ts`. The Convex handler reads the user's month-to-date count
+ * via the `templates.by_userId` index and delegates the decision here.
+ */
+
+/** Free individual AI-authored templates per calendar month. */
+export const FREE_INDIVIDUAL_TEMPLATES_PER_MONTH = 3;
+
+/**
+ * Start-of-calendar-month epoch ms (UTC) for `now`. Used as the query-time
+ * aggregation floor — we count templates whose `_creationTime >=` this value.
+ * This is query-time aggregation from timestamped rows, NOT a denormalized
+ * counter that needs resetting: the window slides with the wall clock and the
+ * count is always recomputed.
+ */
+export function startOfMonthUTC(now: number): number {
+	const d = new Date(now);
+	return Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1);
+}
+
+/**
+ * First day of NEXT calendar month (UTC), as a human-readable ISO date
+ * (YYYY-MM-DD) — the date the free allowance resets. Surfaced in the cap
+ * message so the limit is honest about when it lifts.
+ */
+export function nextMonthResetDate(now: number): string {
+	const d = new Date(now);
+	const year = d.getUTCFullYear();
+	const month = d.getUTCMonth();
+	const next = new Date(Date.UTC(month === 11 ? year + 1 : year, (month + 1) % 12, 1));
+	return next.toISOString().slice(0, 10);
+}
+
+/**
+ * Decide whether an individual (no org membership) may author one more template
+ * this month, given how many they have ALREADY created month-to-date.
+ *
+ * `monthToDateCount` is the count of the user's own templates created since
+ * `startOfMonthUTC(now)`. The NEW template would be the `monthToDateCount + 1`
+ * th, so we block once the existing count has reached the free allowance.
+ */
+export type IndividualCapDecision =
+	| { ok: true }
+	| { ok: false; message: string };
+
+export function decideIndividualAuthoring(
+	monthToDateCount: number,
+	now: number
+): IndividualCapDecision {
+	if (monthToDateCount < FREE_INDIVIDUAL_TEMPLATES_PER_MONTH) {
+		return { ok: true };
+	}
+	return {
+		ok: false,
+		message: `You've authored your ${FREE_INDIVIDUAL_TEMPLATES_PER_MONTH} free messages this month — resets ${nextMonthResetDate(
+			now
+		)}. Higher-volume individual authoring is coming.`
+	};
+}

--- a/convex/networks.ts
+++ b/convex/networks.ts
@@ -9,7 +9,26 @@ import { query, mutation } from './_generated/server';
 import { v } from 'convex/values';
 import { requireOrgRole, loadOrg, requireAuth } from './_authHelpers';
 import { requireInternalSecret } from './_internalAuth';
+import { effectivePlan, isCoalitionPlan } from './_brandingGate';
 import type { Id } from './_generated/dataModel';
+import type { MutationCtx, QueryCtx } from './_generated/server';
+
+/**
+ * Resolve an org's effective billing plan from its subscription row. Only
+ * `active`/`trialing` subscriptions count toward a paid tier (the shared
+ * `effectivePlan` rule). Mirrors `organizations.ts:resolveOrgPlan` so the
+ * coalition-create gate reads plans the same way every other paid gate does.
+ */
+async function resolveOrgPlan(
+	ctx: MutationCtx | QueryCtx,
+	orgId: Id<'organizations'>
+): Promise<string> {
+	const sub = await ctx.db
+		.query('subscriptions')
+		.withIndex('by_orgId', (q) => q.eq('orgId', orgId))
+		.first();
+	return effectivePlan(sub);
+}
 
 // =============================================================================
 // QUERIES
@@ -295,6 +314,18 @@ export const create = mutation({
 	},
 	handler: async (ctx, args) => {
 		const { org, userId } = await requireOrgRole(ctx, args.orgSlug, 'owner');
+
+		// Coalition-tier gate — THE FENCE. The SvelteKit endpoint also checks the
+		// plan, but a public Convex mutation is callable directly, so the paywall
+		// must be enforced here or it is bypassable. Creating a coalition network
+		// requires an active/trialing Coalition plan; everything below (inactive
+		// floor, starter, organization) is rejected with a clear upgrade message.
+		const plan = await resolveOrgPlan(ctx, org._id);
+		if (!isCoalitionPlan(plan)) {
+			throw new Error(
+				'Coalition networks require an active Coalition plan. Upgrade your organization to create one.'
+			);
+		}
 
 		if (args.name.length < 3 || args.name.length > 100) {
 			throw new Error('Name must be 3-100 characters');

--- a/convex/templates.ts
+++ b/convex/templates.ts
@@ -4,6 +4,10 @@ import type { FunctionReference } from "convex/server";
 import { v } from "convex/values";
 import type { Doc, Id } from "./_generated/dataModel";
 import { requireAuth, requireOrgRole, loadOrg } from "./_authHelpers";
+import {
+  startOfMonthUTC,
+  decideIndividualAuthoring,
+} from "./_individualAuthoringCap";
 import anchorsData from "./domain-anchors.json";
 
 declare const process: { env: Record<string, string | undefined> };
@@ -998,6 +1002,27 @@ export const createTemplate = mutation({
         if (templates.length >= org.maxTemplatesMonth) {
           throw new Error("TEMPLATE_QUOTA_EXCEEDED");
         }
+      }
+    } else {
+      // L1 individual AI-authoring cap. Individuals are free forever to ACT on
+      // existing messages; the bound is on AI-AUTHORING NEW templates (the
+      // expensive person-layer TemplateCreator generation path). Org members
+      // are governed by their plan's maxTemplatesMonth above, so this only
+      // applies to the un-orged individual path.
+      //
+      // Query-time aggregation from timestamped rows (templates.by_userId +
+      // _creationTime >= start-of-month), mirroring the billing pattern — NOT a
+      // denormalized counter that needs resetting.
+      const now = Date.now();
+      const monthStart = startOfMonthUTC(now);
+      const monthToDate = await ctx.db
+        .query("templates")
+        .withIndex("by_userId", (q) => q.eq("userId", args.userId))
+        .filter((q) => q.gte(q.field("_creationTime"), monthStart))
+        .collect();
+      const decision = decideIndividualAuthoring(monthToDate.length, now);
+      if (!decision.ok) {
+        throw new Error(decision.message);
       }
     }
 

--- a/src/lib/components/org/os/ReturnSpace.svelte
+++ b/src/lib/components/org/os/ReturnSpace.svelte
@@ -5,7 +5,8 @@
   campaign lands after it ships. It answers the questions an organization
   actually brings here: did it deliver, who composed, did anyone respond, what
   do we show the board. The evidence band leads with constituents and
-  individually-composed authorship beside reach, delivery, and responses. The
+  personalized authorship (edited-vs-verbatim) beside reach, delivery, and
+  responses. The
   delivered artifact is the "Constituent Report" — verification rides under it
   as a quiet watermark, never the lead. Below it sit three lists: action
   records, where actions landed, and response activity.
@@ -68,11 +69,12 @@
 	const districtReach = $derived(deriveDistrictReach(data?.packet?.geography ?? null));
 	const responseActivity = $derived(data ? describeResponseActivity(data.receipts) : null);
 
-	// Individually-composed messages — the differentiator a board reacts to
-	// (individualized messages carry far more influence than form letters), so
-	// it belongs in the impact band beside reach, not buried in the packet.
-	// Sourced from the packet's authorship signal when it carries one.
-	const individuallyComposed = $derived(data?.packet?.authorship?.individual ?? 0);
+	// Personalized messages — the differentiator a board reacts to (a supporter
+	// who edited the org's template away from verbatim carries far more influence
+	// than a form letter), so it belongs in the impact band beside reach, not
+	// buried in the packet. This is an edited-vs-verbatim signal (the packet's
+	// authorship.individual count), NOT a claim of AI authoring.
+	const personalized = $derived(data?.packet?.authorship?.individual ?? 0);
 
 	const funnel = $derived(
 		data?.funnel ?? { imported: 0, postalResolved: 0, identityVerified: 0, districtVerified: 0 }
@@ -130,10 +132,10 @@
 							<span class="evidence-label">verified constituents</span>
 						</span>
 					{/if}
-					{#if individuallyComposed > 0}
+					{#if personalized > 0}
 						<span class="evidence-cell">
-							<Datum value={individuallyComposed} />
-							<span class="evidence-label">individually composed</span>
+							<Datum value={personalized} />
+							<span class="evidence-label">personalized</span>
 						</span>
 					{/if}
 					{#if headline.districtsReached > 0}

--- a/src/lib/server/email/report-template.ts
+++ b/src/lib/server/email/report-template.ts
@@ -184,7 +184,7 @@ function renderHtml(ctx: ReportContext, attestationHash: string): string {
 	if (authorTotal > 0) {
 		const parts: string[] = [];
 		if (authorship.individual > 0) {
-			parts.push(`${authorship.individual} ${authorship.explicit ? 'individually composed' : 'distinct messages'}`);
+			parts.push(`${authorship.individual} ${authorship.explicit ? 'personalized' : 'distinct messages'}`);
 		}
 		if (authorship.shared > 0) {
 			parts.push(`${authorship.shared} shared ${authorship.shared === 1 ? 'statement' : 'statements'}`);
@@ -334,7 +334,7 @@ function renderHtml(ctx: ReportContext, attestationHash: string): string {
               ${
 								authorship.individual > 0
 									? `<p style="margin:8px 0 0 0;font-size:15px;font-weight:600;color:#171717;">
-                ${authorship.individual.toLocaleString()} individually composed ${authorship.individual === 1 ? 'message' : 'messages'}
+                ${authorship.individual.toLocaleString()} personalized ${authorship.individual === 1 ? 'message' : 'messages'}
               </p>`
 									: ''
 							}
@@ -412,7 +412,7 @@ function renderText(ctx: ReportContext, attestationHash: string): string {
 	);
 	if (authorship.individual > 0) {
 		lines.push(
-			`${authorship.individual.toLocaleString()} individually composed ${authorship.individual === 1 ? 'message' : 'messages'}`
+			`${authorship.individual.toLocaleString()} personalized ${authorship.individual === 1 ? 'message' : 'messages'}`
 		);
 	}
 	lines.push(rule);
@@ -436,7 +436,7 @@ function renderText(ctx: ReportContext, attestationHash: string): string {
 		lines.push('Authorship:');
 		if (authorship.individual > 0) {
 			lines.push(
-				`  - ${authorship.individual} ${authorship.explicit ? 'individually composed' : 'distinct messages'}`
+				`  - ${authorship.individual} ${authorship.explicit ? 'personalized' : 'distinct messages'}`
 			);
 		}
 		if (authorship.shared > 0) {

--- a/src/lib/types/verification-packet.ts
+++ b/src/lib/types/verification-packet.ts
@@ -61,7 +61,7 @@ export interface CellWeight {
 	identity?: { govId: number; address: number; email: number };
 	/** Per-cell hourly bins aligned to the packet's temporal field (same startMs/binWidthMs) */
 	temporalBins?: number[];
-	/** Per-cell authorship: individually composed vs shared */
+	/** Per-cell authorship: personalized (edited away from verbatim) vs shared */
 	authorship?: { individual: number; shared: number };
 }
 
@@ -97,7 +97,7 @@ export interface VerificationPacket {
 	/** Unique district hashes (geographic breadth) */
 	districtCount: number;
 
-	/** Authorship: individually composed vs shared template vs unknown */
+	/** Authorship: personalized (edited vs verbatim) vs shared template vs unknown */
 	authorship: AuthorshipBreakdown;
 	/** Submission date range */
 	dateRange: DateRange;

--- a/src/routes/api/org/[slug]/networks/+server.ts
+++ b/src/routes/api/org/[slug]/networks/+server.ts
@@ -34,6 +34,14 @@ export const POST: RequestHandler = async ({ params, request, locals }) => {
 
 	const { name, slug, description } = parsed.data;
 
+	// Coalition-tier gate (aligned with the mutation fence in convex/networks.ts).
+	// The mutation re-checks the plan and is the real enforcement layer; this
+	// pre-check turns the paywall into a clean 403 instead of a 500-shaped throw.
+	const planLimits = await serverQuery(api.subscriptions.checkPlanLimits, { orgSlug: params.slug });
+	if (planLimits.plan !== 'coalition') {
+		throw error(403, 'Coalition networks require an active Coalition plan.');
+	}
+
 	const networkId = await serverMutation(api.networks.create, {
 		orgSlug: params.slug,
 		name,

--- a/src/routes/org/for/agency-rulemaking/+page.svelte
+++ b/src/routes/org/for/agency-rulemaking/+page.svelte
@@ -182,7 +182,7 @@
 						<div class="specimen__evidence-row">
 							<span class="specimen__evidence-label">Authorship</span>
 							<span class="specimen__evidence-detail">
-								<strong>2,612</strong> individually composed
+								<strong>2,612</strong> personalized
 								<span class="specimen__sep">&middot;</span>
 								<strong>816</strong> shared templates (disclosed)
 							</span>

--- a/src/routes/org/for/local-government/+page.svelte
+++ b/src/routes/org/for/local-government/+page.svelte
@@ -192,7 +192,7 @@
 						<div class="specimen__evidence-row">
 							<span class="specimen__evidence-label">Authorship</span>
 							<span class="specimen__evidence-detail">
-								<strong>701</strong> individually composed
+								<strong>701</strong> personalized
 								<span class="specimen__sep">&middot;</span>
 								<strong>173</strong> shared statements
 							</span>

--- a/src/routes/org/for/state-legislature/+page.svelte
+++ b/src/routes/org/for/state-legislature/+page.svelte
@@ -168,7 +168,7 @@
 						<div class="specimen__evidence-row">
 							<span class="specimen__evidence-label">Authorship</span>
 							<span class="specimen__evidence-detail">
-								<strong>967</strong> individually composed
+								<strong>967</strong> personalized
 								<span class="specimen__sep">&middot;</span>
 								<strong>237</strong> shared statements
 							</span>

--- a/tests/unit/billing/individual-authoring-cap.test.ts
+++ b/tests/unit/billing/individual-authoring-cap.test.ts
@@ -1,0 +1,76 @@
+/**
+ * L1 individual AI-authoring cap (3 / calendar month).
+ *
+ * "Individuals free forever" is refined to: free forever to ACT (send, sign,
+ * personalize-and-deliver existing messages), bounded on AI GENERATION. The
+ * expensive person-layer path is authoring a NEW template (subject + grounded
+ * decision-maker resolution + grounded message, ~$0.12–0.22 each), so an
+ * un-orged individual may AI-author up to 3 templates per calendar month.
+ *
+ * The cap is enforced in `convex/templates.ts:createTemplate` (the individual
+ * create fence), in the `else` (no-org) branch — org members are governed by
+ * their plan's `maxTemplatesMonth`. It counts the user's own templates created
+ * month-to-date via the `templates.by_userId` index (query-time aggregation
+ * from `_creationTime`, NOT a denormalized counter), then delegates the
+ * allow/deny decision to the pure helper pinned here.
+ *
+ * ACTING on / SENDING an existing template never touches `createTemplate`
+ * (campaign-action / submit paths), so it is intentionally never gated by this
+ * cap — there is no `createTemplate` call to reach the cap on the action path.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+	FREE_INDIVIDUAL_TEMPLATES_PER_MONTH,
+	startOfMonthUTC,
+	nextMonthResetDate,
+	decideIndividualAuthoring
+} from '../../../convex/_individualAuthoringCap';
+
+const JAN_15 = Date.UTC(2026, 0, 15, 12, 0, 0); // mid-January 2026
+const DEC_20 = Date.UTC(2026, 11, 20, 12, 0, 0); // mid-December (year-rollover case)
+
+describe('FREE_INDIVIDUAL_TEMPLATES_PER_MONTH', () => {
+	it('is 3', () => {
+		expect(FREE_INDIVIDUAL_TEMPLATES_PER_MONTH).toBe(3);
+	});
+});
+
+describe('startOfMonthUTC', () => {
+	it('floors to the first instant of the calendar month (UTC)', () => {
+		expect(startOfMonthUTC(JAN_15)).toBe(Date.UTC(2026, 0, 1));
+		expect(startOfMonthUTC(DEC_20)).toBe(Date.UTC(2026, 11, 1));
+	});
+});
+
+describe('nextMonthResetDate', () => {
+	it('returns the first day of next month as an ISO date', () => {
+		expect(nextMonthResetDate(JAN_15)).toBe('2026-02-01');
+	});
+	it('rolls the year over from December', () => {
+		expect(nextMonthResetDate(DEC_20)).toBe('2027-01-01');
+	});
+});
+
+describe('decideIndividualAuthoring', () => {
+	it('ALLOWS the 1st, 2nd, and 3rd template in a month', () => {
+		expect(decideIndividualAuthoring(0, JAN_15).ok).toBe(true);
+		expect(decideIndividualAuthoring(1, JAN_15).ok).toBe(true);
+		expect(decideIndividualAuthoring(2, JAN_15).ok).toBe(true);
+	});
+
+	it('BLOCKS the 4th creation in the same month (3 already authored)', () => {
+		const d = decideIndividualAuthoring(3, JAN_15);
+		expect(d.ok).toBe(false);
+		if (!d.ok) {
+			expect(d.message).toContain('3 free messages this month');
+			expect(d.message).toContain('resets 2026-02-01');
+			expect(d.message).toContain('Higher-volume individual authoring is coming');
+		}
+	});
+
+	it('stays blocked beyond the cap', () => {
+		expect(decideIndividualAuthoring(4, JAN_15).ok).toBe(false);
+		expect(decideIndividualAuthoring(99, JAN_15).ok).toBe(false);
+	});
+});

--- a/tests/unit/email-report-template.test.ts
+++ b/tests/unit/email-report-template.test.ts
@@ -141,12 +141,17 @@ describe('renderReport', () => {
 		expect(r.text).not.toContain('VERIFICATION REPORT');
 	});
 
-	it('elevates the individually-composed signal as a headline-adjacent line', async () => {
+	it('elevates the personalized signal as a headline-adjacent line', async () => {
 		const r = await renderReport(baseCtx);
 		// authorship.individual = 800 → surfaced near the big number, not only
-		// in the breakdown rows.
-		expect(r.html).toContain('800 individually composed messages');
-		expect(r.text).toContain('800 individually composed messages');
+		// in the breakdown rows. Labeled "personalized" (edited-vs-verbatim CMF
+		// signal), NOT "individually composed" — the metric does not measure AI
+		// authoring, so the label must not imply it.
+		expect(r.html).toContain('800 personalized messages');
+		expect(r.text).toContain('800 personalized messages');
+		// Guard against regression to the misleading AI-authoring framing.
+		expect(r.html).not.toContain('individually composed');
+		expect(r.text).not.toContain('individually composed');
 	});
 
 	it('softens the attestation footer to a watermark (text version)', async () => {

--- a/tests/unit/networks/coalition-create-gate.test.ts
+++ b/tests/unit/networks/coalition-create-gate.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Coalition-tier gate on coalition-network CREATE.
+ *
+ * Before this fix, `convex/networks.ts:create` required owner-role ONLY — any
+ * org owner (including the gated `inactive` floor) could mint a coalition
+ * network, bypassing the Coalition paywall. The mutation now resolves the org's
+ * effective plan and rejects creation unless it is an active/trialing Coalition
+ * plan. The SvelteKit endpoint pre-checks the same predicate for a clean 403,
+ * but the MUTATION is the fence (a public Convex mutation is callable directly,
+ * so an endpoint-only check is bypassable).
+ *
+ * The gate predicate the handler applies is exactly:
+ *     isCoalitionPlan(effectivePlan(subscriptionRow))
+ *
+ * These tests pin that predicate at the pure-helper level — the same SSOT the
+ * Convex handler delegates to (matching the branding-gate test strategy, since
+ * the repo has no live convex-test harness).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { effectivePlan, isCoalitionPlan } from '../../../convex/_brandingGate';
+
+/** The exact decision the `networks.create` mutation makes. */
+function coalitionCreateAllowed(sub: { status?: string; plan?: string } | null | undefined): boolean {
+	return isCoalitionPlan(effectivePlan(sub));
+}
+
+describe('coalition-network create gate', () => {
+	it('BLOCKS a non-Coalition org owner — inactive floor', () => {
+		// No subscription row at all (the un-paid `inactive` floor).
+		expect(coalitionCreateAllowed(null)).toBe(false);
+		expect(coalitionCreateAllowed(undefined)).toBe(false);
+	});
+
+	it('BLOCKS a non-Coalition org owner — starter / organization tiers', () => {
+		expect(coalitionCreateAllowed({ status: 'active', plan: 'starter' })).toBe(false);
+		expect(coalitionCreateAllowed({ status: 'active', plan: 'organization' })).toBe(false);
+		expect(coalitionCreateAllowed({ status: 'trialing', plan: 'organization' })).toBe(false);
+	});
+
+	it('BLOCKS a Coalition plan whose subscription is not active/trialing', () => {
+		// effectivePlan downgrades canceled/past_due to the inactive floor, so a
+		// lapsed Coalition org cannot keep minting networks.
+		expect(coalitionCreateAllowed({ status: 'canceled', plan: 'coalition' })).toBe(false);
+		expect(coalitionCreateAllowed({ status: 'past_due', plan: 'coalition' })).toBe(false);
+	});
+
+	it('ALLOWS an active or trialing Coalition org', () => {
+		expect(coalitionCreateAllowed({ status: 'active', plan: 'coalition' })).toBe(true);
+		expect(coalitionCreateAllowed({ status: 'trialing', plan: 'coalition' })).toBe(true);
+	});
+});


### PR DESCRIPTION
Four grounded changes from the org-tier-justification audit. do→review→fix (review approved, no required fixes; 4 LOW issues noted below).

## 1. Coalition paywall bypass — CLOSED (the verified revenue leak)
`convex/networks.ts` `create` (the mutation = the real fence, since public Convex mutations are directly callable) now gates on `isCoalitionPlan(effectivePlan(sub))` — active/trialing Coalition only — via a new `resolveOrgPlan` helper mirroring `organizations.ts`. The `POST /api/org/[slug]/networks` endpoint pre-checks for a clean 403. Test: non-Coalition owner blocked at the mutation; Coalition allowed.

## 2. Honest report label
`individually composed` → `personalized` everywhere the `authorship.individual` (edited-vs-verbatim) metric renders (report-template, ReturnSpace, the 3 /for/ specimen rows, packet doc comments). The metric stays (it's a real CMF personalization signal); only the label that implied AI authorship changed. **Attestation hash untouched** (0 hash-logic lines in the diff; stability test passes).

## 3. Reframe sweep
grep confirmed prior PRs (#31-35) already cured org-side per-supporter AI-individualization claims; no further corrections needed.

## 4. L1 individual authoring cap (3/mo) — the COGS control
Per-user monthly cap on NEW individual template creation (the ~$0.12-0.22 grounded-authoring op), in the no-org branch of `createTemplate`. Query-time aggregation (`templates.by_userId` + `_creationTime` ≥ start-of-month — not a counter). Acting on / sending existing templates stays uncapped. Refines "individuals free forever" → free to ACT, bounded on AI GENERATION. Test: 4th creation blocked, action path uncapped.

## Evidence
convex tsc 0 · `npm run check` 0 · 48/48 targeted + 42/42 regression.

## LOW (non-blocking, noted)
(a) endpoint vs mutation grace-period predicate edge (mutation is the fence, correct); (b) cap counts moderation-rejected drafts against the 3 (tiny — could skip rejected); (c) the at-cap message says "higher-volume authoring is coming" (true — L2 is designed, pending your pricing call); (d) one rhetorical "individually composed" question on a /for/ page (a distinction, not a system claim).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Individual users can now create up to 3 templates per month on the free tier.
  * Coalition network creation now requires a Coalition subscription plan.

* **Improvements**
  * Added server-side validation for subscription plan eligibility.

* **Documentation**
  * Updated terminology from "individually composed" to "personalized" across the application.

* **Tests**
  * Added unit test coverage for individual authoring cap validation and coalition network creation gates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->