### PR TITLE
Action surface: self-verifying proof footer + tier-gated bounce reporting; gemini-3.5-flash; DEBATE off

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -20,6 +20,7 @@ import type * as _downgradeGuard from "../_downgradeGuard.js";
 import type * as _emailMergeFields from "../_emailMergeFields.js";
 import type * as _emailRecipientFilter from "../_emailRecipientFilter.js";
 import type * as _externalIds from "../_externalIds.js";
+import type * as _individualAuthoringCap from "../_individualAuthoringCap.js";
 import type * as _internalAuth from "../_internalAuth.js";
 import type * as _orgHash from "../_orgHash.js";
 import type * as _orgKey from "../_orgKey.js";
@@ -96,6 +97,7 @@ declare const fullApi: ApiFromModules<{
   _emailMergeFields: typeof _emailMergeFields;
   _emailRecipientFilter: typeof _emailRecipientFilter;
   _externalIds: typeof _externalIds;
+  _individualAuthoringCap: typeof _individualAuthoringCap;
   _internalAuth: typeof _internalAuth;
   _orgHash: typeof _orgHash;
   _orgKey: typeof _orgKey;

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -1041,6 +1041,31 @@ export const getActiveCredentialDistrictCommitment = query({
 });
 
 /**
+ * Return the caller's own active credential hash for the `/v/[hash]` verify URL
+ * shown in proof footers. The hash is public by design (it is already printed in
+ * recipient email footers and `resolveCredentialHash` is unauthenticated), but
+ * this query is auth-scoped so a client only ever learns ITS OWN — preventing a
+ * userId→credentialHash→district enumeration oracle.
+ *
+ * Returns null when there is no active credential, or the active row predates
+ * hash issuance (empty `credentialHash`). Callers MUST render no verification
+ * link in that case rather than a guaranteed-404 one. The row returned here is
+ * the same authoritative active credential `resolveCredentialHash` validates
+ * against, so any hash returned is guaranteed to resolve.
+ */
+export const getActiveCredentialHash = query({
+	args: { userId: v.id('users') },
+	handler: async (ctx, args) => {
+		const { userId: authUserId } = await requireAuth(ctx);
+		if (args.userId !== authUserId) throw new Error('Unauthorized');
+
+		const active = await selectActiveCredentialForUser(ctx, args.userId);
+		if (!active || !active.credentialHash) return null;
+		return { credentialHash: active.credentialHash };
+	}
+});
+
+/**
  * Get user's identity commitment + verification method for Shadow Atlas.
  */
 export const getIdentityForAtlas = query({

--- a/src/lib/components/action/DecisionMakerLandscapeCard.svelte
+++ b/src/lib/components/action/DecisionMakerLandscapeCard.svelte
@@ -34,22 +34,41 @@
 		contacted = false,
 		departing = false,
 		onWriteTo,
-		showRoleBadge = false
+		showRoleBadge = false,
+		canReportBounce = false,
+		reported = false,
+		reporting = false,
+		onReportBounce
 	}: {
 		member: LandscapeMember;
 		contacted: boolean;
 		departing: boolean;
 		onWriteTo: (member: LandscapeMember) => void;
 		showRoleBadge?: boolean;
+		canReportBounce?: boolean;
+		reported?: boolean;
+		reporting?: boolean;
+		onReportBounce?: (email: string) => void;
 	} = $props();
 
 	const canAct = $derived(member.deliveryRoute !== 'recorded' && member.deliveryRoute !== 'phone_only');
 	const isActive = $derived(canAct && !contacted && !departing);
 
+	// A bounce only means something for a direct email route; CWC/form delivery
+	// has no email to bounce. Tier gate is enforced by the parent (server too).
+	const canFlagBounce = $derived(
+		canReportBounce && member.deliveryRoute === 'email' && !!member.email
+	);
+
 	function handleClick() {
 		if (isActive) {
 			onWriteTo(member);
 		}
+	}
+
+	function reportBounce(e: MouseEvent) {
+		e.stopPropagation();
+		if (member.email) onReportBounce?.(member.email);
 	}
 </script>
 
@@ -79,6 +98,20 @@
 					<Mail class="h-3 w-3" />
 					Email started
 				</span>
+				{#if canFlagBounce}
+					{#if reported}
+						<span class="text-xs text-[var(--coord-verified)]">Reported</span>
+					{:else}
+						<button
+							type="button"
+							class="bounce-flag text-xs text-slate-400 underline decoration-dotted underline-offset-2 py-2 -my-2 hover:text-slate-600"
+							disabled={reporting}
+							onclick={reportBounce}
+						>
+							didn't arrive?
+						</button>
+					{/if}
+				{/if}
 			{:else}
 				<span class="action-link flex items-center gap-0.5 text-xs text-slate-400 transition-colors duration-150">
 					Write to them
@@ -113,7 +146,7 @@
 	</button>
 {:else}
 	<div
-		class="entity min-h-[44px]
+		class="entity group min-h-[44px]
 			{departing ? 'departing-entity' : contacted ? 'entity--contacted' : ''}"
 	>
 		{@render entityContent()}
@@ -142,6 +175,27 @@
 	/* Contacted: the entity settles — quieter, done */
 	.entity--contacted :global(h4) { color: var(--color-slate-400); }
 	.entity--contacted :global(p) { color: var(--color-slate-300); }
+
+	/* Bounce flag — subsidiary inquiry affordance (dotted underline = inquiry,
+	   not a primary action). Recedes until the entity is hovered/focused on
+	   pointer devices; stays quietly visible on touch where there is no hover. */
+	.bounce-flag {
+		transition: opacity 150ms ease-out;
+	}
+	@media (hover: hover) and (pointer: fine) {
+		.bounce-flag {
+			opacity: 0;
+		}
+		:global(.group:hover) .bounce-flag,
+		.bounce-flag:focus-visible {
+			opacity: 1;
+		}
+	}
+	/* Submitting cue — scoped (unlayered) so it wins over the reveal rules above
+	   on pointer devices, where a Tailwind disabled: utility would not. */
+	.bounce-flag:disabled {
+		opacity: 0.5;
+	}
 
 	/* Departing */
 	.departing-entity { position: relative; }

--- a/src/lib/components/action/DistrictOfficialCard.svelte
+++ b/src/lib/components/action/DistrictOfficialCard.svelte
@@ -25,13 +25,21 @@
 		contacted = false,
 		departing = false,
 		onWriteTo,
-		showRoleBadge = false
+		showRoleBadge = false,
+		canReportBounce = false,
+		reported = false,
+		reporting = false,
+		onReportBounce
 	}: {
 		member: LandscapeMember;
 		contacted: boolean;
 		departing: boolean;
 		onWriteTo: (member: LandscapeMember) => void;
 		showRoleBadge?: boolean;
+		canReportBounce?: boolean;
+		reported?: boolean;
+		reporting?: boolean;
+		onReportBounce?: (email: string) => void;
 	} = $props();
 
 	function extractDomain(url: string): string {
@@ -45,10 +53,21 @@
 	const canAct = $derived(member.deliveryRoute !== 'recorded' && member.deliveryRoute !== 'phone_only');
 	const isActive = $derived(canAct && !contacted && !departing);
 
+	// A bounce only means something for a direct email route; CWC/form delivery
+	// has no email to bounce. Tier gate is enforced by the parent (server too).
+	const canFlagBounce = $derived(
+		canReportBounce && member.deliveryRoute === 'email' && !!member.email
+	);
+
 	function handleClick() {
 		if (isActive) {
 			onWriteTo(member);
 		}
+	}
+
+	function reportBounce(e: MouseEvent) {
+		e.stopPropagation();
+		if (member.email) onReportBounce?.(member.email);
 	}
 </script>
 
@@ -88,6 +107,20 @@
 					<Mail class="h-3 w-3" />
 					Email started
 				</span>
+				{#if canFlagBounce}
+					{#if reported}
+						<span class="text-xs text-[var(--coord-verified)]">Reported</span>
+					{:else}
+						<button
+							type="button"
+							class="bounce-flag text-xs text-slate-400 underline decoration-dotted underline-offset-2 py-2 -my-2 hover:text-slate-600"
+							disabled={reporting}
+							onclick={reportBounce}
+						>
+							didn't arrive?
+						</button>
+					{/if}
+				{/if}
 			{:else if member.deliveryRoute === 'cwc'}
 				<span class="action-link flex items-center gap-0.5 text-xs text-slate-400 transition-colors duration-150">
 					Send via {labels.legislativeBody}
@@ -138,7 +171,7 @@
 	</button>
 {:else}
 	<div
-		class="entity min-h-[44px]
+		class="entity group min-h-[44px]
 			{departing ? 'departing-entity' : contacted ? 'entity--contacted' : ''}"
 	>
 		{@render entityContent()}
@@ -164,6 +197,28 @@
 	}
 	.entity--contacted :global(h4) { color: var(--color-slate-400); }
 	.entity--contacted :global(p) { color: var(--color-slate-300); }
+
+	/* Bounce flag — subsidiary inquiry affordance (dotted underline = inquiry,
+	   not a primary action). Recedes until the entity is hovered/focused on
+	   pointer devices; stays quietly visible on touch where there is no hover. */
+	.bounce-flag {
+		transition: opacity 150ms ease-out;
+	}
+	@media (hover: hover) and (pointer: fine) {
+		.bounce-flag {
+			opacity: 0;
+		}
+		:global(.group:hover) .bounce-flag,
+		.bounce-flag:focus-visible {
+			opacity: 1;
+		}
+	}
+	/* Submitting cue — scoped (unlayered) so it wins over the reveal rules above
+	   on pointer devices, where a Tailwind disabled: utility would not. */
+	.bounce-flag:disabled {
+		opacity: 0.5;
+	}
+
 	.departing-entity { position: relative; }
 	.departing-pulse {
 		animation: breathe 1.5s ease-in-out infinite;

--- a/src/lib/components/action/PowerLandscape.svelte
+++ b/src/lib/components/action/PowerLandscape.svelte
@@ -18,7 +18,11 @@
 		onBatchRegister,
 		onVerifyAddress,
 		registrationState = 'idle',
-		isCongressional = false
+		isCongressional = false,
+		canReportBounce = false,
+		reportedBounces = new Set(),
+		reportingBounce = null,
+		onReportBounce
 	}: {
 		template: Template;
 		decisionMakers?: ProcessedDecisionMaker[];
@@ -30,6 +34,10 @@
 		onVerifyAddress?: () => void;
 		registrationState?: 'idle' | 'registering' | 'complete';
 		isCongressional?: boolean;
+		canReportBounce?: boolean;
+		reportedBounces?: Set<string>;
+		reportingBounce?: string | null;
+		onReportBounce?: (email: string) => void;
 	} = $props();
 
 	const landscape = $derived(mergeLandscape(decisionMakers, districtOfficials));
@@ -174,6 +182,10 @@
 						{contactedRecipients}
 						{departingRecipients}
 						{onWriteTo}
+						{canReportBounce}
+						{reportedBounces}
+						{reportingBounce}
+						{onReportBounce}
 						showRoleBadge={true}
 					/>
 				</div>
@@ -192,6 +204,10 @@
 					{contactedRecipients}
 					{departingRecipients}
 					{onWriteTo}
+					{canReportBounce}
+					{reportedBounces}
+					{reportingBounce}
+					{onReportBounce}
 					isDistrictGroup={true}
 				/>
 			</div>

--- a/src/lib/components/action/RoleGroup.svelte
+++ b/src/lib/components/action/RoleGroup.svelte
@@ -16,7 +16,11 @@
 		departingRecipients = new Set(),
 		onWriteTo,
 		isDistrictGroup = false,
-		showRoleBadge = false
+		showRoleBadge = false,
+		canReportBounce = false,
+		reportedBounces = new Set(),
+		reportingBounce = null,
+		onReportBounce
 	}: {
 		group: RoleGroupData | { label: string; members: LandscapeMember[] };
 		contactedRecipients: Set<string>;
@@ -24,6 +28,10 @@
 		onWriteTo: (member: LandscapeMember) => void;
 		isDistrictGroup?: boolean;
 		showRoleBadge?: boolean;
+		canReportBounce?: boolean;
+		reportedBounces?: Set<string>;
+		reportingBounce?: string | null;
+		onReportBounce?: (email: string) => void;
 	} = $props();
 
 	const headerMargin = $derived(group.members.length === 1 ? 'mb-2' : 'mb-3');
@@ -44,6 +52,10 @@
 					departing={departingRecipients.has(member.id)}
 					{onWriteTo}
 					{showRoleBadge}
+					{canReportBounce}
+					reported={!!member.email && reportedBounces.has(member.email)}
+					reporting={!!member.email && reportingBounce === member.email}
+					{onReportBounce}
 				/>
 			{:else}
 				<DecisionMakerLandscapeCard
@@ -52,6 +64,10 @@
 					departing={departingRecipients.has(member.id)}
 					{onWriteTo}
 					{showRoleBadge}
+					{canReportBounce}
+					reported={!!member.email && reportedBounces.has(member.email)}
+					reporting={!!member.email && reportingBounce === member.email}
+					{onReportBounce}
 				/>
 			{/if}
 		{/each}

--- a/src/lib/components/template-browser/TemplatePreview.svelte
+++ b/src/lib/components/template-browser/TemplatePreview.svelte
@@ -34,7 +34,7 @@
 		template: Template;
 		inModal?: boolean;
 		context?: 'list' | 'page' | 'modal';
-		user?: { id: string; name: string | null; trust_tier?: number; district_code?: string } | null;
+		user?: { id: string; name: string | null; trust_tier?: number; district_code?: string; credentialHash?: string | null } | null;
 		onScroll?: (isAtBottom: boolean, scrollProgress?: number) => void;
 		onOpenModal?: (() => void) | null;
 		onSendMessage?: (() => void) | null;

--- a/src/lib/components/template-browser/parts/PreviewContent.svelte
+++ b/src/lib/components/template-browser/parts/PreviewContent.svelte
@@ -49,7 +49,7 @@
 		template: Template;
 		inModal: boolean;
 		context?: 'list' | 'page' | 'modal';
-		user: { id: string; name: string | null; trust_tier?: number; district_code?: string } | null;
+		user: { id: string; name: string | null; trust_tier?: number; district_code?: string; credentialHash?: string | null } | null;
 		onScroll: (isAtBottom: boolean, scrollProgress?: number) => void;
 		personalConnectionValue: string;
 		onScrollStateChange?: (scrollState: unknown) => void;
@@ -70,7 +70,19 @@
 		return null;
 	});
 	const hasGovId = $derived(trustTier >= 3);
-	const proofHash = $derived(user?.id ? user.id.slice(0, 8) : null);
+	// The verify URL must point at a resolvable record. Only the user's active
+	// district credentialHash resolves at /v/[hash]; a truncated user id 404s.
+	// Null when unverified → no link is rendered (see {#if proofHash}).
+	const proofHash = $derived(user?.credentialHash ?? null);
+
+	// Suppress the footer entirely when there's nothing to attest — otherwise an
+	// unverified user (no label, no resolvable hash, no gov-ID upgrade CTA) gets
+	// an orphan divider over empty space.
+	const showProofFooter = $derived(
+		context === 'page' &&
+			!!user &&
+			(!!proofLabel || !!proofHash || (trustTier >= 2 && trustTier < 3 && !!onVerifyIdentity))
+	);
 
 	const recipients = $derived(extractRecipientEmails(template?.recipient_config));
 	const recipientConfig = $derived(parseRecipientConfig(template?.recipient_config));
@@ -411,7 +423,7 @@
 	{/if}
 
 	<!-- Proof footer: attestation carried by the message -->
-	{#if context === 'page' && user}
+	{#if showProofFooter}
 		<div class="proof-footer mt-8">
 			<div class="h-px bg-slate-300/50 mb-4"></div>
 			<div class="flex items-baseline gap-1.5 text-[13px]">
@@ -428,11 +440,13 @@
 				{/if}
 			</div>
 			{#if proofHash}
+				<!-- href carries the full hash (must match to resolve); the display is
+				     elided so the 64-char hash doesn't sprawl the proof footer. -->
 				<a
 					href="/v/{proofHash}"
 					class="mt-0.5 block font-mono text-xs text-slate-400 hover:text-slate-600 transition-colors"
 				>
-					commons.email/v/{proofHash}
+					commons.email/v/{proofHash.slice(0, 8)}&hellip;
 				</a>
 			{/if}
 

--- a/src/lib/config/features.ts
+++ b/src/lib/config/features.ts
@@ -24,7 +24,7 @@ if (import.meta.env.PROD && forceShadowAtlasOff && import.meta.env.VITE_ENVIRONM
 
 export const FEATURES = {
 	/** Deliberation surfaces, argument submission, LMSR market, resolution/appeal */
-	DEBATE: true,
+	DEBATE: false,
 
 	/**
 	 * CWC delivery, district officials, congressional template routing.

--- a/src/lib/core/agents/agents/subject-line.ts
+++ b/src/lib/core/agents/agents/subject-line.ts
@@ -217,7 +217,7 @@ ${options.description}`;
 		systemInstruction: systemPrompt,
 		responseSchema: SUBJECT_LINE_SCHEMA,
 		temperature: 0.7, // Creative latitude for sharp, resonant lines
-		thinkingLevel: 'medium', // Context extraction + copywriting — 'high' causes circular self-validation loops
+		thinkingLevel: 'low', // Issue extraction + a short subject line — low reasoning is sufficient and avoids over-elaboration
 		previousInteractionId: options.previousInteractionId
 	});
 
@@ -263,7 +263,7 @@ Generate the output with subject_line, core_message, topics, url_slug, and voice
 				systemInstruction: systemPrompt,
 				responseSchema: SUBJECT_LINE_SCHEMA,
 				temperature: 0.8, // Higher on retry for creative range
-				thinkingLevel: 'medium',
+				thinkingLevel: 'low',
 				previousInteractionId: currentInteractionId
 			}
 		);

--- a/src/lib/core/agents/gemini-client.ts
+++ b/src/lib/core/agents/gemini-client.ts
@@ -78,11 +78,16 @@ export function getGeminiClient(): GoogleGenAI {
 // ============================================================================
 
 export const GEMINI_CONFIG = {
-	model: 'gemini-3-flash-preview',
+	// Latest stable flash. The prior `gemini-3-flash-preview` ran away under the
+	// real agent prompts — generating to the 65k output cap (~64k tokens, ~200s,
+	// MAX_TOKENS truncation) on every subject-line call. 3.5-flash returns the
+	// same task cleanly in ~5s. Pinned (not `gemini-flash-latest`) so a future
+	// Google rollout can't silently reintroduce the regression.
+	model: 'gemini-3.5-flash',
 	defaults: {
 		temperature: 0.3,
 		maxOutputTokens: 65536,
-		thinkingLevel: 'medium' as const
+		thinkingLevel: 'low' as const
 	}
 } as const;
 

--- a/src/lib/services/emailService.ts
+++ b/src/lib/services/emailService.ts
@@ -313,14 +313,13 @@ export function generateMailtoUrl(
 					trustTier,
 				});
 				footer += `\n${proofLine}`;
+				// Only emit the verify URL when it resolves: the active credential
+				// hash is the record /v/[hash] looks up. A truncated user id 404s.
 				if (user?.credentialHash) {
 					footer += `\ncommons.email/v/${user.credentialHash}`;
-				} else if (user?.id) {
-					footer += `\ncommons.email/v/${user.id.slice(0, 8)}`;
 				}
 			} else if (trustTier >= 1) {
 				footer += '\nVerified sender';
-				if (user?.id) footer += `\ncommons.email/v/${user.id.slice(0, 8)}`;
 			}
 
 			const enhancedBody =

--- a/src/routes/s/[slug]/+page.server.ts
+++ b/src/routes/s/[slug]/+page.server.ts
@@ -5,7 +5,6 @@ import { api } from '$lib/convex';
 import { parseRecipientConfig } from '$lib/types/template';
 import { getOfficials } from '$lib/core/shadow-atlas/client';
 import type { DistrictOfficialInput } from '$lib/utils/landscapeMerge';
-import { computePseudonymousId } from '$lib/core/privacy/pseudonymous-id';
 import type { Id } from '$convex/_generated/dataModel';
 
 type DebateArgumentRow = {
@@ -48,11 +47,6 @@ type DebateRow = {
 	appealDeadline: number | null;
 	governanceJustification: string | null;
 	arguments: DebateArgumentRow[];
-};
-
-type UserDeliveryDTO = {
-	recipientKey?: string | null;
-	recipientName?: string | null;
 };
 
 const onchainId = (value: string | number | null | undefined): string =>
@@ -222,34 +216,11 @@ export const load: PageServerLoad = async ({ locals, parent }) => {
 		};
 	}
 
-	// Batch 2: Queries depending on Batch 1 results
-	const [deliveredRecipients, districtOfficials, engagementByDistrict] = await Promise.all([
-		// Deliveries persist across both paths: stance-agnostic (keyed on
-		// pseudonymousId) and stance-linked (tier-3+, via identityCommitment).
-		// pseudonymousId is available at tier 1+ — every authenticated user.
-		// computePseudonymousId throws if salt is missing — degrade gracefully
-		// rather than crashing the page load.
-		((): Promise<string[]> => {
-			if (!templateId || !userId) return Promise.resolve([]);
-			try {
-				const pseudoId = computePseudonymousId(userId);
-				return serverQuery(api.positions.getUserDeliveries, {
-							templateId,
-							pseudonymousId: pseudoId,
-							identityCommitment: identityCommitment ?? undefined,
-							deliveryMethod: 'email'
-						})
-						.then((deliveries: UserDeliveryDTO[]) =>
-							deliveries
-								.map((delivery) => delivery.recipientKey ?? delivery.recipientName)
-								.filter((recipient): recipient is string => Boolean(recipient))
-						)
-						.catch(() => []);
-			} catch {
-				return Promise.resolve([]);
-			}
-		})(),
-
+	// Batch 2: Queries depending on Batch 1 results.
+	// Delivery records are intentionally NOT loaded here: a mailto handoff is not
+	// a confirmed send, so prior "started" state must never persist across a
+	// reload or revisit to lock a user out of writing again.
+	const [districtOfficials, engagementByDistrict, credentialHash] = await Promise.all([
 		userDistrictCode
 			? getOfficials(userDistrictCode)
 					.then((data) =>
@@ -277,6 +248,16 @@ export const load: PageServerLoad = async ({ locals, parent }) => {
 						templateId,
 						userDistrictCode: userDistrictCode ?? undefined
 					}).catch(() => null)
+			: Promise.resolve(null),
+
+		// Active credential hash → the public /v/[hash] verify URL in proof footers.
+		// Auth-scoped (serverQuery carries the user's Convex token); resolves to the
+		// same row resolveCredentialHash validates, so the link never 404s. Null when
+		// the user has no active credential — callers then render no link.
+		userId
+			? serverQuery(api.users.getActiveCredentialHash, { userId: userId as Id<'users'> })
+					.then((r) => r?.credentialHash ?? null)
+					.catch(() => null)
 			: Promise.resolve(null)
 	]);
 
@@ -292,7 +273,8 @@ export const load: PageServerLoad = async ({ locals, parent }) => {
 			email: locals.user.email,
 			avatar: locals.user.avatar,
 			trust_tier: locals.user.trust_tier,
-			is_verified: locals.user.is_verified
+			is_verified: locals.user.is_verified,
+			credentialHash
 		} : null,
 		template: parentData.template,
 		channel: parentData.channel,
@@ -304,7 +286,6 @@ export const load: PageServerLoad = async ({ locals, parent }) => {
 		// Power Landscape data
 		positionCounts,
 		existingPosition,
-		deliveredRecipients,
 		districtOfficials: districtOfficials as DistrictOfficialInput[],
 		recipientConfig,
 		engagementByDistrict

--- a/src/routes/s/[slug]/+page.svelte
+++ b/src/routes/s/[slug]/+page.svelte
@@ -25,7 +25,6 @@
 	import type { EngagementData } from '$lib/types/engagement';
 	import {
 		mergeLandscape,
-		slugify,
 		type LandscapeMember,
 		type DistrictOfficialInput
 	} from '$lib/utils/landscapeMerge';
@@ -67,7 +66,9 @@
 		if (trustTier >= 2 && districtCode) parts.push(`Verified resident · ${districtCode}`);
 		else if (trustTier >= 1) parts.push('Verified sender');
 		if (trustTier >= 3) parts[0] += ' · Gov ID';
-		if (data.user?.id) parts.push(`commons.email/v/${data.user.id.slice(0, 8)}`);
+		// Only emit the verify URL when it resolves: the active credential hash is
+		// the record /v/[hash] looks up. A truncated user id always 404s.
+		if (data.user?.credentialHash) parts.push(`commons.email/v/${data.user.credentialHash}`);
 		return parts.length > 0 ? parts.join('\n') : undefined;
 	}
 	// Simplified - no query parameters needed, default to direct-link
@@ -331,7 +332,6 @@
 	interface PowerLandscapeData {
 		positionCounts?: { support: number; oppose: number; districts: number };
 		existingPosition?: { stance: string; registrationId: string } | null;
-		deliveredRecipients?: string[];
 		districtOfficials?: DistrictOfficialInput[];
 		recipientConfig?: {
 			decisionMakers?: ProcessedDecisionMaker[];
@@ -439,10 +439,6 @@
 		} else {
 			positionState.init(tmplId, counts);
 		}
-
-		// Restore sent recipients from delivery records
-		// Server stores raw recipient_name; client keys by slugify(name)
-		contactedRecipients = new Set((pl.deliveredRecipients ?? []).map(slugify));
 	});
 
 	// Auto-scroll to PowerLandscape on creator arrival (separate effect for reactivity isolation)
@@ -624,19 +620,11 @@
 		batchRegistrationState = 'idle';
 	}
 
-	// Resolve contacted members with emails for bounce reporting
-	const contactedMembers = $derived(
-		(() => {
-			if (contactedRecipients.size === 0) return [];
-			const allMembers = [
-				...landscape.roleGroups.flatMap((g) => g.members),
-				...(landscape.districtGroup?.members ?? [])
-			];
-			return allMembers.filter(
-				(m) => contactedRecipients.has(m.id) && m.email && !reportedBounces.has(m.email)
-			);
-		})()
-	);
+	// Bounce reporting requires address-verified identity (tier 2+); the server
+	// rejects lower tiers. Gate the per-recipient affordance so it only surfaces
+	// for users who can actually file a report — the action lives on the
+	// recipient entity (PowerLandscape → RoleGroup → card), not as an aggregate list.
+	const canReportBounce = $derived((data.user?.trust_tier ?? 0) >= 2);
 
 	async function handleReportBounce(email: string) {
 		if (reportingBounce || reportedBounces.has(email)) return;
@@ -1124,6 +1112,10 @@
 							}
 						: undefined}
 					registrationState={batchRegistrationState}
+					{canReportBounce}
+					{reportedBounces}
+					{reportingBounce}
+					onReportBounce={handleReportBounce}
 				/>
 
 				<!-- Coordination weight — stance tallies are category-error theater without
@@ -1160,27 +1152,11 @@
 					</div>
 				{/if}
 
-				{#if contactedMembers.length > 0}
-					<div class="mt-3 text-xs text-slate-400">
-						<span>Did an email bounce?</span>
-						{#each contactedMembers as member}
-							<button
-								class="ml-2 underline hover:text-slate-600 disabled:no-underline disabled:opacity-50"
-								disabled={reportingBounce === member.email}
-								onclick={() => member.email && handleReportBounce(member.email)}
-							>
-								{member.name}
-							</button>
-						{/each}
-					</div>
-				{/if}
+				<!-- Bounce reporting now lives on each contacted recipient entity
+				     (DecisionMakerLandscapeCard / DistrictOfficialCard) as a
+				     hover-revealed "didn't arrive?" flag — recognition in context,
+				     not an aggregate wall of names. -->
 
-				{#if reportedBounces.size > 0}
-					<p class="mt-1 text-xs text-green-600">
-						Noted — {reportedBounces.size === 1 ? 'this address' : 'these addresses'} won't appear in
-						future results.
-					</p>
-				{/if}
 			</div>
 
 			<!-- Debate surface -->

--- a/tests/unit/agents/gemini-provider.test.ts
+++ b/tests/unit/agents/gemini-provider.test.ts
@@ -151,13 +151,13 @@ describe('Gemini Client — Singleton & Configuration', () => {
 	});
 
 	it('GEMINI_CONFIG exposes expected model name', () => {
-		expect(GEMINI_CONFIG.model).toBe('gemini-3-flash-preview');
+		expect(GEMINI_CONFIG.model).toBe('gemini-3.5-flash');
 	});
 
 	it('GEMINI_CONFIG has sensible defaults', () => {
 		expect(GEMINI_CONFIG.defaults.temperature).toBe(0.3);
 		expect(GEMINI_CONFIG.defaults.maxOutputTokens).toBe(65536);
-		expect(GEMINI_CONFIG.defaults.thinkingLevel).toBe('medium');
+		expect(GEMINI_CONFIG.defaults.thinkingLevel).toBe('low');
 	});
 
 	it('getGeminiClient returns a client when API key is set', () => {


### PR DESCRIPTION
Recovers + melds the pre-spectrum-sweep WIP (set aside on 2026-06-14, preserved in a stash) onto current `main` (b226693a, post-spectrum #40). **Clean meld: 0 file conflicts** (main never touched these 13 files since the stash base), convex tsc 0, svelte-check 0 errors, **4,802 tests pass** — DEBATE:false broke nothing (debate tests are flag-aware).

## What it adds
- **Self-verifying proof footer** on the `/s/[slug]` action surface — emits `commons.email/v/{credentialHash}` *only when the hash resolves*, backed by a new auth-scoped `users.getActiveCredentialHash` (returns only the caller's own hash — no userId→hash→district enumeration oracle).
- **Tier-gated bounce reporting** on the action cards (`DecisionMakerLandscapeCard`/`DistrictOfficialCard`/`PowerLandscape`/`RoleGroup`) — affordance only for address-verified (tier 2+) users.
- **`/s/[slug]` refactor** — server + page, net smaller.
- **`gemini-3.5-flash`** — pinned (the prior `gemini-3-flash-preview` ran away under MAX_TOKENS on subject-line calls), `thinkingLevel: low`; the `gemini-provider` test updated to match (this is the source of the "2 gemini WIP-collateral" failures that shadowed every prior PR this session — now resolved).
- **`features.ts`: `DEBATE: false`** — intentional, per your direction to bring the WIP in including the flag.
- template-browser preview + emailService + subject-line tweaks.

## Evidence
0 conflicts on apply · convex tsc 0 · svelte-check 0 errors · vitest 4,802 passed (the prior 2 gemini failures fixed; regenerated `convex/_generated/api.d.ts` from the merged function set).

## Follow-up flagged (not in this PR — a decision)
DEBATE off makes the strategy corpus's "Adversarial Quality (Debate Markets)" a *dormant/flag-gated* capability (like CONGRESSIONAL), not a live one. Whether that's a launch-gate or a deprecation is a call — the docs may want a caveat once decided.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bounce reporting functionality for email delivery tracking.
  * Updated proof footer display to show abbreviated credential identifiers.

* **Improvements**
  * Enhanced credential verification integration throughout the platform.
  * Optimized AI model performance with configuration updates.

* **Chores**
  * Disabled DEBATE feature flag.
  * Refactored backend delivery record handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->