### PR TITLE
L2 individual paid authoring (Voice $7/20, Advocate $20/75)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -389,11 +389,16 @@ STRIPE_SECRET_KEY=
 #   customer.subscription.deleted, invoice.payment_succeeded, invoice.payment_failed
 STRIPE_WEBHOOK_SECRET=
 
-# Stripe Price IDs for each plan tier
+# Stripe Price IDs for each ORG plan tier
 # Create products+prices at: https://dashboard.stripe.com/products
 STRIPE_PRICE_STARTER=
 STRIPE_PRICE_ORGANIZATION=
 STRIPE_PRICE_COALITION=
+
+# Stripe Price IDs for INDIVIDUAL (person-layer) paid authoring tiers
+# Voice = $7/mo (20 authored/mo), Advocate = $20/mo (75 authored/mo)
+STRIPE_PRICE_VOICE=
+STRIPE_PRICE_ADVOCATE=
 
 
 # ============================================================================

--- a/convex/_individualAuthoringCap.ts
+++ b/convex/_individualAuthoringCap.ts
@@ -1,22 +1,62 @@
 /**
- * Pure helpers for the L1 individual AI-authoring cap.
+ * Pure helpers for the individual AI-authoring cap (the L2 metered surface).
  *
  * Individuals are free forever to ACT on existing messages (send, sign,
  * personalize-and-deliver). What carries real LLM COGS is AI-AUTHORING a NEW
  * template (the person-layer TemplateCreator runs the subject + grounded
  * decision-maker resolution + grounded message generation, ~$0.12–0.22 each).
- * So the free tier is bounded on GENERATION, not action: an individual may
- * author up to FREE_INDIVIDUAL_TEMPLATES_PER_MONTH new templates per calendar
- * month. Acting on / sending templates is never gated by this.
+ * So the person layer is bounded on GENERATION, not action: an individual may
+ * author up to their plan's authored-per-month limit. The free floor is
+ * FREE_INDIVIDUAL_TEMPLATES_PER_MONTH (3); paid individual tiers (Voice/Advocate)
+ * raise ONLY this limit — see src/lib/server/billing/plans.ts INDIVIDUAL_PLANS.
+ * Acting on / sending templates is never gated by this.
+ *
+ * The template-creation count IS the meter: the Convex handler reads the user's
+ * month-to-date template count via the `templates.by_userId` index and the
+ * effective limit from their subscription plan, then delegates the allow/deny
+ * decision here. There is no separate counter — this is query-time aggregation
+ * from timestamped rows.
  *
  * These functions live here (not inline in the mutation) so the cap's count
  * math + message are unit-testable without a live Convex context, mirroring
- * `_brandingGate.ts`. The Convex handler reads the user's month-to-date count
- * via the `templates.by_userId` index and delegates the decision here.
+ * `_brandingGate.ts`.
  */
 
-/** Free individual AI-authored templates per calendar month. */
+/** Free individual AI-authored templates per calendar month (the free floor). */
 export const FREE_INDIVIDUAL_TEMPLATES_PER_MONTH = 3;
+
+/**
+ * Authored-per-month limit by INDIVIDUAL plan slug. Mirrors
+ * `INDIVIDUAL_PLANS[*].authoredPerMonth` in src/lib/server/billing/plans.ts
+ * (the canonical source — kept in sync there; this Convex-side copy exists only
+ * because templates.ts cannot import SvelteKit server code).
+ *
+ * Deliberately holds ONLY individual slugs. Org slugs
+ * (starter/organization/coalition/inactive) are absent so they can never be
+ * honored by the individual cap — an org plan slug resolves to the free floor.
+ */
+export const INDIVIDUAL_AUTHORED_PER_MONTH: Record<string, number> = {
+	voice: 20,
+	advocate: 75
+};
+
+/**
+ * Effective authored-per-month limit for an individual given their subscription
+ * plan slug. Falls back to the free floor (3) when the user has no individual
+ * sub, an org slug leaks in, or the slug is unknown — the individual cap must
+ * never honor an org plan and an unknown slug must never grant MORE than floor.
+ */
+export function authoredLimitForPlan(plan: string | null | undefined): number {
+	if (!plan) return FREE_INDIVIDUAL_TEMPLATES_PER_MONTH;
+	return INDIVIDUAL_AUTHORED_PER_MONTH[plan] ?? FREE_INDIVIDUAL_TEMPLATES_PER_MONTH;
+}
+
+/**
+ * Coded prefix the mutation throws so the SvelteKit route can recognize the
+ * authoring-quota block and surface the at-cap upgrade card, distinct from the
+ * org `TEMPLATE_QUOTA_EXCEEDED`. The human message follows the colon.
+ */
+export const AUTHORING_QUOTA_EXCEEDED = 'AUTHORING_QUOTA_EXCEEDED';
 
 /**
  * Start-of-calendar-month epoch ms (UTC) for `now`. Used as the query-time
@@ -45,11 +85,18 @@ export function nextMonthResetDate(now: number): string {
 
 /**
  * Decide whether an individual (no org membership) may author one more template
- * this month, given how many they have ALREADY created month-to-date.
+ * this month, given how many they have ALREADY created month-to-date and their
+ * effective monthly limit (their plan's `authoredPerMonth`, default the free
+ * floor of 3).
  *
  * `monthToDateCount` is the count of the user's own templates created since
  * `startOfMonthUTC(now)`. The NEW template would be the `monthToDateCount + 1`
- * th, so we block once the existing count has reached the free allowance.
+ * th, so we block once the existing count has reached `limit`.
+ *
+ * `limit` defaults to FREE_INDIVIDUAL_TEMPLATES_PER_MONTH so the free-floor
+ * behavior (and its test contract) is unchanged when no plan limit is supplied.
+ * Paid individual tiers pass their higher `authoredPerMonth`. The denial message
+ * is plan-aware: the free floor offers an upgrade, paid tiers report the limit.
  */
 export type IndividualCapDecision =
 	| { ok: true }
@@ -57,15 +104,19 @@ export type IndividualCapDecision =
 
 export function decideIndividualAuthoring(
 	monthToDateCount: number,
-	now: number
+	now: number,
+	limit: number = FREE_INDIVIDUAL_TEMPLATES_PER_MONTH
 ): IndividualCapDecision {
-	if (monthToDateCount < FREE_INDIVIDUAL_TEMPLATES_PER_MONTH) {
+	if (monthToDateCount < limit) {
 		return { ok: true };
 	}
-	return {
-		ok: false,
-		message: `You've authored your ${FREE_INDIVIDUAL_TEMPLATES_PER_MONTH} free messages this month — resets ${nextMonthResetDate(
-			now
-		)}. Higher-volume individual authoring is coming.`
-	};
+	const reset = nextMonthResetDate(now);
+	// Free floor: the message invites an upgrade (the L2 path). Paid tiers: the
+	// message states the plan limit and the reset, no upgrade ask (Advocate is
+	// the top individual tier).
+	const isFreeFloor = limit <= FREE_INDIVIDUAL_TEMPLATES_PER_MONTH;
+	const message = isFreeFloor
+		? `You've authored your ${limit} free messages this month — resets ${reset}. Upgrade to Voice or Advocate for higher-volume authoring.`
+		: `You've authored your ${limit} messages for this billing period — resets ${reset}.`;
+	return { ok: false, message };
 }

--- a/convex/_validators.ts
+++ b/convex/_validators.ts
@@ -103,9 +103,16 @@ export const subscriptionPlan = v.union(
 	// marketed tier (absent from PLAN_ORDER), but a persisted plan value the
 	// cancellation path writes, so it must validate.
 	v.literal('inactive'),
+	// Org (org-layer) plans — keyed on orgId.
 	v.literal('starter'),
 	v.literal('organization'),
-	v.literal('coalition')
+	v.literal('coalition'),
+	// Individual (person-layer) paid authoring tiers — keyed on userId. These buy
+	// ONLY authoring volume; they never carry org quotas. The polymorphic
+	// subscriptions.plan field stores these for user-scoped rows, so they must
+	// validate here. See src/lib/server/billing/plans.ts INDIVIDUAL_PLANS.
+	v.literal('voice'),
+	v.literal('advocate')
 );
 
 export const subscriptionStatus = v.union(

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -140,7 +140,13 @@ export default defineSchema({
 		location: v.optional(v.string()),
 		connection: v.optional(v.string()),
 		profileCompletedAt: v.optional(v.number()),
-		profileVisibility: v.string() // 'private' | 'public'
+		profileVisibility: v.string(), // 'private' | 'public'
+
+		// Stripe customer for individual (person-layer) paid authoring tiers.
+		// Mirrors organizations.stripeCustomerId so the individual checkout can
+		// find-or-create one Stripe customer per user and the webhook can resolve
+		// the user from the customer. Org subs use organizations.stripeCustomerId.
+		stripeCustomerId: v.optional(v.string())
 	})
 		.index('by_tokenIdentifier', ['tokenIdentifier'])
 		.index('by_email', ['email'])
@@ -150,7 +156,8 @@ export default defineSchema({
 		.index('by_passkeyCredentialId', ['passkeyCredentialId'])
 		.index('by_didKey', ['didKey'])
 		.index('by_walletAddress', ['walletAddress'])
-		.index('by_nearAccountId', ['nearAccountId']),
+		.index('by_nearAccountId', ['nearAccountId'])
+		.index('by_stripeCustomerId', ['stripeCustomerId']),
 
 	sessions: defineTable({
 		userId: v.id('users'),
@@ -2136,9 +2143,15 @@ export default defineSchema({
 		// the gated floor (unsubscribed/canceled), not a marketed tier.
 		plan: v.union(
 			v.literal('inactive'),
+			// Org (org-layer) plans — keyed on orgId.
 			v.literal('starter'),
 			v.literal('organization'),
-			v.literal('coalition')
+			v.literal('coalition'),
+			// Individual (person-layer) paid authoring tiers — keyed on userId.
+			// They buy ONLY authoring volume; the org-quota fields above are never
+			// synced for these. See src/lib/server/billing/plans.ts INDIVIDUAL_PLANS.
+			v.literal('voice'),
+			v.literal('advocate')
 		),
 		planDescription: v.optional(v.string()),
 		priceCents: v.number(),

--- a/convex/subscriptions.ts
+++ b/convex/subscriptions.ts
@@ -34,6 +34,19 @@ const PLANS: Record<
   coalition: { priceCents: 20_000, maxSeats: 25, maxTemplatesMonth: 1_000, maxVerifiedActions: 10_000, maxEmails: 250_000, maxSms: 50_000 },
 };
 
+// Individual (person-layer) paid authoring tiers — mirrored from
+// src/lib/server/billing/plans.ts INDIVIDUAL_PLANS (MUST stay in sync).
+// DELIBERATELY SEPARATE from org PLANS above: individual plans carry ONLY
+// `priceCents` + `authoredPerMonth`. They have NO org quotas (no maxEmails /
+// maxSms / maxSeats / maxTemplatesMonth) — an individual sub never syncs org
+// limits. The org `checkPlanLimits` path reads PLANS (keyed on orgId); the
+// individual authoring cap (templates.ts) reads the per-plan authored limit. The
+// two maps never overlap, so neither scope can read the other's plans.
+const INDIVIDUAL_PLANS: Record<string, { priceCents: number; authoredPerMonth: number }> = {
+  voice: { priceCents: 700, authoredPerMonth: 20 },
+  advocate: { priceCents: 2_000, authoredPerMonth: 75 },
+};
+
 /**
  * Verified actions within the current billing period — scale-safe.
  *
@@ -216,6 +229,76 @@ export const getByUser = query({
       paymentMethod: sub.paymentMethod,
       updatedAt: sub.updatedAt,
     };
+  },
+});
+
+/**
+ * Billing context for an individual (person-layer) paid authoring sub.
+ *
+ * Returns the caller's userId, their Stripe customer id (if any), and their
+ * current individual subscription summary. Used by the individual checkout
+ * route to find-or-create the Stripe customer and to guard against duplicate /
+ * downgrade checkout. User-scoped only — never touches org state.
+ */
+export const getMyBillingContext = query({
+  args: {},
+  handler: async (ctx) => {
+    const { userId } = await requireAuth(ctx);
+    const user = await ctx.db.get(userId);
+
+    const sub = await ctx.db
+      .query("subscriptions")
+      .withIndex("by_userId", (idx) => idx.eq("userId", userId))
+      .first();
+
+    return {
+      userId,
+      email: user?.email ?? null,
+      stripeCustomerId: user?.stripeCustomerId ?? null,
+      subscription: sub
+        ? { plan: sub.plan, status: sub.status, stripeSubscriptionId: sub.stripeSubscriptionId ?? null }
+        : null,
+    };
+  },
+});
+
+/**
+ * Whether the authed user holds an effectively-active PAID individual
+ * (person-layer) subscription — Voice or Advocate, status active/trialing, or
+ * past_due within the 7-day grace. Used to raise the daily-global LLM
+ * circuit-breaker ceiling for paying authors (see llm-cost-protection.ts).
+ * Returns false for org plans / no sub.
+ */
+export const hasActivePaidIndividual = query({
+  args: {},
+  handler: async (ctx) => {
+    const { userId } = await requireAuth(ctx);
+    const sub = await ctx.db
+      .query("subscriptions")
+      .withIndex("by_userId", (idx) => idx.eq("userId", userId))
+      .first();
+    if (!sub) return false;
+    if (!INDIVIDUAL_PLANS[sub.plan]) return false; // org plan / unknown → not paid individual
+
+    const GRACE_PERIOD_MS = 7 * 24 * 60 * 60 * 1000;
+    const isWithinGrace =
+      sub.status === "past_due" &&
+      sub.pastDueSince !== undefined &&
+      Date.now() - sub.pastDueSince < GRACE_PERIOD_MS;
+    return sub.status === "active" || sub.status === "trialing" || isWithinGrace;
+  },
+});
+
+/**
+ * Persist the Stripe customer id on the user after the individual checkout
+ * route creates it. Auth-gated to the caller's own row.
+ */
+export const updateMyStripeCustomerId = mutation({
+  args: { stripeCustomerId: v.string() },
+  handler: async (ctx, args) => {
+    const { userId } = await requireAuth(ctx);
+    await ctx.db.patch(userId, { stripeCustomerId: args.stripeCustomerId });
+    return { success: true };
   },
 });
 
@@ -514,18 +597,30 @@ export const cancel = mutation({
       );
     }
 
-    await ctx.db.patch(args.subscriptionId, {
-      status: "canceled",
-      plan: "inactive",
-      updatedAt: Date.now(),
-    });
-
-    // Reset org limits to the gated inactive floor if org-scoped
     if (sub.orgId) {
+      // ORG sub: drop to the org gated floor ('inactive' is org-shaped —
+      // delivery 0, maxTemplatesMonth 2) and reset org limits.
+      await ctx.db.patch(args.subscriptionId, {
+        status: "canceled",
+        plan: "inactive",
+        updatedAt: Date.now(),
+      });
       const floorLimits = PLANS.inactive;
       await ctx.db.patch(sub.orgId, {
         maxSeats: floorLimits.maxSeats,
         maxTemplatesMonth: floorLimits.maxTemplatesMonth,
+        updatedAt: Date.now(),
+      });
+    } else {
+      // INDIVIDUAL sub: 'inactive' is the ORG floor (delivery 0 / no authored
+      // limit) — it would be a semantic mismatch on a user row. The individual
+      // free floor is "no active sub → 3 authored/mo", which the authoring cap
+      // derives from a non-active status. So we mark the sub canceled and LEAVE
+      // the individual plan slug intact: the cap reads the plan only when the
+      // status is effectively active, so a canceled individual sub resolves to
+      // the free floor (3) without writing the org-shaped 'inactive' value.
+      await ctx.db.patch(args.subscriptionId, {
+        status: "canceled",
         updatedAt: Date.now(),
       });
     }
@@ -555,23 +650,41 @@ export const processStripeWebhook = internalAction({
         const session = data;
         if (session.mode !== "subscription" || !session.subscription) break;
 
-        const orgId = session.metadata?.orgId;
         const plan = session.metadata?.plan;
-        if (!orgId || !plan || !PLANS[plan]) break;
+        const orgId = session.metadata?.orgId;
+        const userId = session.metadata?.userId;
 
         // Use session.created (Stripe timestamp in seconds) for period start.
         // The subsequent subscription.updated event will correct to exact Stripe periods.
         const periodStartMs = (session.created ?? Math.floor(Date.now() / 1000)) * 1000;
 
-        await ctx.runMutation(internal.subscriptions.upsertFromStripe, {
-          orgId,
-          plan,
-          priceCents: PLANS[plan].priceCents,
-          status: "active",
-          stripeSubscriptionId: session.subscription,
-          currentPeriodStart: periodStartMs,
-          currentPeriodEnd: periodStartMs + 30 * 24 * 60 * 60 * 1000,
-        });
+        // INDIVIDUAL (person-layer) checkout: metadata.userId + an individual
+        // plan. User-scoped upsert, NO org-limit sync.
+        if (userId && plan && INDIVIDUAL_PLANS[plan]) {
+          await ctx.runMutation(internal.subscriptions.upsertIndividualFromStripe, {
+            userId,
+            plan,
+            priceCents: INDIVIDUAL_PLANS[plan].priceCents,
+            status: "active",
+            stripeSubscriptionId: session.subscription,
+            currentPeriodStart: periodStartMs,
+            currentPeriodEnd: periodStartMs + 30 * 24 * 60 * 60 * 1000,
+          });
+          break;
+        }
+
+        // ORG checkout: metadata.orgId + a marketed org plan. Syncs org limits.
+        if (orgId && plan && PLANS[plan]) {
+          await ctx.runMutation(internal.subscriptions.upsertFromStripe, {
+            orgId,
+            plan,
+            priceCents: PLANS[plan].priceCents,
+            status: "active",
+            stripeSubscriptionId: session.subscription,
+            currentPeriodStart: periodStartMs,
+            currentPeriodEnd: periodStartMs + 30 * 24 * 60 * 60 * 1000,
+          });
+        }
         break;
       }
 
@@ -594,14 +707,23 @@ export const processStripeWebhook = internalAction({
           ? sub.current_period_end * 1000
           : undefined;
 
+        // Accept BOTH org and individual plan slugs as valid plan changes (e.g.
+        // a Stripe-portal voice→advocate switch). Only request org-limit sync
+        // for ORG plans; individual plans never sync org limits — and
+        // updateByStripeId additionally gates the sync on `sub.orgId`, so even
+        // if requested it cannot touch a user-scoped sub.
+        const isOrgPlan = !!(plan && PLANS[plan]);
+        const isIndividualPlan = !!(plan && INDIVIDUAL_PLANS[plan]);
+        const validPlan = isOrgPlan || isIndividualPlan;
+
         await ctx.runMutation(internal.subscriptions.updateByStripeId, {
           stripeSubscriptionId: sub.id,
           status: effectiveStatus,
-          plan: plan && PLANS[plan] ? plan : undefined,
+          plan: validPlan ? plan : undefined,
           priceCents,
           currentPeriodStart: periodStart,
           currentPeriodEnd: periodEnd,
-          syncOrgLimits: plan && PLANS[plan] ? true : undefined,
+          syncOrgLimits: isOrgPlan ? true : undefined,
         });
         break;
       }
@@ -799,6 +921,74 @@ export const upsertFromStripe = internalMutation({
     // Snapshot the verified-action billing baseline for the new period so the
     // metering read is O(1) (no scan) for this paid org going forward.
     await snapshotVerifiedActionBaseline(ctx, org._id, args.currentPeriodStart);
+  },
+});
+
+/**
+ * Upsert an INDIVIDUAL (person-layer) subscription from Stripe checkout
+ * completion. User-scoped: keyed on userId, writes the individual plan
+ * (voice/advocate) onto a by_userId subscription row, and does NOT run any
+ * org-limit sync or verified-action baseline snapshot (those are org-only). The
+ * individual authoring cap reads this sub's plan to size the authored-per-month
+ * allowance; nothing else is unlocked.
+ */
+export const upsertIndividualFromStripe = internalMutation({
+  args: {
+    userId: v.string(),
+    plan: subscriptionPlan,
+    priceCents: v.number(),
+    status: subscriptionStatus,
+    stripeSubscriptionId: v.string(),
+    currentPeriodStart: v.number(),
+    currentPeriodEnd: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const userId = args.userId as Id<"users">;
+    const user = await ctx.db.get(userId);
+    if (!user) {
+      console.warn(`[subscriptions] User not found for Stripe webhook: ${args.userId}`);
+      return;
+    }
+    // Guard: only individual plans may be written to a user-scoped sub. An org
+    // plan slug arriving on a userId checkout is a metadata mismatch — refuse it
+    // rather than silently granting org-shaped state to an individual row.
+    if (!INDIVIDUAL_PLANS[args.plan]) {
+      console.warn(`[subscriptions] Non-individual plan "${args.plan}" on user checkout — ignoring`);
+      return;
+    }
+
+    const existing = await ctx.db
+      .query("subscriptions")
+      .withIndex("by_userId", (idx) => idx.eq("userId", userId))
+      .first();
+
+    const now = Date.now();
+
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        plan: args.plan,
+        priceCents: args.priceCents,
+        status: args.status,
+        stripeSubscriptionId: args.stripeSubscriptionId,
+        currentPeriodStart: args.currentPeriodStart,
+        currentPeriodEnd: args.currentPeriodEnd,
+        updatedAt: now,
+      });
+    } else {
+      await ctx.db.insert("subscriptions", {
+        userId,
+        plan: args.plan,
+        priceCents: args.priceCents,
+        status: args.status,
+        paymentMethod: "stripe",
+        stripeSubscriptionId: args.stripeSubscriptionId,
+        currentPeriodStart: args.currentPeriodStart,
+        currentPeriodEnd: args.currentPeriodEnd,
+        updatedAt: now,
+      });
+    }
+    // NOTE: no org-limit sync, no verified-action baseline. Individual subs buy
+    // ONLY authoring volume (read off this row by the templates.ts cap).
   },
 });
 

--- a/convex/templates.ts
+++ b/convex/templates.ts
@@ -7,6 +7,8 @@ import { requireAuth, requireOrgRole, loadOrg } from "./_authHelpers";
 import {
   startOfMonthUTC,
   decideIndividualAuthoring,
+  authoredLimitForPlan,
+  AUTHORING_QUOTA_EXCEEDED,
 } from "./_individualAuthoringCap";
 import anchorsData from "./domain-anchors.json";
 
@@ -1004,25 +1006,52 @@ export const createTemplate = mutation({
         }
       }
     } else {
-      // L1 individual AI-authoring cap. Individuals are free forever to ACT on
-      // existing messages; the bound is on AI-AUTHORING NEW templates (the
-      // expensive person-layer TemplateCreator generation path). Org members
-      // are governed by their plan's maxTemplatesMonth above, so this only
-      // applies to the un-orged individual path.
+      // Individual AI-authoring cap (the L2 metered surface). Individuals are
+      // free forever to ACT on existing messages; the bound is on AI-AUTHORING
+      // NEW templates (the expensive person-layer TemplateCreator generation
+      // path). Org members are governed by their plan's maxTemplatesMonth above,
+      // so this only applies to the un-orged individual path.
       //
-      // Query-time aggregation from timestamped rows (templates.by_userId +
-      // _creationTime >= start-of-month), mirroring the billing pattern — NOT a
-      // denormalized counter that needs resetting.
+      // The limit is DYNAMIC: read the user's individual subscription plan and
+      // resolve its authored-per-month allowance (free floor 3, Voice 20,
+      // Advocate 75). The template-creation count IS the meter — query-time
+      // aggregation from timestamped rows (templates.by_userId + _creationTime
+      // >= start-of-month), mirroring the billing pattern, NOT a denormalized
+      // counter that needs resetting.
       const now = Date.now();
+
+      // Resolve the user's effective individual authored limit. Only honor the
+      // plan when the sub is effectively active (active/trialing, or past_due
+      // within a 7-day grace) — otherwise fall to the free floor. The sub is
+      // user-scoped (by_userId); org-scoped subs never reach this branch (those
+      // users have an orgMembership and take the maxTemplatesMonth path above).
+      const sub = await ctx.db
+        .query("subscriptions")
+        .withIndex("by_userId", (q) => q.eq("userId", args.userId))
+        .first();
+      const GRACE_PERIOD_MS = 7 * 24 * 60 * 60 * 1000;
+      const isWithinGrace =
+        sub?.status === "past_due" &&
+        sub.pastDueSince !== undefined &&
+        now - sub.pastDueSince < GRACE_PERIOD_MS;
+      const effectivelyActive =
+        sub?.status === "active" || sub?.status === "trialing" || isWithinGrace;
+      // authoredLimitForPlan resolves org slugs + unknowns to the free floor,
+      // so an individual sub can NEVER unlock an org plan's volume here.
+      const limit = effectivelyActive
+        ? authoredLimitForPlan(sub?.plan)
+        : authoredLimitForPlan(null);
+
       const monthStart = startOfMonthUTC(now);
       const monthToDate = await ctx.db
         .query("templates")
         .withIndex("by_userId", (q) => q.eq("userId", args.userId))
         .filter((q) => q.gte(q.field("_creationTime"), monthStart))
         .collect();
-      const decision = decideIndividualAuthoring(monthToDate.length, now);
+      const decision = decideIndividualAuthoring(monthToDate.length, now, limit);
       if (!decision.ok) {
-        throw new Error(decision.message);
+        // Coded throw so the SvelteKit route surfaces the at-cap upgrade card.
+        throw new Error(`${AUTHORING_QUOTA_EXCEEDED}:${decision.message}`);
       }
     }
 

--- a/src/lib/components/billing/AuthoringUpgradeCard.svelte
+++ b/src/lib/components/billing/AuthoringUpgradeCard.svelte
@@ -1,0 +1,161 @@
+<script lang="ts">
+	/**
+	 * At-cap upgrade card for the individual (person-layer) AI-authoring limit.
+	 *
+	 * Surfaced when a free-floor user hits the monthly authoring cap (the server
+	 * throws AUTHORING_QUOTA_EXCEEDED). Individual tiers buy ONLY more authoring
+	 * volume — never org tooling — so this card sells exactly that: Voice
+	 * ($7/mo, 20 authored) and Advocate ($20/mo, 75 authored). Clicking a tier
+	 * POSTs to /api/billing/checkout-individual and redirects to Stripe Checkout.
+	 *
+	 * The display price/volume here is presentation copy. The canonical source is
+	 * INDIVIDUAL_PLANS in src/lib/server/billing/plans.ts (server-only), enforced
+	 * by the dynamic authoring cap + plan-sync.test.ts.
+	 */
+
+	interface Props {
+		/** Plan-aware copy from the server (the message after the coded prefix). */
+		message?: string | null;
+		/** Dismiss the card. */
+		onclose?: () => void;
+	}
+
+	let { message = null, onclose }: Props = $props();
+
+	const TIERS = [
+		{ slug: 'voice', name: 'Voice', priceLabel: '$7/mo', authored: 20 },
+		{ slug: 'advocate', name: 'Advocate', priceLabel: '$20/mo', authored: 75 }
+	] as const;
+
+	let pending = $state<string | null>(null);
+	let checkoutError = $state<string | null>(null);
+
+	async function upgrade(plan: string) {
+		if (pending) return;
+		pending = plan;
+		checkoutError = null;
+		try {
+			const res = await fetch('/api/billing/checkout-individual', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ plan })
+			});
+			const body = (await res.json().catch(() => ({}))) as { url?: string; message?: string };
+			if (!res.ok || !body.url) {
+				checkoutError = body.message || 'Could not start checkout. Please try again.';
+				pending = null;
+				return;
+			}
+			// Redirect to Stripe Checkout.
+			window.location.href = body.url;
+		} catch {
+			checkoutError = 'Could not start checkout. Please try again.';
+			pending = null;
+		}
+	}
+</script>
+
+<div class="authoring-upgrade" role="group" aria-label="Upgrade authoring volume">
+	<p class="cap-message">
+		{message ?? "You've reached your monthly AI-authoring limit."}
+	</p>
+	<p class="cap-sub">Keep authoring this month — upgrade for higher-volume authoring.</p>
+
+	<div class="tiers">
+		{#each TIERS as tier (tier.slug)}
+			<button
+				type="button"
+				class="tier"
+				disabled={pending !== null}
+				onclick={() => upgrade(tier.slug)}
+			>
+				<span class="tier-name">{tier.name}</span>
+				<span class="tier-price">{tier.priceLabel}</span>
+				<span class="tier-volume">{tier.authored} messages / month</span>
+				{#if pending === tier.slug}
+					<span class="tier-pending">Redirecting…</span>
+				{/if}
+			</button>
+		{/each}
+	</div>
+
+	{#if checkoutError}
+		<p class="checkout-error" role="alert">{checkoutError}</p>
+	{/if}
+
+	{#if onclose}
+		<button type="button" class="dismiss" onclick={onclose}>Maybe later</button>
+	{/if}
+</div>
+
+<style>
+	.authoring-upgrade {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+		padding: 1rem;
+		border: 1px solid var(--border, #e2e8f0);
+		border-radius: 0.75rem;
+		background: var(--surface, #fff);
+	}
+	.cap-message {
+		font-weight: 600;
+		margin: 0;
+	}
+	.cap-sub {
+		margin: 0;
+		font-size: 0.875rem;
+		opacity: 0.8;
+	}
+	.tiers {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: 0.5rem;
+	}
+	.tier {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+		padding: 0.75rem;
+		border: 1px solid var(--border, #e2e8f0);
+		border-radius: 0.5rem;
+		background: transparent;
+		cursor: pointer;
+		text-align: left;
+	}
+	.tier:hover:not(:disabled) {
+		border-color: var(--accent, #2563eb);
+	}
+	.tier:disabled {
+		opacity: 0.6;
+		cursor: default;
+	}
+	.tier-name {
+		font-weight: 600;
+	}
+	.tier-price {
+		font-size: 1rem;
+	}
+	.tier-volume {
+		font-size: 0.8125rem;
+		opacity: 0.75;
+	}
+	.tier-pending {
+		font-size: 0.75rem;
+		opacity: 0.7;
+	}
+	.checkout-error {
+		margin: 0;
+		font-size: 0.8125rem;
+		color: var(--error, #dc2626);
+	}
+	.dismiss {
+		align-self: flex-start;
+		background: none;
+		border: none;
+		font-size: 0.8125rem;
+		text-decoration: underline;
+		cursor: pointer;
+		opacity: 0.7;
+	}
+</style>

--- a/src/lib/core/agents/cogs-fanout.ts
+++ b/src/lib/core/agents/cogs-fanout.ts
@@ -1,0 +1,46 @@
+/**
+ * COGS-fanout guard for decision-maker resolution.
+ *
+ * Per-message COGS scales with the number of discovered roles/identities: each
+ * role drives an Exa identity search, then a per-identity contact search, then
+ * Firecrawl page reads, then chunked Gemini synthesis. Phase 1 (role discovery)
+ * is an unbounded LLM enumeration — a broad subject can return many roles, and
+ * the fanout (and its cost) grows ~linearly with that count. Without a bound a
+ * single authoring run could exceed the budgeted ~$0.22 ceiling.
+ *
+ * This guard caps the role count BEFORE the fanout begins, so the downstream
+ * Exa/Firecrawl/Gemini work is deterministically bounded regardless of how many
+ * roles Phase 1 enumerates. It lives in its own module (no Gemini/Exa imports)
+ * so the bound is unit-testable.
+ *
+ * Budget arithmetic (canonical prices in llm-cost-protection.ts API_PRICING):
+ * - Firecrawl reads are already capped at 20 (~$0.106 at $0.0053/read).
+ * - Exa searches: ~1 identity search + ~1 contact search per role
+ *   (~$0.007 each at $7/1K). At the cap below the Exa spend is bounded to
+ *   2 * MAX_DECISION_MAKER_FANOUT searches.
+ * - Gemini synthesis: chunked 3 identities/call, so calls scale with the cap.
+ *
+ * MAX_DECISION_MAKER_FANOUT = 12 keeps the worst-case external-API spend
+ * (~12*2 Exa ≈ $0.17 + 20 Firecrawl ≈ $0.106, minus cache hits) within the same
+ * order as the ~$0.22 budgeted ceiling while still surfacing a useful breadth of
+ * decision-makers. Guided/explicitly-targeted roles are kept first so a precise
+ * audience request is never truncated in favor of speculative breadth.
+ */
+export const MAX_DECISION_MAKER_FANOUT = 12;
+
+/**
+ * Bound a list of discovered roles to the COGS fanout cap. Stable: keeps the
+ * first `max` after sorting guided roles ahead of speculative ones (a guided
+ * role is one the user explicitly steered toward via audience guidance). Pure —
+ * does not mutate the input.
+ */
+export function capFanout<T extends { guided?: boolean }>(
+	roles: T[],
+	max: number = MAX_DECISION_MAKER_FANOUT
+): T[] {
+	if (roles.length <= max) return roles;
+	// Guided roles first (preserve precise targeting), then the rest in order.
+	const guided = roles.filter((r) => r.guided === true);
+	const rest = roles.filter((r) => r.guided !== true);
+	return [...guided, ...rest].slice(0, max);
+}

--- a/src/lib/core/agents/providers/gemini-provider.ts
+++ b/src/lib/core/agents/providers/gemini-provider.ts
@@ -34,6 +34,7 @@ import {
 	generateDomainContext,
 } from '../prompts/decision-maker';
 import { getCachedContacts, upsertResolvedContacts, normalizeOrgKey } from '../utils/contact-cache';
+import { capFanout, MAX_DECISION_MAKER_FANOUT } from '../cogs-fanout';
 import { extractJsonFromGroundingResponse, isSuccessfulExtraction } from '../utils/grounding-json';
 import { searchWeb, readPage, prunePageContent, type ExaPageContent } from '../exa-search';
 import {
@@ -1070,10 +1071,22 @@ export class GeminiDecisionMakerProvider implements DecisionMakerProvider {
 				throw new Error('Finding decision-makers hit a snag. Please try again.');
 			}
 
-			const roles: DiscoveredRole[] = extraction.data?.roles || [];
+			const discoveredRoles: DiscoveredRole[] = extraction.data?.roles || [];
+
+			// COGS-fanout guard: cap the role count before the Exa/Firecrawl/Gemini
+			// fanout so per-message COGS can't exceed the budgeted ~$0.22 ceiling.
+			// Phase 1 is an unbounded enumeration; the entire downstream cost scales
+			// with this count, so bounding it here bounds the whole resolution.
+			const roles = capFanout(discoveredRoles, MAX_DECISION_MAKER_FANOUT);
+			if (roles.length < discoveredRoles.length) {
+				console.debug(
+					`[gemini-provider] COGS-fanout guard: capped ${discoveredRoles.length} roles → ${roles.length} (max ${MAX_DECISION_MAKER_FANOUT})`
+				);
+			}
 
 			console.debug('[gemini-provider] Phase 1 complete:', {
 				rolesFound: roles.length,
+				rolesDiscovered: discoveredRoles.length,
 				positions: roles.map((r) => `${r.position} at ${r.organization}`)
 			});
 

--- a/src/lib/core/api/client.ts
+++ b/src/lib/core/api/client.ts
@@ -157,6 +157,29 @@ class UnifiedApiClient {
 				clearTimeout(timeoutId);
 				lastError = error instanceof Error ? error : new Error(String(error));
 
+				// Client errors (4xx) are not transient — fail fast WITHOUT retrying
+				// and surface the structured error (code via `errors[]`) to the
+				// caller. Retrying a 403 quota response is wasteful and would
+				// otherwise swallow the typed code (e.g. AUTHORING_QUOTA_EXCEEDED)
+				// the at-cap upgrade UX keys on. 429 still retries (rate-limit
+				// backoff is the intended behavior there).
+				if (
+					error instanceof ApiClientError &&
+					typeof error.status === 'number' &&
+					error.status >= 400 &&
+					error.status < 500 &&
+					error.status !== 429
+				) {
+					onLoadingChange?.(false);
+					if (showToast) toast.error(error.message);
+					return {
+						success: false,
+						error: error.message,
+						errors: error.errors,
+						status: error.status
+					};
+				}
+
 				// Don't retry on abort errors — for mutating requests the server
 				// may have already processed it (template publish, etc.)
 				if (error instanceof Error && error.name === 'AbortError') {

--- a/src/lib/server/billing/plans.ts
+++ b/src/lib/server/billing/plans.ts
@@ -83,10 +83,81 @@ export const PLANS: Record<string, PlanLimits> = {
 /**
  * Marketed plan slugs ordered by tier for upgrade/downgrade comparison.
  * `inactive` is deliberately excluded — it is the gated floor, not a tier.
+ *
+ * NOTE: individual plans (voice/advocate) are intentionally absent here. They
+ * are NOT org tiers — `checkPlanLimits` (keyed on orgId) and the org checkout
+ * (which validates against PLAN_ORDER) must never see them. They live in their
+ * own `INDIVIDUAL_PLANS` map below so the two billing scopes can never read
+ * each other's plans.
  */
 export const PLAN_ORDER = ['starter', 'organization', 'coalition'] as const;
 
 export function getPlanForOrg(subscription: { plan: string } | null): PlanLimits {
 	if (!subscription) return PLANS.inactive;
 	return PLANS[subscription.plan] ?? PLANS.inactive;
+}
+
+// ===========================================================================
+// INDIVIDUAL (PERSON-LAYER) PAID AUTHORING TIERS — fully separate from org PLANS
+// ===========================================================================
+//
+// Individuals are free forever to ACT (send/sign/personalize-and-deliver
+// existing messages). The only metered person-layer cost is NET-NEW AI
+// AUTHORING of a template (the grounded subject + decision-maker resolution +
+// message generation pipeline, ~$0.12–0.22 each). The free floor allows 3
+// authored templates per calendar month (the shipped L1 cap); paid individual
+// tiers buy ONLY more authoring volume.
+//
+// CRITICAL SEPARATION (issue 6): individual plans carry ONLY `authoredPerMonth`.
+// They DO NOT carry maxEmails / maxSms / maxSeats / maxTemplatesMonth — those
+// are org-only quotas and are NEVER unlocked by an individual subscription. The
+// individual authoring cap reads `authoredPerMonth` from this map; org
+// `checkPlanLimits` reads `maxEmails`/etc from `PLANS`. The two never overlap.
+export interface IndividualPlanLimits {
+	slug: string;
+	name: string;
+	priceCents: number;
+	stripePriceId: string;
+	/** AI-authored templates allowed per calendar month. The ONLY thing bought. */
+	authoredPerMonth: number;
+}
+
+/** Free floor for an un-subscribed individual: 3 authored templates / month. */
+export const FREE_INDIVIDUAL_AUTHORED_PER_MONTH = 3;
+
+export const INDIVIDUAL_PLANS: Record<string, IndividualPlanLimits> = {
+	voice: {
+		slug: 'voice',
+		name: 'Voice',
+		priceCents: 700,
+		get stripePriceId() {
+			return process.env.STRIPE_PRICE_VOICE || '';
+		},
+		authoredPerMonth: 20
+	},
+	advocate: {
+		slug: 'advocate',
+		name: 'Advocate',
+		priceCents: 2_000,
+		get stripePriceId() {
+			return process.env.STRIPE_PRICE_ADVOCATE || '';
+		},
+		authoredPerMonth: 75
+	}
+};
+
+/** Marketed individual tiers, cheapest first. Distinct from PLAN_ORDER (orgs). */
+export const INDIVIDUAL_PLAN_ORDER = ['voice', 'advocate'] as const;
+
+/**
+ * Authored-per-month limit for an individual given their subscription plan
+ * slug. Falls back to the free floor (3) when the user has no individual sub,
+ * an org-scoped plan slug leaks in, or the slug is unknown — the individual cap
+ * must never honor an org plan, and an unknown slug must never grant MORE than
+ * the floor. Org slugs (starter/organization/coalition/inactive) are not in
+ * INDIVIDUAL_PLANS, so they resolve to the floor here by design.
+ */
+export function authoredPerMonthForPlan(plan: string | null | undefined): number {
+	if (!plan) return FREE_INDIVIDUAL_AUTHORED_PER_MONTH;
+	return INDIVIDUAL_PLANS[plan]?.authoredPerMonth ?? FREE_INDIVIDUAL_AUTHORED_PER_MONTH;
 }

--- a/src/lib/server/llm-cost-protection.ts
+++ b/src/lib/server/llm-cost-protection.ts
@@ -85,6 +85,20 @@ const QUOTAS: Record<string, Record<LLMTrustTier, [number, number]>> = {
 	}
 };
 
+/**
+ * Daily-global circuit-breaker ceiling for a PAID individual (Voice/Advocate).
+ *
+ * The free daily ceilings above are an ABUSE breaker calibrated for free usage
+ * (~15/day verified). A paying Advocate (75 authored/mo) can legitimately burst
+ * on a heavy day and would otherwise be hard-blocked by the 15/day breaker. The
+ * real bound for paid individuals is their MONTHLY authored cap (enforced in
+ * convex/templates.ts), so the daily breaker is raised to the full top monthly
+ * allowance — high enough that a paying user is never blocked by the abuse
+ * breaker, while the monthly cap still bounds total COGS. Per-op limits
+ * (decision-makers/message-generation) still apply.
+ */
+const PAID_INDIVIDUAL_DAILY_GLOBAL: [number, number] = [75, 86400000];
+
 // ============================================
 // Trust Tier Resolution
 // ============================================
@@ -95,6 +109,15 @@ interface UserContext {
 	isVerified: boolean;
 	tier: LLMTrustTier;
 	identifier: string; // For rate limit key (userId or IP)
+	/**
+	 * True when the user holds an active paid individual authoring sub
+	 * (Voice/Advocate). Raises the daily-global circuit-breaker ceiling so a
+	 * paying user isn't hard-blocked by the free abuse breaker — their monthly
+	 * authored cap (convex/templates.ts) is the real bound. Optional: absent /
+	 * false means the free abuse ceiling applies. The caller sets it after
+	 * resolving the user's subscription.
+	 */
+	paidIndividual?: boolean;
 }
 
 /**
@@ -145,7 +168,8 @@ export function getUserContext(event: RequestEvent): UserContext {
 		isAuthenticated,
 		isVerified,
 		tier,
-		identifier: userId || `ip:${ip}`
+		identifier: userId || `ip:${ip}`,
+		paidIndividual: false
 	};
 }
 
@@ -219,8 +243,12 @@ export async function checkRateLimit(
 		};
 	}
 
-	// Also check daily global limit (circuit breaker)
-	const dailyQuota = QUOTAS['daily-global'][context.tier];
+	// Also check daily global limit (circuit breaker). Paid individuals get a
+	// raised ceiling so the free abuse breaker doesn't hard-block a paying user;
+	// their monthly authored cap (convex/templates.ts) is the real bound.
+	const dailyQuota = context.paidIndividual
+		? PAID_INDIVIDUAL_DAILY_GLOBAL
+		: QUOTAS['daily-global'][context.tier];
 	const dailyKey = `llm:daily:${context.identifier}`;
 	const dailyResult = await rateLimiter.limit(dailyKey, dailyQuota[0], dailyQuota[1]);
 
@@ -314,9 +342,11 @@ function getRateLimitReason(
  */
 export async function enforceLLMRateLimit(
 	event: RequestEvent,
-	operation: string
+	operation: string,
+	options?: { paidIndividual?: boolean }
 ): Promise<RateLimitCheck> {
 	const context = getUserContext(event);
+	if (options?.paidIndividual) context.paidIndividual = true;
 	const check = await checkRateLimit(operation, context);
 
 	if (!check.allowed) {

--- a/src/lib/stores/templates.svelte.ts
+++ b/src/lib/stores/templates.svelte.ts
@@ -2,6 +2,7 @@
 import type { Template } from '$lib/types/template';
 import { formatErrorMessage } from '$lib/utils/error-formatting';
 import { api, type ApiResponse } from '$lib/core/api';
+import { AppError, ERROR_CODES, type ApiError } from '$lib/types/errors';
 
 // Templates API wrapper (domain-specific response unwrapping)
 const templatesApi = {
@@ -310,6 +311,17 @@ function createTemplateStore() {
 				const result = await templatesApi.create(template);
 
 				if (!result.success) {
+					// Preserve the typed individual AI-authoring quota code so the
+					// at-cap upgrade card (Voice/Advocate) can be surfaced. The
+					// server stamps AUTHORING_QUOTA_EXCEEDED into errors[]; throw an
+					// AppError carrying it so the caller can branch on the code, not
+					// brittle message text.
+					const authoringQuota = (result.errors as ApiError[] | undefined)?.find(
+						(e) => e.code === ERROR_CODES.AUTHORING_QUOTA_EXCEEDED
+					);
+					if (authoringQuota) {
+						throw new AppError(authoringQuota);
+					}
 					throw new Error(result.error || 'Failed to create template');
 				}
 

--- a/src/lib/types/errors.ts
+++ b/src/lib/types/errors.ts
@@ -45,6 +45,9 @@ export const ERROR_CODES = {
 
 	// Billing errors
 	TEMPLATE_QUOTA_EXCEEDED: 'TEMPLATE_QUOTA_EXCEEDED',
+	// Individual (person-layer) AI-authoring cap — distinct from the org
+	// TEMPLATE_QUOTA so the client can surface the Voice/Advocate upgrade card.
+	AUTHORING_QUOTA_EXCEEDED: 'AUTHORING_QUOTA_EXCEEDED',
 
 	// Auth errors
 	AUTH_REQUIRED: 'AUTH_REQUIRED',
@@ -74,6 +77,8 @@ export const ERROR_MESSAGES = {
 	[ERROR_CODES.MODERATION_FAILED]: 'Content moderation failed',
 
 	[ERROR_CODES.TEMPLATE_QUOTA_EXCEEDED]: 'Monthly template quota exceeded. Please upgrade your plan.',
+	[ERROR_CODES.AUTHORING_QUOTA_EXCEEDED]:
+		"You've reached your monthly AI-authoring limit. Upgrade to Voice or Advocate for higher-volume authoring.",
 
 	[ERROR_CODES.AUTH_REQUIRED]: 'Please sign in to continue',
 	[ERROR_CODES.AUTH_INVALID_TOKEN]: 'Your session has expired. Please sign in again.',

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -30,6 +30,8 @@
 	import type { ModalComponent } from '$lib/types/component-props';
 
 	import TemplateCreator from '$lib/components/template/TemplateCreator.svelte';
+	import AuthoringUpgradeCard from '$lib/components/billing/AuthoringUpgradeCard.svelte';
+	import { AppError, ERROR_CODES } from '$lib/types/errors';
 	import { CreationSpark, CoordinationExplainer } from '$lib/components/activation';
 	import LocationScopeBar from '$lib/components/template-browser/LocationScopeBar.svelte';
 	import { guestState } from '$lib/stores/guestState.svelte';
@@ -78,6 +80,9 @@
 	let templatePublishError = $state<string | null>(null);
 	let pendingPublishData = $state<Omit<Template, 'id'> | null>(null);
 	let userInitiatedSelection = $state(false);
+	// At-cap individual AI-authoring upgrade card (Voice/Advocate).
+	let showAuthoringUpgrade = $state(false);
+	let authoringCapMessage = $state<string | null>(null);
 
 	// Location scope state (user-selected geographic filter for templates)
 	const SCOPE_KEY = 'commons_location_scope';
@@ -131,8 +136,19 @@
 							.then(() => {
 								sessionStorage.removeItem('pending_template_save');
 							})
-							.catch((_error) => {
-								// Template save failed - user can retry later
+							.catch((error) => {
+								// Post-auth resume: if the user is at their individual
+								// authoring cap, surface the Voice/Advocate upgrade card
+								// rather than silently dropping the publish.
+								if (
+									error instanceof AppError &&
+									error.apiError.code === ERROR_CODES.AUTHORING_QUOTA_EXCEEDED
+								) {
+									sessionStorage.removeItem('pending_template_save');
+									authoringCapMessage = error.apiError.message;
+									showAuthoringUpgrade = true;
+								}
+								// Other failures: user can retry later.
 							});
 					} else {
 						console.warn('[HomePage] Invalid pending template data:', result.error.flatten());
@@ -274,7 +290,18 @@
 			const newTemplate = await templateStore.addTemplate(pendingPublishData);
 			savedTemplate = newTemplate;
 		} catch (err) {
-			templatePublishError = err instanceof Error ? err.message : 'Failed to publish template';
+			// At-cap individual authoring quota → upgrade card, not a dead-end.
+			if (
+				err instanceof AppError &&
+				err.apiError.code === ERROR_CODES.AUTHORING_QUOTA_EXCEEDED
+			) {
+				showTemplateSuccess = false;
+				savedTemplate = null;
+				authoringCapMessage = err.apiError.message;
+				showAuthoringUpgrade = true;
+			} else {
+				templatePublishError = err instanceof Error ? err.message : 'Failed to publish template';
+			}
 		} finally {
 			templatePublishing = false;
 		}
@@ -954,9 +981,23 @@
 						const newTemplate = await templateStore.addTemplate(templateData);
 						savedTemplate = newTemplate;
 					} catch (error) {
-						templatePublishError =
-							error instanceof Error ? error.message : 'Failed to publish template';
-						console.error('Template save failed:', error);
+						// At-cap individual AI-authoring quota → surface the
+						// Voice/Advocate upgrade card instead of a dead-end error.
+						// The store throws an AppError carrying the typed code so we
+						// branch on the code, not brittle message text.
+						if (
+							error instanceof AppError &&
+							error.apiError.code === ERROR_CODES.AUTHORING_QUOTA_EXCEEDED
+						) {
+							showTemplateSuccess = false;
+							savedTemplate = null;
+							authoringCapMessage = error.apiError.message;
+							showAuthoringUpgrade = true;
+						} else {
+							templatePublishError =
+								error instanceof Error ? error.message : 'Failed to publish template';
+							console.error('Template save failed:', error);
+						}
 					} finally {
 						templatePublishing = false;
 						isSubmitting = false;
@@ -992,6 +1033,25 @@
 			pendingPublishData = null;
 		}}
 	/>
+{/if}
+
+<!-- At-cap individual AI-authoring upgrade (Voice/Advocate) -->
+{#if showAuthoringUpgrade}
+	<SimpleModal
+		maxWidth="max-w-md"
+		onclose={() => {
+			showAuthoringUpgrade = false;
+			authoringCapMessage = null;
+		}}
+	>
+		<AuthoringUpgradeCard
+			message={authoringCapMessage}
+			onclose={() => {
+				showAuthoringUpgrade = false;
+				authoringCapMessage = null;
+			}}
+		/>
+	</SimpleModal>
 {/if}
 
 <style>

--- a/src/routes/api/agents/stream-decision-makers/+server.ts
+++ b/src/routes/api/agents/stream-decision-makers/+server.ts
@@ -25,6 +25,8 @@ import {
 	logLLMOperation
 } from '$lib/server/llm-cost-protection';
 import { moderatePromptOnly } from '$lib/core/server/moderation';
+import { serverQuery } from 'convex-sveltekit';
+import { api } from '$lib/convex';
 
 interface RequestBody {
 	subject_line: string;
@@ -43,7 +45,20 @@ interface RequestBody {
 }
 
 export const POST: RequestHandler = async (event) => {
-	const rateLimitCheck = await enforceLLMRateLimit(event, 'decision-makers');
+	// Paid individuals (Voice/Advocate) are not hard-blocked by the free
+	// daily-global abuse breaker — their monthly authored cap is the real bound.
+	// Resolve the paid signal before the rate-limit check (best-effort; a lookup
+	// failure falls back to the free ceiling, never elevates).
+	let paidIndividual = false;
+	if (event.locals.session?.userId) {
+		try {
+			paidIndividual = (await serverQuery(api.subscriptions.hasActivePaidIndividual, {})) === true;
+		} catch (err) {
+			console.warn('[stream-decision-makers] paid-individual lookup failed, using free ceiling:', err);
+		}
+	}
+
+	const rateLimitCheck = await enforceLLMRateLimit(event, 'decision-makers', { paidIndividual });
 	if (!rateLimitCheck.allowed) {
 		return rateLimitResponse(rateLimitCheck);
 	}

--- a/src/routes/api/agents/stream-message/+server.ts
+++ b/src/routes/api/agents/stream-message/+server.ts
@@ -96,7 +96,22 @@ function isRecoveryPublicKeyJwk(value: unknown): value is JsonWebKey {
 }
 
 export const POST: RequestHandler = async (event) => {
-	const rateLimitCheck = await enforceLLMRateLimit(event, 'message-generation');
+	// Paid individuals (Voice/Advocate) are not hard-blocked by the free
+	// daily-global abuse breaker on the message-generation step — their monthly
+	// authored cap is the real bound. The daily-global key is shared across every
+	// LLM op, so an authoring run (decision-makers + message-generation) must
+	// elevate the ceiling on BOTH steps or the paying user is still blocked here.
+	// Best-effort: a lookup failure falls back to the free ceiling, never elevates.
+	let paidIndividual = false;
+	if (event.locals.session?.userId) {
+		try {
+			paidIndividual = (await serverQuery(api.subscriptions.hasActivePaidIndividual, {})) === true;
+		} catch (err) {
+			console.warn('[stream-message] paid-individual lookup failed, using free ceiling:', err);
+		}
+	}
+
+	const rateLimitCheck = await enforceLLMRateLimit(event, 'message-generation', { paidIndividual });
 	if (!rateLimitCheck.allowed) {
 		return rateLimitResponse(rateLimitCheck);
 	}

--- a/src/routes/api/billing/checkout-individual/+server.ts
+++ b/src/routes/api/billing/checkout-individual/+server.ts
@@ -1,0 +1,89 @@
+/**
+ * Create a Stripe Checkout Session for an INDIVIDUAL (person-layer) paid
+ * authoring tier (Voice / Advocate).
+ *
+ * POST { plan: 'voice' | 'advocate' }
+ * Returns { url: string } — redirect the user to this URL.
+ *
+ * User-scoped: no org lookup, no org role check. Any authenticated user may
+ * subscribe. Finds or creates a Stripe customer ON THE USER (not an org) and
+ * stamps the session metadata with { userId, plan } so the webhook routes it to
+ * the individual upsert path (no org-limit sync). Individual tiers buy ONLY
+ * authoring volume — never org tooling.
+ */
+
+import { json, error } from '@sveltejs/kit';
+import { getStripe } from '$lib/server/billing/stripe';
+import { INDIVIDUAL_PLANS, INDIVIDUAL_PLAN_ORDER } from '$lib/server/billing/plans';
+import { serverQuery, serverMutation } from 'convex-sveltekit';
+import { api } from '$lib/convex';
+import type { RequestHandler } from './$types';
+
+export const POST: RequestHandler = async ({ request, locals, url }) => {
+	if (!locals.user) throw error(401, 'Authentication required');
+
+	const body = await request.json();
+	const { plan } = body as { plan: string };
+
+	if (!plan) throw error(400, 'plan required');
+	// Only the marketed individual tiers are purchasable here. Org plan slugs and
+	// any unknown slug are rejected — this endpoint never sells org tooling.
+	if (
+		!INDIVIDUAL_PLANS[plan] ||
+		!INDIVIDUAL_PLAN_ORDER.includes(plan as (typeof INDIVIDUAL_PLAN_ORDER)[number])
+	)
+		throw error(400, 'Invalid plan');
+
+	// User billing context via Convex (auth-gated to the caller's own row).
+	const billing = await serverQuery(api.subscriptions.getMyBillingContext, {});
+	if (!billing) throw error(401, 'Authentication required');
+
+	// Prevent duplicate checkout for the same plan or downgrade via checkout.
+	if (billing.subscription && billing.subscription.status !== 'canceled') {
+		const currentIdx = INDIVIDUAL_PLAN_ORDER.indexOf(
+			billing.subscription.plan as (typeof INDIVIDUAL_PLAN_ORDER)[number]
+		);
+		const targetIdx = INDIVIDUAL_PLAN_ORDER.indexOf(plan as (typeof INDIVIDUAL_PLAN_ORDER)[number]);
+		if (targetIdx >= 0 && currentIdx >= 0 && targetIdx <= currentIdx) {
+			throw error(
+				400,
+				targetIdx === currentIdx
+					? 'You are already on this plan. Manage your subscription in the billing portal.'
+					: 'Plan downgrades should be managed through the billing portal.'
+			);
+		}
+	}
+
+	const stripe = getStripe();
+	const planDef = INDIVIDUAL_PLANS[plan];
+
+	if (!planDef.stripePriceId) {
+		throw error(500, `Stripe Price ID not configured for plan: ${plan}`);
+	}
+
+	// Find or create the user's Stripe customer (mirrors the org checkout, but on
+	// the user row — userId metadata so the webhook can resolve the user).
+	let customerId = billing.stripeCustomerId;
+	if (!customerId) {
+		const customer = await stripe.customers.create({
+			email: locals.user.email,
+			metadata: { userId: billing.userId }
+		});
+		customerId = customer.id;
+		await serverMutation(api.subscriptions.updateMyStripeCustomerId, {
+			stripeCustomerId: customerId
+		});
+	}
+
+	const session = await stripe.checkout.sessions.create({
+		customer: customerId,
+		mode: 'subscription',
+		line_items: [{ price: planDef.stripePriceId, quantity: 1 }],
+		success_url: `${url.origin}/profile?billing=success`,
+		cancel_url: `${url.origin}/profile?billing=canceled`,
+		// userId (NOT orgId) routes the webhook to the individual upsert path.
+		metadata: { userId: billing.userId, plan }
+	});
+
+	return json({ url: session.url });
+};

--- a/src/routes/api/templates/+server.ts
+++ b/src/routes/api/templates/+server.ts
@@ -583,6 +583,25 @@ export const POST: RequestHandler = async ({ request, locals, platform }) => {
 					return json(response, { status: 403 });
 				}
 
+				// Individual AI-authoring cap. The coded prefix lets the client
+				// distinguish this from the org quota and surface the at-cap upgrade
+				// card (Voice/Advocate). The human message after the colon is the
+				// plan-aware copy from decideIndividualAuthoring.
+				if (error instanceof Error && error.message.startsWith('AUTHORING_QUOTA_EXCEEDED:')) {
+					const message = error.message.slice('AUTHORING_QUOTA_EXCEEDED:'.length);
+					const apiError = createApiError('authorization', 'AUTHORING_QUOTA_EXCEEDED', message);
+					// Surface the code in BOTH `error` and `errors[]` so the api client
+					// (which forwards `errors` onto ApiClientError) preserves the
+					// AUTHORING_QUOTA_EXCEEDED code for the at-cap upgrade card; the
+					// `error` message is the plan-aware copy shown inline.
+					const response: StructuredApiResponse = {
+						success: false,
+						error: apiError,
+						errors: [apiError]
+					};
+					return json(response, { status: 403 });
+				}
+
 				console.error('Database error creating template:', error);
 
 				const response: StructuredApiResponse = {

--- a/tests/unit/agents/cogs-fanout.test.ts
+++ b/tests/unit/agents/cogs-fanout.test.ts
@@ -1,0 +1,84 @@
+/**
+ * COGS-fanout guard for decision-maker resolution (guard a).
+ *
+ * Per-message COGS scales ~linearly with the number of roles Phase 1 enumerates:
+ * each role drives an Exa identity search + a per-identity contact search +
+ * chunked Gemini synthesis (Firecrawl reads are separately capped at 20). Phase 1
+ * is an UNBOUNDED LLM enumeration, so without a bound a broad subject could fan
+ * out far enough to blow past the budgeted ~$0.22 per-message ceiling.
+ *
+ * `capFanout` bounds the role count BEFORE the fanout begins so the downstream
+ * external-API spend is deterministically bounded. These tests pin:
+ *   - the bound is applied (length never exceeds the cap),
+ *   - lists at/under the cap pass through unchanged,
+ *   - guided (explicitly-targeted) roles are kept first so precise targeting is
+ *     never truncated in favor of speculative breadth,
+ *   - it is pure (does not mutate the input).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { capFanout, MAX_DECISION_MAKER_FANOUT } from '$lib/core/agents/cogs-fanout';
+
+interface Role {
+	position: string;
+	guided?: boolean;
+}
+
+function roles(n: number, guided = false): Role[] {
+	return Array.from({ length: n }, (_, i) => ({ position: `role-${i}`, guided }));
+}
+
+describe('MAX_DECISION_MAKER_FANOUT', () => {
+	it('is a small positive bound (keeps per-message COGS within the ~$0.22 ceiling)', () => {
+		expect(MAX_DECISION_MAKER_FANOUT).toBeGreaterThan(0);
+		expect(MAX_DECISION_MAKER_FANOUT).toBeLessThanOrEqual(20);
+	});
+});
+
+describe('capFanout', () => {
+	it('passes a list AT the cap through unchanged', () => {
+		const input = roles(MAX_DECISION_MAKER_FANOUT);
+		expect(capFanout(input)).toHaveLength(MAX_DECISION_MAKER_FANOUT);
+	});
+
+	it('passes a list UNDER the cap through unchanged', () => {
+		const input = roles(3);
+		const out = capFanout(input);
+		expect(out).toHaveLength(3);
+		expect(out).toEqual(input);
+	});
+
+	it('BOUNDS a list over the cap to exactly the cap', () => {
+		const out = capFanout(roles(100));
+		expect(out).toHaveLength(MAX_DECISION_MAKER_FANOUT);
+	});
+
+	it('never exceeds the cap regardless of how many roles Phase 1 enumerates', () => {
+		for (const n of [0, 1, 12, 13, 50, 500]) {
+			expect(capFanout(roles(n)).length).toBeLessThanOrEqual(MAX_DECISION_MAKER_FANOUT);
+		}
+	});
+
+	it('keeps GUIDED (explicitly-targeted) roles first when truncating', () => {
+		// 2 guided + many speculative; cap must retain BOTH guided roles.
+		const guided = roles(2, true).map((r, i) => ({ ...r, position: `guided-${i}` }));
+		const speculative = roles(50, false);
+		const out = capFanout([...speculative, ...guided], MAX_DECISION_MAKER_FANOUT);
+		expect(out).toHaveLength(MAX_DECISION_MAKER_FANOUT);
+		const keptGuided = out.filter((r) => r.guided === true);
+		expect(keptGuided).toHaveLength(2);
+		expect(keptGuided.map((r) => r.position).sort()).toEqual(['guided-0', 'guided-1']);
+	});
+
+	it('respects an explicit max argument', () => {
+		expect(capFanout(roles(20), 5)).toHaveLength(5);
+	});
+
+	it('is pure — does not mutate the input array', () => {
+		const input = roles(50);
+		const snapshot = [...input];
+		capFanout(input);
+		expect(input).toEqual(snapshot);
+		expect(input).toHaveLength(50);
+	});
+});

--- a/tests/unit/billing/individual-authoring-cap.test.ts
+++ b/tests/unit/billing/individual-authoring-cap.test.ts
@@ -1,18 +1,20 @@
 /**
- * L1 individual AI-authoring cap (3 / calendar month).
+ * Individual (person-layer) AI-authoring cap — the L2 metered surface.
  *
  * "Individuals free forever" is refined to: free forever to ACT (send, sign,
  * personalize-and-deliver existing messages), bounded on AI GENERATION. The
  * expensive person-layer path is authoring a NEW template (subject + grounded
  * decision-maker resolution + grounded message, ~$0.12–0.22 each), so an
- * un-orged individual may AI-author up to 3 templates per calendar month.
+ * un-orged individual may AI-author up to their plan's authored-per-month limit:
+ * free floor 3, Voice 20, Advocate 75.
  *
  * The cap is enforced in `convex/templates.ts:createTemplate` (the individual
  * create fence), in the `else` (no-org) branch — org members are governed by
  * their plan's `maxTemplatesMonth`. It counts the user's own templates created
  * month-to-date via the `templates.by_userId` index (query-time aggregation
- * from `_creationTime`, NOT a denormalized counter), then delegates the
- * allow/deny decision to the pure helper pinned here.
+ * from `_creationTime`, NOT a denormalized counter), resolves the limit from the
+ * user's individual subscription plan, then delegates the allow/deny decision to
+ * the pure helpers pinned here.
  *
  * ACTING on / SENDING an existing template never touches `createTemplate`
  * (campaign-action / submit paths), so it is intentionally never gated by this
@@ -22,6 +24,8 @@
 import { describe, it, expect } from 'vitest';
 import {
 	FREE_INDIVIDUAL_TEMPLATES_PER_MONTH,
+	INDIVIDUAL_AUTHORED_PER_MONTH,
+	authoredLimitForPlan,
 	startOfMonthUTC,
 	nextMonthResetDate,
 	decideIndividualAuthoring
@@ -31,8 +35,50 @@ const JAN_15 = Date.UTC(2026, 0, 15, 12, 0, 0); // mid-January 2026
 const DEC_20 = Date.UTC(2026, 11, 20, 12, 0, 0); // mid-December (year-rollover case)
 
 describe('FREE_INDIVIDUAL_TEMPLATES_PER_MONTH', () => {
-	it('is 3', () => {
+	it('is 3 (the free floor)', () => {
 		expect(FREE_INDIVIDUAL_TEMPLATES_PER_MONTH).toBe(3);
+	});
+});
+
+describe('INDIVIDUAL_AUTHORED_PER_MONTH (the dynamic limit map)', () => {
+	it('Voice = 20, Advocate = 75', () => {
+		expect(INDIVIDUAL_AUTHORED_PER_MONTH.voice).toBe(20);
+		expect(INDIVIDUAL_AUTHORED_PER_MONTH.advocate).toBe(75);
+	});
+
+	it('holds ONLY individual slugs — no org slug leaks in', () => {
+		const slugs = Object.keys(INDIVIDUAL_AUTHORED_PER_MONTH).sort();
+		expect(slugs).toEqual(['advocate', 'voice']);
+		// Org plan slugs must be absent so the individual cap can never honor them.
+		for (const org of ['inactive', 'starter', 'organization', 'coalition']) {
+			expect(INDIVIDUAL_AUTHORED_PER_MONTH[org]).toBeUndefined();
+		}
+	});
+});
+
+describe('authoredLimitForPlan (resolves the effective monthly limit)', () => {
+	it('free floor (3) for no plan', () => {
+		expect(authoredLimitForPlan(null)).toBe(3);
+		expect(authoredLimitForPlan(undefined)).toBe(3);
+	});
+
+	it('Voice → 20, Advocate → 75', () => {
+		expect(authoredLimitForPlan('voice')).toBe(20);
+		expect(authoredLimitForPlan('advocate')).toBe(75);
+	});
+
+	it('an ORG plan slug NEVER unlocks org volume — resolves to the free floor', () => {
+		// Cross-contamination guard (issue 6): the individual cap must never honor
+		// an org plan. starter/organization/coalition all resolve to floor 3.
+		expect(authoredLimitForPlan('starter')).toBe(3);
+		expect(authoredLimitForPlan('organization')).toBe(3);
+		expect(authoredLimitForPlan('coalition')).toBe(3);
+		expect(authoredLimitForPlan('inactive')).toBe(3);
+	});
+
+	it('an unknown slug never grants MORE than the floor', () => {
+		expect(authoredLimitForPlan('enterprise')).toBe(3);
+		expect(authoredLimitForPlan('')).toBe(3);
 	});
 });
 
@@ -52,7 +98,7 @@ describe('nextMonthResetDate', () => {
 	});
 });
 
-describe('decideIndividualAuthoring', () => {
+describe('decideIndividualAuthoring — FREE FLOOR (limit defaults to 3)', () => {
 	it('ALLOWS the 1st, 2nd, and 3rd template in a month', () => {
 		expect(decideIndividualAuthoring(0, JAN_15).ok).toBe(true);
 		expect(decideIndividualAuthoring(1, JAN_15).ok).toBe(true);
@@ -65,12 +111,49 @@ describe('decideIndividualAuthoring', () => {
 		if (!d.ok) {
 			expect(d.message).toContain('3 free messages this month');
 			expect(d.message).toContain('resets 2026-02-01');
-			expect(d.message).toContain('Higher-volume individual authoring is coming');
+			// Free-floor copy invites the L2 upgrade.
+			expect(d.message).toContain('Upgrade to Voice or Advocate');
 		}
 	});
 
 	it('stays blocked beyond the cap', () => {
 		expect(decideIndividualAuthoring(4, JAN_15).ok).toBe(false);
 		expect(decideIndividualAuthoring(99, JAN_15).ok).toBe(false);
+	});
+});
+
+describe('decideIndividualAuthoring — VOICE (limit 20)', () => {
+	const VOICE = authoredLimitForPlan('voice'); // 20
+
+	it('ALLOWS up to the 20th template', () => {
+		expect(decideIndividualAuthoring(0, JAN_15, VOICE).ok).toBe(true);
+		expect(decideIndividualAuthoring(19, JAN_15, VOICE).ok).toBe(true);
+	});
+
+	it('BLOCKS the 21st (20 already authored) with the paid-tier message (no upgrade ask)', () => {
+		const d = decideIndividualAuthoring(20, JAN_15, VOICE);
+		expect(d.ok).toBe(false);
+		if (!d.ok) {
+			expect(d.message).toContain('20 messages for this billing period');
+			expect(d.message).toContain('resets 2026-02-01');
+			expect(d.message).not.toContain('Upgrade to Voice');
+		}
+	});
+});
+
+describe('decideIndividualAuthoring — ADVOCATE (limit 75)', () => {
+	const ADVOCATE = authoredLimitForPlan('advocate'); // 75
+
+	it('ALLOWS up to the 75th template', () => {
+		expect(decideIndividualAuthoring(0, JAN_15, ADVOCATE).ok).toBe(true);
+		expect(decideIndividualAuthoring(74, JAN_15, ADVOCATE).ok).toBe(true);
+	});
+
+	it('BLOCKS the 76th (75 already authored)', () => {
+		const d = decideIndividualAuthoring(75, JAN_15, ADVOCATE);
+		expect(d.ok).toBe(false);
+		if (!d.ok) {
+			expect(d.message).toContain('75 messages for this billing period');
+		}
 	});
 });

--- a/tests/unit/billing/individual-subscription-routing.test.ts
+++ b/tests/unit/billing/individual-subscription-routing.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Individual (person-layer) subscription routing on the polymorphic
+ * subscriptions table.
+ *
+ * The subscriptions table is polymorphic: a row is keyed on EITHER orgId (org
+ * tier) OR userId (individual Voice/Advocate). The Stripe webhook + cancel paths
+ * must route the two scopes distinctly or an individual sub leaks org-shaped
+ * state (delivery quotas, the org 'inactive' floor) onto a user row, or an org
+ * sub gets routed through the no-org-sync individual path.
+ *
+ * convex-test isn't wired in this repo, so — mirroring
+ * verified-action-metering.test.ts — these pin the handler's pure branching
+ * logic (the routing decisions in convex/subscriptions.ts) rather than a live
+ * Convex context. The mirrors below MUST match the handler branches; if the
+ * handler changes, these break.
+ *
+ * Invariants pinned (the design-review blocking issues):
+ *   - issue 3: cancel/delete of an INDIVIDUAL sub drops to the individual FREE
+ *     FLOOR (no row / no plan write), NOT the org-shaped 'inactive'.
+ *   - issue 4: checkout.session.completed routes on metadata (userId →
+ *     individual upsert, NO org-limit sync; orgId → org upsert WITH sync).
+ *   - the individual authoring cap reads the plan ONLY when effectively active,
+ *     so a canceled individual sub resolves to the free floor 3.
+ *   - an individual sub NEVER unlocks org limits (no maxEmails/maxSms/etc).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { PLANS, INDIVIDUAL_PLANS } from '$lib/server/billing/plans';
+import { authoredLimitForPlan, FREE_INDIVIDUAL_TEMPLATES_PER_MONTH } from '../../../convex/_individualAuthoringCap';
+
+// ---------------------------------------------------------------------------
+// Mirror of the webhook checkout.session.completed routing branch
+// (convex/subscriptions.ts processStripeWebhook → INDIVIDUAL_PLANS / PLANS).
+// ---------------------------------------------------------------------------
+const CONVEX_INDIVIDUAL_PLANS: Record<string, { priceCents: number; authoredPerMonth: number }> = {
+	voice: { priceCents: 700, authoredPerMonth: 20 },
+	advocate: { priceCents: 2_000, authoredPerMonth: 75 }
+};
+const CONVEX_ORG_PLANS = new Set(['inactive', 'starter', 'organization', 'coalition']);
+
+type Route = 'individual-upsert-no-org-sync' | 'org-upsert-with-sync' | 'ignored';
+
+function routeCheckoutCompleted(metadata: { userId?: string; orgId?: string; plan?: string }): Route {
+	const { userId, orgId, plan } = metadata;
+	// INDIVIDUAL branch FIRST: userId + an individual plan → user-scoped, no sync.
+	if (userId && plan && CONVEX_INDIVIDUAL_PLANS[plan]) {
+		return 'individual-upsert-no-org-sync';
+	}
+	// ORG branch: orgId + a marketed org plan → org upsert WITH limit sync.
+	if (orgId && plan && CONVEX_ORG_PLANS.has(plan)) {
+		return 'org-upsert-with-sync';
+	}
+	return 'ignored';
+}
+
+// Mirror of upsertIndividualFromStripe's guard: refuse a non-individual plan on
+// a userId checkout (a metadata mismatch must NOT grant org-shaped state).
+function individualUpsertAccepts(plan: string): boolean {
+	return !!CONVEX_INDIVIDUAL_PLANS[plan];
+}
+
+// ---------------------------------------------------------------------------
+// Mirror of cancel()'s userId vs orgId branch + the authoring cap's
+// "honor plan only when effectively active" rule.
+// ---------------------------------------------------------------------------
+type CancelOutcome =
+	| { scope: 'org'; planWritten: 'inactive'; resetsOrgLimits: true }
+	| { scope: 'individual'; planWritten: null; resetsOrgLimits: false };
+
+function cancelOutcome(sub: { orgId?: string; userId?: string }): CancelOutcome {
+	if (sub.orgId) {
+		// ORG sub → org gated floor + reset org limits.
+		return { scope: 'org', planWritten: 'inactive', resetsOrgLimits: true };
+	}
+	// INDIVIDUAL sub → mark canceled, LEAVE the plan slug intact, no org write.
+	return { scope: 'individual', planWritten: null, resetsOrgLimits: false };
+}
+
+/**
+ * Mirror of the authoring cap's effective-limit resolution
+ * (convex/templates.ts createTemplate no-org branch): honor the plan only when
+ * the sub is effectively active; otherwise free floor.
+ */
+function effectiveAuthoredLimit(sub: { plan?: string; status?: string } | null): number {
+	const effectivelyActive = sub?.status === 'active' || sub?.status === 'trialing';
+	return effectivelyActive ? authoredLimitForPlan(sub?.plan) : authoredLimitForPlan(null);
+}
+
+describe('webhook checkout.session.completed routing (issue 4)', () => {
+	it('userId + voice → individual upsert, NO org-limit sync', () => {
+		expect(routeCheckoutCompleted({ userId: 'u1', plan: 'voice' })).toBe(
+			'individual-upsert-no-org-sync'
+		);
+	});
+
+	it('userId + advocate → individual upsert, NO org-limit sync', () => {
+		expect(routeCheckoutCompleted({ userId: 'u1', plan: 'advocate' })).toBe(
+			'individual-upsert-no-org-sync'
+		);
+	});
+
+	it('orgId + organization → org upsert WITH limit sync', () => {
+		expect(routeCheckoutCompleted({ orgId: 'o1', plan: 'organization' })).toBe(
+			'org-upsert-with-sync'
+		);
+	});
+
+	it('userId branch is preferred when an individual plan is present (no cross-route)', () => {
+		// A userId checkout for an individual plan never falls into the org branch.
+		expect(routeCheckoutCompleted({ userId: 'u1', orgId: 'o1', plan: 'voice' })).toBe(
+			'individual-upsert-no-org-sync'
+		);
+	});
+
+	it('an org plan slug arriving on a userId checkout is NOT honored as individual', () => {
+		// upsertIndividualFromStripe refuses a non-individual plan.
+		expect(individualUpsertAccepts('organization')).toBe(false);
+		expect(individualUpsertAccepts('coalition')).toBe(false);
+		expect(individualUpsertAccepts('voice')).toBe(true);
+		expect(individualUpsertAccepts('advocate')).toBe(true);
+	});
+});
+
+describe('cancel / delete routing (issue 3)', () => {
+	it('an ORG sub cancel drops to the org-shaped "inactive" floor + resets org limits', () => {
+		const out = cancelOutcome({ orgId: 'o1' });
+		expect(out.scope).toBe('org');
+		expect(out.planWritten).toBe('inactive');
+		expect(out.resetsOrgLimits).toBe(true);
+	});
+
+	it('an INDIVIDUAL sub cancel does NOT write the org "inactive" floor + no org reset', () => {
+		const out = cancelOutcome({ userId: 'u1' });
+		expect(out.scope).toBe('individual');
+		expect(out.planWritten).toBeNull();
+		expect(out.resetsOrgLimits).toBe(false);
+	});
+
+	it('a canceled individual sub resolves to the free floor (3), not org "inactive" (2 templates)', () => {
+		// After cancel the row keeps its slug (e.g. 'voice') but status is canceled,
+		// so the authoring cap falls to the free floor — NOT the org 'inactive'
+		// shape (which would be maxTemplatesMonth 2 + zero authored allowance).
+		const canceledVoice = { plan: 'voice', status: 'canceled' };
+		expect(effectiveAuthoredLimit(canceledVoice)).toBe(FREE_INDIVIDUAL_TEMPLATES_PER_MONTH);
+		expect(effectiveAuthoredLimit(canceledVoice)).toBe(3);
+		// org 'inactive' is a DIFFERENT (org-layer) shape — 2 maxTemplatesMonth,
+		// not an authored allowance. The individual free floor must not be it.
+		expect(PLANS.inactive.maxTemplatesMonth).toBe(2);
+		expect(effectiveAuthoredLimit(canceledVoice)).not.toBe(PLANS.inactive.maxTemplatesMonth);
+	});
+
+	it('an ACTIVE individual sub gets its plan limit; a past_due-out-of-grace falls to floor', () => {
+		expect(effectiveAuthoredLimit({ plan: 'voice', status: 'active' })).toBe(20);
+		expect(effectiveAuthoredLimit({ plan: 'advocate', status: 'active' })).toBe(75);
+		expect(effectiveAuthoredLimit({ plan: 'advocate', status: 'canceled' })).toBe(3);
+		expect(effectiveAuthoredLimit(null)).toBe(3);
+	});
+});
+
+describe('individual subs NEVER unlock org tooling (issue 6 cross-contamination)', () => {
+	it('INDIVIDUAL_PLANS carry no org quota fields', () => {
+		for (const slug of Object.keys(INDIVIDUAL_PLANS)) {
+			const p = INDIVIDUAL_PLANS[slug] as unknown as Record<string, unknown>;
+			expect(p.maxEmails).toBeUndefined();
+			expect(p.maxSms).toBeUndefined();
+			expect(p.maxSeats).toBeUndefined();
+			expect(p.maxTemplatesMonth).toBeUndefined();
+		}
+	});
+
+	it('an individual plan slug resolves to NO org plan (the org cap never honors it)', () => {
+		// getPlanForOrg-equivalent: PLANS[plan] is undefined for an individual slug,
+		// so an org would fall to inactive — an individual sub can never grant an
+		// org delivery quota.
+		expect(PLANS['voice']).toBeUndefined();
+		expect(PLANS['advocate']).toBeUndefined();
+	});
+});

--- a/tests/unit/billing/plan-sync.test.ts
+++ b/tests/unit/billing/plan-sync.test.ts
@@ -10,7 +10,16 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { PLANS } from '$lib/server/billing/plans';
+import {
+	PLANS,
+	INDIVIDUAL_PLANS,
+	FREE_INDIVIDUAL_AUTHORED_PER_MONTH,
+	authoredPerMonthForPlan
+} from '$lib/server/billing/plans';
+import {
+	INDIVIDUAL_AUTHORED_PER_MONTH,
+	FREE_INDIVIDUAL_TEMPLATES_PER_MONTH
+} from '../../../convex/_individualAuthoringCap';
 
 /**
  * These values MUST match convex/subscriptions.ts PLANS exactly.
@@ -87,4 +96,89 @@ describe('Plan Sync: SvelteKit ↔ Convex Mirror', () => {
 			});
 		});
 	}
+});
+
+/**
+ * Individual (person-layer) paid authoring tiers must land in the 4 plan-literal
+ * sites in lockstep (issue 6):
+ *   1. convex/schema.ts subscriptions.plan union  (validates the persisted slug)
+ *   2. convex/_validators.ts subscriptionPlan     (validates mutation args)
+ *   3. src/lib/server/billing/plans.ts INDIVIDUAL_PLANS  (canonical price + limit)
+ *   4. convex/subscriptions.ts INDIVIDUAL_PLANS    (Convex mirror — price + limit)
+ *
+ * This file directly imports the Convex-side authored-limit map
+ * (_individualAuthoringCap.ts, which templates.ts reads) and the canonical
+ * plans.ts INDIVIDUAL_PLANS. The schema/validator unions and the
+ * subscriptions.ts mirror can't be imported into vitest (Convex server code), so
+ * we assert the expected contract those sites MUST encode. If this fails, sync
+ * the failing site.
+ *
+ * CRITICAL: individual plans must never carry org quotas, and org plans must
+ * never appear in the individual maps. The two scopes can never read each other.
+ */
+const EXPECTED_INDIVIDUAL_MIRROR = {
+	voice: { priceCents: 700, authoredPerMonth: 20 },
+	advocate: { priceCents: 2_000, authoredPerMonth: 75 }
+} as const;
+
+describe('Plan Sync: individual (person-layer) tiers across the 4 sites', () => {
+	it('the same individual slugs exist in plans.ts INDIVIDUAL_PLANS and the expected mirror', () => {
+		const sveltSlugs = Object.keys(INDIVIDUAL_PLANS).sort();
+		const expectedSlugs = Object.keys(EXPECTED_INDIVIDUAL_MIRROR).sort();
+		expect(sveltSlugs).toEqual(expectedSlugs);
+	});
+
+	it('the Convex authored-limit map (_individualAuthoringCap.ts) holds the same slugs', () => {
+		const capSlugs = Object.keys(INDIVIDUAL_AUTHORED_PER_MONTH).sort();
+		expect(capSlugs).toEqual(Object.keys(EXPECTED_INDIVIDUAL_MIRROR).sort());
+	});
+
+	it('the free floor is 3 in BOTH the SvelteKit and Convex constants', () => {
+		expect(FREE_INDIVIDUAL_AUTHORED_PER_MONTH).toBe(3);
+		expect(FREE_INDIVIDUAL_TEMPLATES_PER_MONTH).toBe(3);
+	});
+
+	for (const [slug, expected] of Object.entries(EXPECTED_INDIVIDUAL_MIRROR)) {
+		describe(`${slug} individual tier`, () => {
+			const sveltePlan = INDIVIDUAL_PLANS[slug];
+
+			it('priceCents matches plans.ts', () => {
+				expect(sveltePlan.priceCents).toBe(expected.priceCents);
+			});
+
+			it('authoredPerMonth matches plans.ts', () => {
+				expect(sveltePlan.authoredPerMonth).toBe(expected.authoredPerMonth);
+			});
+
+			it('authoredPerMonth matches the Convex cap map (_individualAuthoringCap.ts)', () => {
+				expect(INDIVIDUAL_AUTHORED_PER_MONTH[slug]).toBe(expected.authoredPerMonth);
+			});
+
+			it('authoredPerMonthForPlan resolves it', () => {
+				expect(authoredPerMonthForPlan(slug)).toBe(expected.authoredPerMonth);
+			});
+
+			it('carries NO org quota fields (individual plans buy ONLY authoring volume)', () => {
+				const fields = sveltePlan as unknown as Record<string, unknown>;
+				expect(fields.maxEmails).toBeUndefined();
+				expect(fields.maxSms).toBeUndefined();
+				expect(fields.maxSeats).toBeUndefined();
+				expect(fields.maxTemplatesMonth).toBeUndefined();
+			});
+		});
+	}
+
+	it('org PLANS and INDIVIDUAL_PLANS share NO slugs (no cross-contamination)', () => {
+		const orgSlugs = new Set(Object.keys(PLANS));
+		for (const indSlug of Object.keys(INDIVIDUAL_PLANS)) {
+			expect(orgSlugs.has(indSlug)).toBe(false);
+		}
+	});
+
+	it('individual slugs are absent from PLAN_ORDER (not marketed org tiers)', async () => {
+		const { PLAN_ORDER } = await import('$lib/server/billing/plans');
+		for (const indSlug of Object.keys(INDIVIDUAL_PLANS)) {
+			expect((PLAN_ORDER as readonly string[]).includes(indSlug)).toBe(false);
+		}
+	});
 });


### PR DESCRIPTION
The L2 layer of the 3-layer monetization model, on the already-polymorphic subscription substrate. Locked tiers: free floor 3 authored/mo → **Voice $7/mo · 20** → **Advocate $20/mo · 75**. Individuals pay for their-own-voice authoring volume only — NO org tooling. do→review→fix (review approved, no required fixes).

## The 6 design-review blocking issues — all resolved
1. **Meter reuse, made dynamic** — the shipped L1 meter (`templates.by_userId` + `_creationTime`) now reads the user's plan limit (free 3 / voice 20 / advocate 75), not a hardcoded 3. No new meter.
2. **`users.stripeCustomerId`** + `by_stripeCustomerId` index added (mirrors orgs).
3. **Free-floor on cancel** — a canceled individual sub retains its slug + `status:canceled`, so the dynamic cap resolves it to the free floor (3), NOT the org `inactive` (delivery-0). Org cancel still → `inactive`.
4. **Webhook userId branch** — `checkout.session.completed` routes individual (userId + individual plan) → `upsertIndividualFromStripe` with NO org-limit sync; org writes stay guarded on `sub.orgId`.
5. **Paid individuals off the daily abuse-breaker** — `PAID_INDIVIDUAL_DAILY_GLOBAL` (75/day) so Advocate isn't hard-blocked by the ~15/day ceiling.
6. **4-site plan-literal lockstep** + clean scope separation — voice/advocate live in their own `INDIVIDUAL_PLANS` map, absent from `PLAN_ORDER`, carry only price+authored (no org quotas). Org `checkPlanLimits` (orgId-keyed) and the individual cap can never read each other's plans.

Plus: COGS-fanout guard (`capFanout`, MAX_DECISION_MAKER_FANOUT=12) bounds per-message COGS to protect the Advocate margin (guard a); individual Stripe checkout (`/api/billing/checkout-individual`, userId-scoped); at-cap upgrade card on the homepage authoring flow (typed-code branch).

## Verification
convex tsc 0 · `npm run check` 0 · 174 billing tests (plan-sync, individual-authoring-cap, individual-subscription-routing) + cogs-fanout + llm-cost-protection green. **Invariant verified: individual subs never unlock org limits.**

## Activation + coordination notes
- **Not live until provisioned:** create the Stripe prices + set `STRIPE_PRICE_VOICE` / `STRIPE_PRICE_ADVOCATE` to make the upgrade checkout functional (pre-launch, no production individual hits the cap yet — this is the activation step, customer/launch-gated).
- **`+page.svelte` overlaps the spectrum landing rebuild** — the at-cap UX is a small self-contained block (catch-branch + modal); reconcile when the spectrum landing lands.

## Review-noted (non-blocking)
routing test is a logic-mirror (no live Convex harness, same as branding-gate); plan-sync asserts 2/4 sites; at-cap relies on the inherited message→code translation; concurrent-checkout duplicate-customer edge (parity with org flow).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added individual paid authoring tiers: Voice and Advocate plans with monthly quota limits.
  * Added upgrade prompt when monthly authoring quota is exceeded.
  * Enhanced rate limiting for paid individual subscribers.
  * Improved decision-maker discovery efficiency with automatic role prioritization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->