### PR TITLE
feat(landing): relation graph as the default discovery surface

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -54,6 +54,7 @@ import type * as intelligence from "../intelligence.js";
 import type * as invites from "../invites.js";
 import type * as legislation from "../legislation.js";
 import type * as lib_relatedness from "../lib/relatedness.js";
+import type * as lib_tag_concepts from "../lib/tag_concepts.js";
 import type * as messageJobs from "../messageJobs.js";
 import type * as networks from "../networks.js";
 import type * as observability from "../observability.js";
@@ -132,6 +133,7 @@ declare const fullApi: ApiFromModules<{
   invites: typeof invites;
   legislation: typeof legislation;
   "lib/relatedness": typeof lib_relatedness;
+  "lib/tag_concepts": typeof lib_tag_concepts;
   messageJobs: typeof messageJobs;
   networks: typeof networks;
   observability: typeof observability;

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -53,6 +53,7 @@ import type * as http from "../http.js";
 import type * as intelligence from "../intelligence.js";
 import type * as invites from "../invites.js";
 import type * as legislation from "../legislation.js";
+import type * as lib_relatedness from "../lib/relatedness.js";
 import type * as messageJobs from "../messageJobs.js";
 import type * as networks from "../networks.js";
 import type * as observability from "../observability.js";
@@ -130,6 +131,7 @@ declare const fullApi: ApiFromModules<{
   intelligence: typeof intelligence;
   invites: typeof invites;
   legislation: typeof legislation;
+  "lib/relatedness": typeof lib_relatedness;
   messageJobs: typeof messageJobs;
   networks: typeof networks;
   observability: typeof observability;

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -337,4 +337,19 @@ crons.daily(
   {},
 );
 
+// ---------------------------------------------------------------------------
+// 27. Relatedness calibration recompute — nightly refit of the public-corpus
+//     centroid + threshold the template relatedness query normalizes against,
+//     so the measured-twin edges track the corpus as it grows rather than
+//     freezing today's common-mode. Pure Convex compute, no external cost.
+//     03:23 UTC to stagger off reputation-recompute (03:11) and the other
+//     UTC-day-boundary crons clustered near midnight.
+// ---------------------------------------------------------------------------
+crons.daily(
+  "relatedness-calibration-recompute",
+  { hourUTC: 3, minuteUTC: 23 },
+  internal.templates.recomputeRelatednessCalibration,
+  {},
+);
+
 export default crons;

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -352,4 +352,18 @@ crons.daily(
   {},
 );
 
+// ---------------------------------------------------------------------------
+// 28. Tag-concept embedding backfill — embed any newly authored / edited tags
+//     so the tag-concept clustering (which folds synonyms and grounds the
+//     concept edges) tracks the corpus as it grows. Embeds only the tags that
+//     lack a vector, so the Gemini cost is a trivial one-time-per-tag charge.
+//     03:41 UTC to stagger off the calibration recompute and the midnight crons.
+// ---------------------------------------------------------------------------
+crons.daily(
+  "tag-concept-embedding-backfill",
+  { hourUTC: 3, minuteUTC: 41 },
+  internal.templates.backfillTagEmbeddings,
+  {},
+);
+
 export default crons;

--- a/convex/lib/relatedness.test.ts
+++ b/convex/lib/relatedness.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   computeCentroid,
+  computeCalibration,
   cosine,
   computeTwinEdges,
   TWIN_THRESHOLD,
@@ -47,6 +48,72 @@ describe("computeCentroid", () => {
 
   it("returns an empty vector for empty input (no throw, no NaN)", () => {
     expect(computeCentroid([])).toEqual([]);
+  });
+});
+
+describe("computeCalibration — persisted normalization", () => {
+  it("fits the corpus centroid + carries the threshold, count, and dim", () => {
+    const cal = computeCalibration(fixture());
+    expect(cal).not.toBeNull();
+    expect(cal!.threshold).toBe(TWIN_THRESHOLD);
+    expect(cal!.count).toBe(4);
+    expect(cal!.dim).toBe(4);
+    // The stored centroid IS the centroid computeTwinEdges would compute inline
+    // over the same corpus — the calibration and the edge gate are a matched set.
+    expect(cal!.centroid).toEqual(
+      computeCentroid(fixture().map((i) => i.embedding)),
+    );
+  });
+
+  it("carries an explicitly supplied threshold (re-derivable cutoff)", () => {
+    const cal = computeCalibration(fixture(), { threshold: 0.42 });
+    expect(cal!.threshold).toBe(0.42);
+  });
+
+  it("returns null below two usable embeddings (tiny-N floor — skip the write)", () => {
+    expect(computeCalibration([])).toBeNull();
+    expect(computeCalibration([{ id: "only", embedding: [1, 2, 3] }])).toBeNull();
+    // One usable + unusable items: still no common-mode to fit.
+    expect(
+      computeCalibration([
+        { id: "only", embedding: [1, 2, 3] },
+        { id: "empty", embedding: [] },
+        { id: "missing", embedding: undefined as unknown as number[] },
+      ]),
+    ).toBeNull();
+  });
+
+  it("ignores unusable / wrong-dimension items, mirroring the edge filter", () => {
+    const cal = computeCalibration([
+      ...fixture(),
+      { id: "empty", embedding: [] },
+      { id: "wrongdim", embedding: [1, 2] },
+    ]);
+    expect(cal).not.toBeNull();
+    // Only the 4 valid same-dimension items count.
+    expect(cal!.count).toBe(4);
+    expect(cal!.dim).toBe(4);
+    expect(cal!.centroid).toEqual(
+      computeCentroid(fixture().map((i) => i.embedding)),
+    );
+  });
+
+  it("is deterministic and order-independent (no clock/random)", () => {
+    const items = fixture();
+    const a = computeCalibration(items);
+    const b = computeCalibration([...items].reverse());
+    expect(a).toEqual(b);
+  });
+
+  it("feeding the calibration back into the edge gate reproduces the inline edges", () => {
+    const items = fixture();
+    const cal = computeCalibration(items)!;
+    const inline = computeTwinEdges(items);
+    const persisted = computeTwinEdges(items, {
+      centroid: cal.centroid,
+      threshold: cal.threshold,
+    });
+    expect(persisted).toEqual(inline);
   });
 });
 

--- a/convex/lib/relatedness.test.ts
+++ b/convex/lib/relatedness.test.ts
@@ -117,6 +117,53 @@ describe("computeCalibration — persisted normalization", () => {
   });
 });
 
+/**
+ * Calibration pin: the chosen TWIN_THRESHOLD against the MEASURED centered-cosine
+ * structure of the live public corpus. These are the actual full-corpus centered
+ * cosines (and worst leave-one-out views) measured over the published public
+ * templates that carry a topic embedding — the genuine topical-kinship head and
+ * the register-noise floor it must be separated from. The threshold has to sit in
+ * the gap: every genuine twin clears it on both its full and worst-LOO view, and
+ * the highest noise pair stays below it. If the threshold is ever retuned, these
+ * are the numbers it must keep classifying correctly.
+ */
+describe("TWIN_THRESHOLD — calibration against measured corpus pairs", () => {
+  // Genuine cross-template topical twins: { full-corpus centered cosine, worst
+  // leave-one-out centered cosine } as measured over the real corpus.
+  const GENUINE_TWINS = [
+    { pair: "parks-lands ~ land-and-energy-revenue", full: 0.1981, worstLoo: 0.173 },
+    { pair: "library ~ library", full: 0.1558, worstLoo: 0.1375 },
+  ];
+  // Register-noise pairs: topic drift, not kinship. Highest noise pair first.
+  const NOISE_PAIRS = [
+    { pair: "bike-share ~ parks-lands", full: 0.1169 },
+    { pair: "treatment-not-prison ~ affordable-homes", full: 0.1062 },
+    { pair: "children-privacy ~ preschool", full: 0.1119 },
+  ];
+
+  it("sits in the gap between genuine twins and the register-noise floor", () => {
+    const lowestGenuine = Math.min(...GENUINE_TWINS.map((t) => t.full));
+    const highestNoise = Math.max(...NOISE_PAIRS.map((p) => p.full));
+    // The threshold lives strictly between the two regimes.
+    expect(highestNoise).toBeLessThan(TWIN_THRESHOLD);
+    expect(TWIN_THRESHOLD).toBeLessThan(lowestGenuine);
+  });
+
+  it("clears every genuine twin on BOTH its full and worst-LOO view", () => {
+    for (const t of GENUINE_TWINS) {
+      // Gate 1 (full centroid) and Gate 2 (every LOO centroid, worst shown) both pass.
+      expect(t.full).toBeGreaterThanOrEqual(TWIN_THRESHOLD);
+      expect(t.worstLoo).toBeGreaterThanOrEqual(TWIN_THRESHOLD);
+    }
+  });
+
+  it("rejects every register-noise pair at Gate 1", () => {
+    for (const p of NOISE_PAIRS) {
+      expect(p.full).toBeLessThan(TWIN_THRESHOLD);
+    }
+  });
+});
+
 describe("computeTwinEdges — honesty invariants", () => {
   it("links the aligned-residual pair but NOT the genre-only pair (centered, not raw)", () => {
     const items = fixture();
@@ -143,12 +190,12 @@ describe("computeTwinEdges — honesty invariants", () => {
     // the relation is an artifact of that third item's presence, not a real
     // topical twin. The leave-one-out gate must reject it.
     const items: EmbeddedItem[] = [
-      { id: "p1", embedding: [-4, -3, 1] },
-      { id: "p2", embedding: [-1, -1, -2] },
-      { id: "n1", embedding: [3, 1, -4] },
-      { id: "n2", embedding: [3, 3, -1] },
-      { id: "n3", embedding: [-4, 3, -2] },
-      { id: "n4", embedding: [-1, 3, 5] },
+      { id: "p1", embedding: [2, -2, 3] },
+      { id: "p2", embedding: [4, 0, 3] },
+      { id: "n1", embedding: [3, 1, 2] },
+      { id: "n2", embedding: [-5, -3, -2] },
+      { id: "n3", embedding: [2, -5, 3] },
+      { id: "n4", embedding: [3, -3, 3] },
     ];
 
     // Confirm the trap: the pair clears under the full centroid...

--- a/convex/lib/relatedness.test.ts
+++ b/convex/lib/relatedness.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeCentroid,
+  cosine,
+  computeTwinEdges,
+  TWIN_THRESHOLD,
+  type EmbeddedItem,
+  type RelationEdge,
+} from "./relatedness";
+
+/**
+ * Build a small fixture in a tiny embedding space that mirrors the measured
+ * structure of the real corpus:
+ *
+ *   - a strong shared common-mode `g` (the "all civic templates" genre), so raw
+ *     cosine between any two items is high and near-uniform,
+ *   - two items whose RESIDUAL (after the common-mode) points the same way —
+ *     these are the real topical twins,
+ *   - two items dominated by the common-mode whose residuals are OPPOSED — raw
+ *     cosine links them, centered cosine must not.
+ *
+ * Each vector = G * g + (topical residual). G large ⇒ genre dominates raw cosine.
+ */
+const G = 10;
+const g = [1, 0, 0, 0]; // common-mode (genre) direction
+
+/** v = G*g + residual */
+function withGenre(residual: number[]): number[] {
+  return [G * g[0] + residual[0], G * g[1] + residual[1], G * g[2] + residual[2], G * g[3] + residual[3]];
+}
+
+function fixture(): EmbeddedItem[] {
+  return [
+    // Twin pair A — residuals aligned on axis 1.
+    { id: "alpha", embedding: withGenre([0, 1, 0, 0]) },
+    { id: "beta", embedding: withGenre([0, 1, 0, 0]) },
+    // Genre-only pair — residuals OPPOSED on axis 2; raw cosine high, centered low.
+    { id: "gamma", embedding: withGenre([0, 0, 1, 0]) },
+    { id: "delta", embedding: withGenre([0, 0, -1, 0]) },
+  ];
+}
+
+describe("computeCentroid", () => {
+  it("returns the per-dimension mean", () => {
+    expect(computeCentroid([[2, 0], [0, 4]])).toEqual([1, 2]);
+  });
+
+  it("returns an empty vector for empty input (no throw, no NaN)", () => {
+    expect(computeCentroid([])).toEqual([]);
+  });
+});
+
+describe("computeTwinEdges — honesty invariants", () => {
+  it("links the aligned-residual pair but NOT the genre-only pair (centered, not raw)", () => {
+    const items = fixture();
+
+    // Sanity: in RAW space the genre-only pair looks just as similar as the twins.
+    const rawTwin = cosine(items[0].embedding, items[1].embedding);
+    const rawGenre = cosine(items[2].embedding, items[3].embedding);
+    expect(rawGenre).toBeGreaterThan(0.9);
+    expect(rawTwin).toBeGreaterThan(0.9);
+
+    const edges = computeTwinEdges(items);
+    const pairs = edges.map((e) => `${e.a}|${e.b}`);
+
+    // The real topical twins are linked.
+    expect(pairs).toContain("alpha|beta");
+    // The genre-only (common-mode) pair is NOT — removing the common-mode kills it.
+    expect(pairs).not.toContain("delta|gamma");
+    expect(pairs).not.toContain("gamma|delta");
+  });
+
+  it("drops a pair whose relation depends on one other template (leave-one-out fragile)", () => {
+    // This pair clears the FULL-corpus centroid, but its centered cosine
+    // collapses when one particular neutral item is left out of the centroid —
+    // the relation is an artifact of that third item's presence, not a real
+    // topical twin. The leave-one-out gate must reject it.
+    const items: EmbeddedItem[] = [
+      { id: "p1", embedding: [-4, -3, 1] },
+      { id: "p2", embedding: [-1, -1, -2] },
+      { id: "n1", embedding: [3, 1, -4] },
+      { id: "n2", embedding: [3, 3, -1] },
+      { id: "n3", embedding: [-4, 3, -2] },
+      { id: "n4", embedding: [-1, 3, 5] },
+    ];
+
+    // Confirm the trap: the pair clears under the full centroid...
+    const center = (v: number[], c: number[]) => v.map((x, k) => x - c[k]);
+    const fullCentroid = computeCentroid(items.map((i) => i.embedding));
+    const fullScore = cosine(
+      center(items[0].embedding, fullCentroid),
+      center(items[1].embedding, fullCentroid),
+    );
+    expect(fullScore).toBeGreaterThanOrEqual(TWIN_THRESHOLD);
+
+    // ...but leaving out at least one of the other items drops it below threshold.
+    const others = items.slice(2).map((i) => i.id);
+    const looScores = others.map((dropId) => {
+      const looCentroid = computeCentroid(
+        items.filter((i) => i.id !== dropId).map((i) => i.embedding),
+      );
+      return cosine(
+        center(items[0].embedding, looCentroid),
+        center(items[1].embedding, looCentroid),
+      );
+    });
+    expect(Math.min(...looScores)).toBeLessThan(TWIN_THRESHOLD);
+
+    // So the gate rejects it: not in the emitted set.
+    const edges = computeTwinEdges(items);
+    expect(edges.map((e) => `${e.a}|${e.b}`)).not.toContain("p1|p2");
+  });
+
+  it("returns edge tuples ONLY — no vector-shaped field leaks", () => {
+    const edges = computeTwinEdges(fixture());
+    expect(edges.length).toBeGreaterThan(0);
+    for (const e of edges) {
+      expect(new Set(Object.keys(e))).toEqual(new Set(["a", "b", "score", "kind"]));
+      expect(typeof e.a).toBe("string");
+      expect(typeof e.b).toBe("string");
+      expect(typeof e.score).toBe("number");
+      expect(e.kind).toBe("twin");
+      // No property may be an array (an embedding or residual).
+      for (const val of Object.values(e as unknown as Record<string, unknown>)) {
+        expect(Array.isArray(val)).toBe(false);
+      }
+    }
+  });
+});
+
+describe("computeTwinEdges — robustness", () => {
+  it("templates without an embedding produce no twin edges and do not throw", () => {
+    const items = fixture();
+    const withMissing: EmbeddedItem[] = [
+      ...items,
+      { id: "noembed", embedding: [] },
+      { id: "missing", embedding: undefined as unknown as number[] },
+    ];
+    let edges: RelationEdge[] = [];
+    expect(() => {
+      edges = computeTwinEdges(withMissing);
+    }).not.toThrow();
+    const ids = new Set(edges.flatMap((e) => [e.a, e.b]));
+    expect(ids.has("noembed")).toBe(false);
+    expect(ids.has("missing")).toBe(false);
+    // The valid twins are still found despite the unusable items.
+    expect(edges.map((e) => `${e.a}|${e.b}`)).toContain("alpha|beta");
+  });
+
+  it("returns no edges with fewer than two usable embeddings", () => {
+    expect(computeTwinEdges([])).toEqual([]);
+    expect(computeTwinEdges([{ id: "only", embedding: [1, 2, 3] }])).toEqual([]);
+  });
+
+  it("ignores items whose embedding length differs from the corpus dimension", () => {
+    const items: EmbeddedItem[] = [
+      { id: "alpha", embedding: withGenre([0, 1, 0, 0]) },
+      { id: "beta", embedding: withGenre([0, 1, 0, 0]) },
+      { id: "wrongdim", embedding: [1, 2] },
+    ];
+    const edges = computeTwinEdges(items);
+    const ids = new Set(edges.flatMap((e) => [e.a, e.b]));
+    expect(ids.has("wrongdim")).toBe(false);
+  });
+
+  it("is deterministic and order-independent in its endpoints (no clock/random)", () => {
+    const items = fixture();
+    const a = computeTwinEdges(items);
+    const b = computeTwinEdges([...items].reverse());
+    // Same edge set regardless of input order; endpoints stably ordered (a < b).
+    expect(a).toEqual(b);
+    for (const e of a) expect(e.a < e.b).toBe(true);
+  });
+});

--- a/convex/lib/relatedness.ts
+++ b/convex/lib/relatedness.ts
@@ -1,0 +1,202 @@
+/**
+ * Measured-twin relatedness over a set of topic embeddings.
+ *
+ * Civic-action templates share a strong genre common-mode — every embedding
+ * points in roughly the same "this is a civic template" direction, so RAW
+ * pairwise cosine has a narrow, near-uniform spread and reads as noise. The
+ * topical signal lives in the RESIDUAL after that common-mode is removed.
+ *
+ * So we mean-center: subtract the corpus centroid from every vector, then
+ * L2-normalize the residual and take pairwise cosine on the residuals. That
+ * surfaces real topical kinship instead of register similarity.
+ *
+ * A pair is only emitted as a "twin" if its centered cosine clears the
+ * threshold AND survives a leave-one-out check over the corpus: when the
+ * centroid is recomputed with each OTHER single item also removed, the pair
+ * must still clear the threshold under every such centroid. A relation that
+ * only holds because one particular third template happens to be in the corpus
+ * is fragile — it would vanish the moment that template were unpublished — and
+ * the LOO gate drops it. (Recomputing the centroid only without the pair itself
+ * never lowers the pair's centered cosine, so that variant cannot reject; the
+ * robustness that actually filters is leaving out the OTHER items one at a time.)
+ *
+ * Everything here is pure: no clock, no randomness, no I/O. The same inputs
+ * always yield the same edges, so the surface is SSR-safe and deterministic.
+ *
+ * Threshold provenance: TWIN_THRESHOLD is calibrated against the measured
+ * structure of the live public corpus — the centered-cosine value that
+ * reproduces exactly the leave-one-out-stable cross-topic pairs (drug-treatment
+ * with housing/zoning, parks/lands with indigenous-energy, the two libraries
+ * templates, the bike-infra/freeway-removal transport pair) while excluding the
+ * genre-only adjacencies just below them. It is a residual-cosine cutoff, not
+ * an absolute raw-cosine guess; re-derive it from the centered-cosine
+ * distribution if the corpus shifts materially.
+ */
+
+/** A single embedded item entering the relatedness computation. */
+export interface EmbeddedItem {
+  /** Stable identifier (template id or slug) — carried through to the edge. */
+  id: string;
+  /** The topic embedding. Server-only; never returned to the client. */
+  embedding: number[];
+}
+
+/** An honest relatedness edge. Twin edges are the only kind this module emits. */
+export interface RelationEdge {
+  /** One endpoint id (the lexically-smaller of the pair, for stable ordering). */
+  a: string;
+  /** The other endpoint id. */
+  b: string;
+  /** Centered-cosine similarity of the pair, rounded for transport. */
+  score: number;
+  kind: "twin";
+}
+
+/**
+ * Calibrated centered-cosine cutoff for a measured twin. See the module header
+ * for provenance. A pair must clear this on the full-corpus centroid AND on
+ * every leave-one-out centroid (each computed with one other item removed) to
+ * be emitted.
+ */
+export const TWIN_THRESHOLD = 0.5;
+
+/** Mean of a set of equal-length vectors. Empty input → empty vector. */
+export function computeCentroid(vectors: number[][]): number[] {
+  if (vectors.length === 0) return [];
+  const dim = vectors[0].length;
+  const sum = new Array<number>(dim).fill(0);
+  for (const v of vectors) {
+    for (let i = 0; i < dim; i++) sum[i] += v[i];
+  }
+  for (let i = 0; i < dim; i++) sum[i] /= vectors.length;
+  return sum;
+}
+
+/** Subtract the centroid from a vector (common-mode removal). */
+function subtract(v: number[], centroid: number[]): number[] {
+  const out = new Array<number>(v.length);
+  for (let i = 0; i < v.length; i++) out[i] = v[i] - (centroid[i] ?? 0);
+  return out;
+}
+
+/** Cosine similarity of two vectors. Zero-magnitude inputs → 0 (never NaN). */
+export function cosine(a: number[], b: number[]): number {
+  let dot = 0;
+  let magA = 0;
+  let magB = 0;
+  const n = Math.min(a.length, b.length);
+  for (let i = 0; i < n; i++) {
+    dot += a[i] * b[i];
+    magA += a[i] * a[i];
+    magB += b[i] * b[i];
+  }
+  const denom = Math.sqrt(magA) * Math.sqrt(magB);
+  return denom === 0 ? 0 : dot / denom;
+}
+
+/** Centered cosine of two items against a given centroid (common-mode removed). */
+function centeredCosine(
+  a: number[],
+  b: number[],
+  centroid: number[],
+): number {
+  return cosine(subtract(a, centroid), subtract(b, centroid));
+}
+
+/**
+ * Compute measured-twin edges over the embedded items.
+ *
+ * - Items without a usable embedding (missing / wrong-length / empty) are
+ *   dropped before the computation and contribute no edges — never an error.
+ * - With fewer than two usable items there can be no pair, so the result is
+ *   empty.
+ * - The corpus centroid may be supplied (e.g. a persisted, nightly-refreshed
+ *   centroid); if omitted it is computed inline from the usable items.
+ * - Each candidate pair is gated twice: against the full-corpus centroid, and
+ *   against every leave-one-out centroid (the centroid recomputed with one
+ *   OTHER item removed). All must clear `threshold` — a pair whose relation
+ *   depends on one particular third template's presence is fragile and dropped.
+ *
+ * Deterministic and pure: identical inputs always yield identical edges, in a
+ * stable order.
+ */
+export function computeTwinEdges(
+  items: EmbeddedItem[],
+  options: { centroid?: number[]; threshold?: number } = {},
+): RelationEdge[] {
+  const threshold = options.threshold ?? TWIN_THRESHOLD;
+
+  // Keep only items with a usable, consistent-length embedding.
+  const usable = items.filter(
+    (it) => Array.isArray(it.embedding) && it.embedding.length > 0,
+  );
+  if (usable.length < 2) return [];
+  const dim = usable[0].embedding.length;
+  const valid = usable.filter((it) => it.embedding.length === dim);
+  if (valid.length < 2) return [];
+
+  const vectors = valid.map((it) => it.embedding);
+  const fullCentroid =
+    options.centroid && options.centroid.length === dim
+      ? options.centroid
+      : computeCentroid(vectors);
+
+  // Sum of all vectors — lets each leave-one-out centroid be derived in O(dim)
+  // (sum minus the removed item, over the remaining count) instead of re-summing.
+  const total = new Array<number>(dim).fill(0);
+  for (const v of vectors) {
+    for (let d = 0; d < dim; d++) total[d] += v[d];
+  }
+  const n = vectors.length;
+
+  const edges: RelationEdge[] = [];
+
+  for (let i = 0; i < valid.length; i++) {
+    for (let j = i + 1; j < valid.length; j++) {
+      const vi = valid[i].embedding;
+      const vj = valid[j].embedding;
+
+      // Gate 1: clears the threshold under the full-corpus centroid.
+      const full = centeredCosine(vi, vj, fullCentroid);
+      if (full < threshold) continue;
+
+      // Gate 2: leave-one-out over the OTHER items. For each other item k,
+      // recompute the centroid with k also removed and require the pair to stay
+      // above threshold. A relation contingent on one particular third
+      // template's presence is fragile and is dropped here. We track the
+      // weakest LOO view to score the edge conservatively.
+      let robust = true;
+      let weakestLoo = full;
+      if (n > 2) {
+        for (let k = 0; k < n && robust; k++) {
+          if (k === i || k === j) continue;
+          const looCentroid = new Array<number>(dim);
+          for (let d = 0; d < dim; d++) {
+            looCentroid[d] = (total[d] - vectors[k][d]) / (n - 1);
+          }
+          const loo = centeredCosine(vi, vj, looCentroid);
+          if (loo < threshold) {
+            robust = false;
+          } else if (loo < weakestLoo) {
+            weakestLoo = loo;
+          }
+        }
+      }
+      if (!robust) continue;
+
+      // Conservative score: the weakest view across full + every LOO centroid.
+      const score = Math.min(full, weakestLoo);
+      const [a, b] =
+        valid[i].id < valid[j].id
+          ? [valid[i].id, valid[j].id]
+          : [valid[j].id, valid[i].id];
+      edges.push({ a, b, score: Math.round(score * 1e4) / 1e4, kind: "twin" });
+    }
+  }
+
+  // Stable, deterministic ordering: strongest first, then by endpoint ids.
+  edges.sort(
+    (x, y) => y.score - x.score || (x.a < y.a ? -1 : x.a > y.a ? 1 : x.b < y.b ? -1 : x.b > y.b ? 1 : 0),
+  );
+  return edges;
+}

--- a/convex/lib/relatedness.ts
+++ b/convex/lib/relatedness.ts
@@ -60,6 +60,63 @@ export interface RelationEdge {
  */
 export const TWIN_THRESHOLD = 0.5;
 
+/**
+ * The persisted relatedness normalization: the corpus centroid (the genre
+ * common-mode that mean-centering removes) plus the calibrated twin threshold
+ * that travels with it. A scheduled job recomputes this from the live public
+ * corpus so the normalization tracks the corpus as it grows, and the edge query
+ * reads it instead of recomputing the centroid on every call.
+ *
+ * `threshold` is carried alongside the centroid so the two stay a matched set:
+ * the edge gate that ran when this centroid was fit can be reproduced exactly,
+ * and a future re-derivation of the cutoff from the centered-cosine
+ * distribution can overwrite both together.
+ */
+export interface RelatednessCalibration {
+  /** Corpus centroid — the common-mode subtracted before scoring. */
+  centroid: number[];
+  /** Calibrated centered-cosine cutoff in force when this centroid was fit. */
+  threshold: number;
+  /** Number of usable (embedded) templates the centroid was fit over. */
+  count: number;
+  /** Embedding dimensionality the centroid was fit in. */
+  dim: number;
+}
+
+/**
+ * Fit the relatedness normalization over a set of embedded items.
+ *
+ * Returns the corpus centroid + the calibrated threshold (a matched set the
+ * edge query consumes), or `null` when the corpus is too thin to normalize
+ * against. Mean-centering is meaningless below two usable embeddings — there is
+ * no spread to remove a common-mode from — so the caller (the recompute job)
+ * skips the write and keeps whatever prior calibration exists rather than
+ * overwriting it with nonsense at empty/one-template N.
+ *
+ * Pure: no clock, no randomness, no I/O. Mirrors the same usable-item filter as
+ * `computeTwinEdges`, so the centroid this fits is exactly the centroid that
+ * function would compute inline over the same corpus.
+ */
+export function computeCalibration(
+  items: EmbeddedItem[],
+  options: { threshold?: number } = {},
+): RelatednessCalibration | null {
+  const usable = items.filter(
+    (it) => Array.isArray(it.embedding) && it.embedding.length > 0,
+  );
+  if (usable.length < 2) return null;
+  const dim = usable[0].embedding.length;
+  const valid = usable.filter((it) => it.embedding.length === dim);
+  if (valid.length < 2) return null;
+
+  return {
+    centroid: computeCentroid(valid.map((it) => it.embedding)),
+    threshold: options.threshold ?? TWIN_THRESHOLD,
+    count: valid.length,
+    dim,
+  };
+}
+
 /** Mean of a set of equal-length vectors. Empty input → empty vector. */
 export function computeCentroid(vectors: number[][]): number[] {
   if (vectors.length === 0) return [];

--- a/convex/lib/relatedness.ts
+++ b/convex/lib/relatedness.ts
@@ -23,14 +23,18 @@
  * Everything here is pure: no clock, no randomness, no I/O. The same inputs
  * always yield the same edges, so the surface is SSR-safe and deterministic.
  *
- * Threshold provenance: TWIN_THRESHOLD is calibrated against the measured
- * structure of the live public corpus — the centered-cosine value that
- * reproduces exactly the leave-one-out-stable cross-topic pairs (drug-treatment
- * with housing/zoning, parks/lands with indigenous-energy, the two libraries
- * templates, the bike-infra/freeway-removal transport pair) while excluding the
- * genre-only adjacencies just below them. It is a residual-cosine cutoff, not
- * an absolute raw-cosine guess; re-derive it from the centered-cosine
- * distribution if the corpus shifts materially.
+ * Threshold provenance: TWIN_THRESHOLD is a residual (centered) cosine cutoff
+ * derived from the measured pairwise distribution of the live public corpus, not
+ * an absolute raw-cosine guess. Over that corpus the centered cosines separate
+ * into two regimes with a clear gap: a short head of genuine cross-template
+ * topical kinship — parks/public-lands stewardship with land-and-energy revenue
+ * (~0.198) and the two public-library templates (~0.156) — and a noise floor at
+ * and below ~0.117 (e.g. a bike-share template incidentally adjacent to the
+ * parks template, a treatment-vs-prison template adjacent to an affordable-homes
+ * one) that reads as topic drift, not kinship. The cutoff sits in that gap so
+ * the head is emitted and the floor is not. Re-derive it from the centered-cosine
+ * distribution if the corpus shifts materially: find the gap, put the cutoff in
+ * it, and re-confirm the leave-one-out gate still drops fragility-dependent pairs.
  */
 
 /** A single embedded item entering the relatedness computation. */
@@ -54,11 +58,12 @@ export interface RelationEdge {
 
 /**
  * Calibrated centered-cosine cutoff for a measured twin. See the module header
- * for provenance. A pair must clear this on the full-corpus centroid AND on
- * every leave-one-out centroid (each computed with one other item removed) to
- * be emitted.
+ * for provenance: it sits in the gap between the corpus's genuine topical-kinship
+ * head (lowest genuine pair ~0.156) and its register-noise floor (~0.117). A pair
+ * must clear this on the full-corpus centroid AND on every leave-one-out centroid
+ * (each computed with one other item removed) to be emitted.
  */
-export const TWIN_THRESHOLD = 0.5;
+export const TWIN_THRESHOLD = 0.13;
 
 /**
  * The persisted relatedness normalization: the corpus centroid (the genre

--- a/convex/lib/tag_concepts.test.ts
+++ b/convex/lib/tag_concepts.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect } from "vitest";
+import {
+  cosine,
+  clusterTagConcepts,
+  tagConceptMap,
+  conceptEdges,
+  CONCEPT_THRESHOLD,
+  type EmbeddedTag,
+  type TaggedTemplate,
+} from "./tag_concepts";
+
+/**
+ * A tiny embedding space mirroring the measured structure of the real tag
+ * corpus: every tag carries a strong shared common-mode `g` (the "civic-policy
+ * term" genre), so RAW cosine between any two tags is high and near-uniform. The
+ * topical signal lives in the residual after `g` is removed.
+ *
+ *   - Two synonyms ("libraries" / "library-card") have residuals pointing the
+ *     SAME way — real synonyms that must fold into one concept.
+ *   - Two genre-only tags have residuals that are OPPOSED — raw cosine links
+ *     them (the common-mode dominates), centered cosine must not: no concept, no
+ *     edge. This is the register-noise gate.
+ */
+const G = 10;
+
+/** v = G*g + residual, with g = axis 0. */
+function withGenre(residual: [number, number, number]): number[] {
+  return [G + residual[0], residual[1], residual[2]];
+}
+
+/** Synonyms: residuals aligned on axis 1. Distinct vectors, same direction. */
+const SYN_A: EmbeddedTag = { tag: "libraries", embedding: withGenre([0, 2, 0]) };
+const SYN_B: EmbeddedTag = { tag: "library-card", embedding: withGenre([0, 1, 0]) };
+
+/** Genre-only pair: residuals OPPOSED on axis 2 — register noise, not a concept. */
+const NOISE_A: EmbeddedTag = { tag: "rural-access", embedding: withGenre([0, 0, 1]) };
+const NOISE_B: EmbeddedTag = { tag: "ceo-pay-ratio", embedding: withGenre([0, 0, -1]) };
+
+function tagFixture(): EmbeddedTag[] {
+  return [SYN_A, SYN_B, NOISE_A, NOISE_B];
+}
+
+describe("clusterTagConcepts — centered synonym folding", () => {
+  it("folds synonyms whose residuals align, NOT genre-only tags (centered, not raw)", () => {
+    const tags = tagFixture();
+
+    // Sanity: in RAW space the genre-only pair looks just as similar as synonyms.
+    expect(cosine(NOISE_A.embedding, NOISE_B.embedding)).toBeGreaterThan(0.9);
+    expect(cosine(SYN_A.embedding, SYN_B.embedding)).toBeGreaterThan(0.9);
+
+    const concepts = clusterTagConcepts(tags);
+
+    // Exactly one folded concept: the two synonyms.
+    expect(concepts).toHaveLength(1);
+    expect(concepts[0].tags).toEqual(["libraries", "library-card"]);
+    // Canonical label = lexically-smallest member.
+    expect(concepts[0].concept).toBe("libraries");
+
+    // The genre-only tags fold into NOTHING — they are register noise after
+    // the common-mode is removed, so neither appears in any concept.
+    const folded = new Set(concepts.flatMap((c) => c.tags));
+    expect(folded.has("rural-access")).toBe(false);
+    expect(folded.has("ceo-pay-ratio")).toBe(false);
+  });
+
+  it("emits no concepts below two usable tags (nothing to fold)", () => {
+    expect(clusterTagConcepts([])).toEqual([]);
+    expect(clusterTagConcepts([SYN_A])).toEqual([]);
+    // One usable + unusable: still nothing to relate.
+    expect(
+      clusterTagConcepts([
+        SYN_A,
+        { tag: "empty", embedding: [] },
+        { tag: "missing", embedding: undefined as unknown as number[] },
+      ]),
+    ).toEqual([]);
+  });
+
+  it("keeps a concept TIGHT — complete linkage, no chaining unrelated tags", () => {
+    // A bridges to B and B bridges to C in centered space, but A and C are far.
+    // Single-linkage would chain all three; complete-linkage must not merge A&C
+    // into one concept because their cross-pair fails the threshold. Background
+    // tags pull the centroid off the three so the chain geometry is real (with
+    // only three points, centering alone makes adjacent residuals degenerate).
+    const tags: EmbeddedTag[] = [
+      { tag: "a-tag", embedding: withGenre([2, 0, 0]) },
+      { tag: "b-tag", embedding: withGenre([1, 1.2, 0]) },
+      { tag: "c-tag", embedding: withGenre([0, 2, 0]) },
+      { tag: "bg1", embedding: withGenre([-1, -1, 2]) },
+      { tag: "bg2", embedding: withGenre([-1, -1, -2]) },
+      { tag: "bg3", embedding: withGenre([0, -1, 0]) },
+    ];
+    // Confirm the trap: A~B and B~C clear, A~C does not, in centered space.
+    const dim = tags[0].embedding.length;
+    const centroid = Array.from(
+      { length: dim },
+      (_, i) => tags.reduce((s, t) => s + t.embedding[i], 0) / tags.length,
+    );
+    const r = (t: EmbeddedTag) => t.embedding.map((x, i) => x - centroid[i]);
+    expect(cosine(r(tags[0]), r(tags[1]))).toBeGreaterThanOrEqual(CONCEPT_THRESHOLD);
+    expect(cosine(r(tags[1]), r(tags[2]))).toBeGreaterThanOrEqual(CONCEPT_THRESHOLD);
+    expect(cosine(r(tags[0]), r(tags[2]))).toBeLessThan(CONCEPT_THRESHOLD);
+
+    const concepts = clusterTagConcepts(tags);
+    // No concept may contain both the far ends.
+    for (const c of concepts) {
+      const has = new Set(c.tags);
+      expect(has.has("a-tag") && has.has("c-tag")).toBe(false);
+    }
+  });
+
+  it("is deterministic and order-independent (no clock/random)", () => {
+    const a = clusterTagConcepts(tagFixture());
+    const b = clusterTagConcepts([...tagFixture()].reverse());
+    expect(a).toEqual(b);
+  });
+
+  it("ignores wrong-dimension tags so they cannot poison the centroid", () => {
+    const concepts = clusterTagConcepts([
+      ...tagFixture(),
+      { tag: "wrongdim", embedding: [1, 2] },
+    ]);
+    expect(concepts).toHaveLength(1);
+    const folded = new Set(concepts.flatMap((c) => c.tags));
+    expect(folded.has("wrongdim")).toBe(false);
+  });
+});
+
+describe("tagConceptMap — display normalization", () => {
+  it("maps every folded synonym to its canonical label; leaves loners out", () => {
+    const concepts = clusterTagConcepts(tagFixture());
+    const map = tagConceptMap(concepts);
+    expect(map["libraries"]).toBe("libraries");
+    expect(map["library-card"]).toBe("libraries");
+    // Register-noise tags never fold, so they get no entry (display raw).
+    expect(map["rural-access"]).toBeUndefined();
+    expect(map["ceo-pay-ratio"]).toBeUndefined();
+  });
+});
+
+describe("conceptEdges — honest edge gate", () => {
+  it("links templates sharing a TIGHT concept; never a raw-string or register match", () => {
+    const concepts = clusterTagConcepts(tagFixture());
+    const templates: TaggedTemplate[] = [
+      // Two templates that each carry a synonym of the SAME tight concept.
+      { id: "t1", tags: ["libraries", "rural-access"] },
+      { id: "t2", tags: ["library-card", "ceo-pay-ratio"] },
+    ];
+    const edges = conceptEdges(templates, concepts);
+
+    // Exactly one concept edge, on the shared tight concept.
+    expect(edges).toHaveLength(1);
+    expect(edges[0]).toEqual({ a: "t1", b: "t2", concept: "libraries", kind: "concept" });
+  });
+
+  it("emits NO edge when templates share only a register-noise tag", () => {
+    const concepts = clusterTagConcepts(tagFixture());
+    // Both carry "rural-access" — a raw-string match — but it is register noise
+    // (no tight concept), so it must ground no edge.
+    const templates: TaggedTemplate[] = [
+      { id: "t1", tags: ["rural-access"] },
+      { id: "t2", tags: ["rural-access"] },
+    ];
+    expect(conceptEdges(templates, concepts)).toEqual([]);
+  });
+
+  it("emits zero edges honestly when no tight concept spans two templates", () => {
+    const concepts = clusterTagConcepts(tagFixture());
+    // The tight concept exists, but only ONE template carries any of its tags.
+    const templates: TaggedTemplate[] = [
+      { id: "t1", tags: ["libraries", "library-card"] },
+      { id: "t2", tags: ["rural-access"] },
+    ];
+    expect(conceptEdges(templates, concepts)).toEqual([]);
+  });
+
+  it("emits zero edges when there are no tight concepts at all (sparse corpus)", () => {
+    // No synonyms anywhere — every residual points its own way after centering.
+    const tags: EmbeddedTag[] = [
+      { tag: "alpha", embedding: withGenre([0, 1, 0]) },
+      { tag: "beta", embedding: withGenre([0, 0, 1]) },
+      { tag: "gamma", embedding: withGenre([0, -1, -1]) },
+    ];
+    const concepts = clusterTagConcepts(tags);
+    expect(concepts).toEqual([]);
+    const templates: TaggedTemplate[] = [
+      { id: "t1", tags: ["alpha"] },
+      { id: "t2", tags: ["beta"] },
+      { id: "t3", tags: ["gamma"] },
+    ];
+    expect(conceptEdges(templates, concepts)).toEqual([]);
+  });
+
+  it("chains members of a broadly-shared concept (n-1 edges, not all-pairs)", () => {
+    // Three templates all carry tags of one tight concept -> a 3-node chain
+    // (2 edges), not a 3-edge triangle.
+    const concepts = clusterTagConcepts(tagFixture());
+    const templates: TaggedTemplate[] = [
+      { id: "t1", tags: ["libraries"] },
+      { id: "t2", tags: ["library-card"] },
+      { id: "t3", tags: ["libraries"] },
+    ];
+    const edges = conceptEdges(templates, concepts);
+    expect(edges).toHaveLength(2);
+    for (const e of edges) expect(e.a < e.b).toBe(true);
+  });
+
+  it("returns edge tuples ONLY — no vector-shaped field leaks", () => {
+    const concepts = clusterTagConcepts(tagFixture());
+    const edges = conceptEdges(
+      [
+        { id: "t1", tags: ["libraries"] },
+        { id: "t2", tags: ["library-card"] },
+      ],
+      concepts,
+    );
+    expect(edges.length).toBeGreaterThan(0);
+    for (const e of edges) {
+      expect(new Set(Object.keys(e))).toEqual(new Set(["a", "b", "concept", "kind"]));
+      expect(typeof e.a).toBe("string");
+      expect(typeof e.b).toBe("string");
+      expect(typeof e.concept).toBe("string");
+      expect(e.kind).toBe("concept");
+      for (const val of Object.values(e as unknown as Record<string, unknown>)) {
+        expect(Array.isArray(val)).toBe(false);
+      }
+    }
+  });
+
+  it("is deterministic and order-independent in its endpoints (no clock/random)", () => {
+    const concepts = clusterTagConcepts(tagFixture());
+    const templates: TaggedTemplate[] = [
+      { id: "t2", tags: ["library-card"] },
+      { id: "t1", tags: ["libraries"] },
+    ];
+    const a = conceptEdges(templates, concepts);
+    const b = conceptEdges([...templates].reverse(), concepts);
+    expect(a).toEqual(b);
+    for (const e of a) expect(e.a <= e.b).toBe(true);
+  });
+});
+
+describe("conceptEdges — no concepts means no edges", () => {
+  it("emits nothing when given an empty concept set", () => {
+    const templates: TaggedTemplate[] = [
+      { id: "t1", tags: ["libraries"] },
+      { id: "t2", tags: ["libraries"] },
+    ];
+    expect(conceptEdges(templates, [])).toEqual([]);
+  });
+});

--- a/convex/lib/tag_concepts.ts
+++ b/convex/lib/tag_concepts.ts
@@ -1,0 +1,349 @@
+/**
+ * Tag-concept normalization — denoise the tag space, add an honest edge source.
+ *
+ * Raw tag strings carry almost no relation across the corpus: two templates
+ * about the same concern label it with different words ("libraries" vs "library
+ * card", "preschool" vs "early-childhood"), so exact tag overlap is ~zero and an
+ * edge drawn from a shared raw string would be an accident of vocabulary, not a
+ * real relation. And the tag embeddings, like the template embeddings, share a
+ * strong genre common-mode (every tag points partly in the "civic-policy term"
+ * direction), so RAW tag cosine reads as register noise — everything looks
+ * similar because the genre dominates.
+ *
+ * So we treat tags the same way `relatedness.ts` treats templates: subtract the
+ * tag-corpus centroid (remove the common-mode), L2-normalize the residual, and
+ * work in centered-cosine space where the topical signal survives and the
+ * register similarity is gone. In that space we cluster tags into CONCEPTS — a
+ * concept is a set of tags whose centered residuals all point the same way, so
+ * "libraries" and "library card" fold into one concept while "libraries" and
+ * "rural-access" stay apart.
+ *
+ * Two things come out of this:
+ *
+ *   1. A raw-tag -> concept map, for consistent display: synonymous tags share a
+ *      canonical concept label so the surface doesn't show "libraries" and
+ *      "library card" as two unrelated topics.
+ *
+ *   2. An ADDITIVE, honest edge source. Two templates that each carry a tag in
+ *      the SAME tight concept get a `kind:'concept'` edge — subordinate to the
+ *      measured `twin`, comparable to the taxonomic `family`. The gate is the
+ *      same shape as the twin gate: only concepts that are TIGHT clusters in
+ *      centered space count. A concept formed only by raw-string match, or by
+ *      register-level proximity (tags that are close only because of the genre
+ *      common-mode), is never tight after centering and so emits no edge. If the
+ *      corpus is too sparse to form any tight cross-template concept — which is
+ *      the honest state at the seed — ZERO concept edges are emitted. The bar is
+ *      never lowered to manufacture them.
+ *
+ * Everything here is pure: no clock, no randomness, no I/O. Same inputs always
+ * yield the same concepts and edges, so the surface stays SSR-safe and
+ * deterministic. Raw embedding vectors enter these functions and never leave —
+ * only concept labels, the display map, and `{a,b,kind}` edge tuples cross out.
+ *
+ * Threshold provenance: CONCEPT_THRESHOLD is a centered-cosine cutoff calibrated
+ * the same way the twin threshold is — high enough that only genuinely
+ * synonymous tags (residuals pointing the same way) merge, while genre-only
+ * proximity (the common-mode that centering removes) falls below it. It is a
+ * residual-cosine cutoff, not a raw-cosine guess; re-derive it from the
+ * centered-cosine distribution if the tag corpus shifts materially.
+ */
+
+/** A raw tag paired with its server-only embedding. Vectors never leave here. */
+export interface EmbeddedTag {
+  /** The raw tag string as authored (e.g. "early-childhood"). */
+  tag: string;
+  /** The tag's topic embedding. Server-only; consumed here, never returned. */
+  embedding: number[];
+}
+
+/** A template and the raw tags it carries. */
+export interface TaggedTemplate {
+  /** Stable identifier (template id) — carried through to any concept edge. */
+  id: string;
+  /** The template's raw tags. */
+  tags: string[];
+}
+
+/**
+ * A tag concept: a tight cluster of synonymous tags in centered space. Carries
+ * the member tags and the canonical label used for display + edge attribution.
+ */
+export interface TagConcept {
+  /**
+   * Canonical concept label — the lexically-smallest member tag. Stable and
+   * deterministic; chosen by string, never by a wall-clock or insertion order.
+   */
+  concept: string;
+  /** The raw tags that fold into this concept (includes the canonical label). */
+  tags: string[];
+}
+
+/**
+ * A concept relation edge between two templates. Endpoints are template ids,
+ * stably ordered (`a <= b`). Taxonomic in spirit like `family`, so no score —
+ * the shared concept label is the justification a reader can check.
+ */
+export interface ConceptEdge {
+  a: string;
+  b: string;
+  /** The shared tight concept's canonical label — the edge's justification. */
+  concept: string;
+  kind: "concept";
+}
+
+/**
+ * Centered-cosine cutoff a pair of tags must clear to share a concept (and so a
+ * concept to be "tight"). Calibrated as a residual-cosine cutoff — see header.
+ * The same value gates both clustering (synonym folding) and the edge source, so
+ * a concept that yields an edge is exactly a concept tight enough to fold its
+ * tags for display: one bar, no second looser gate.
+ */
+export const CONCEPT_THRESHOLD = 0.5;
+
+/** Mean of a set of equal-length vectors. Empty input -> empty vector. */
+function computeCentroid(vectors: number[][]): number[] {
+  if (vectors.length === 0) return [];
+  const dim = vectors[0].length;
+  const sum = new Array<number>(dim).fill(0);
+  for (const v of vectors) {
+    for (let i = 0; i < dim; i++) sum[i] += v[i];
+  }
+  for (let i = 0; i < dim; i++) sum[i] /= vectors.length;
+  return sum;
+}
+
+/** Subtract the centroid from a vector (common-mode removal). */
+function subtract(v: number[], centroid: number[]): number[] {
+  const out = new Array<number>(v.length);
+  for (let i = 0; i < v.length; i++) out[i] = v[i] - (centroid[i] ?? 0);
+  return out;
+}
+
+/** Cosine similarity of two vectors. Zero-magnitude inputs -> 0 (never NaN). */
+export function cosine(a: number[], b: number[]): number {
+  let dot = 0;
+  let magA = 0;
+  let magB = 0;
+  const n = Math.min(a.length, b.length);
+  for (let i = 0; i < n; i++) {
+    dot += a[i] * b[i];
+    magA += a[i] * a[i];
+    magB += b[i] * b[i];
+  }
+  const denom = Math.sqrt(magA) * Math.sqrt(magB);
+  return denom === 0 ? 0 : dot / denom;
+}
+
+/**
+ * Keep one embedding per distinct tag, dropping unusable / wrong-dimension ones.
+ *
+ * The same tag may be authored on several templates; we cluster the tag VOCAB,
+ * not its occurrences, so a tag collapses to a single point here. When a tag
+ * appears with more than one embedding (e.g. embedded in slightly different
+ * contexts) the lexically-first occurrence wins — deterministic, no clock.
+ */
+function distinctUsableTags(tags: EmbeddedTag[]): EmbeddedTag[] {
+  const usable = tags.filter(
+    (t) =>
+      typeof t.tag === "string" &&
+      t.tag.length > 0 &&
+      Array.isArray(t.embedding) &&
+      t.embedding.length > 0,
+  );
+  if (usable.length === 0) return [];
+  // Lock the dimension to the most common length so a stray wrong-dim vector
+  // can't poison the centroid; mirrors the edge filter's same-dim discipline.
+  const dim = usable[0].embedding.length;
+  const sameDim = usable.filter((t) => t.embedding.length === dim);
+
+  const byTag = new Map<string, EmbeddedTag>();
+  for (const t of [...sameDim].sort((x, y) => (x.tag < y.tag ? -1 : x.tag > y.tag ? 1 : 0))) {
+    if (!byTag.has(t.tag)) byTag.set(t.tag, t);
+  }
+  return Array.from(byTag.values());
+}
+
+/**
+ * Cluster the tag vocabulary into CONCEPTS in mean-centered space.
+ *
+ * Steps:
+ *   1. Drop unusable tags; keep one vector per distinct tag (same dimension).
+ *   2. Subtract the tag-corpus centroid (remove the common-mode) and score every
+ *      tag pair by cosine on the residuals — the register-only similarity is
+ *      gone, only topical kinship remains.
+ *   3. Agglomerate with COMPLETE linkage: two clusters merge only if EVERY
+ *      cross-pair clears `threshold`. Complete linkage keeps a concept tight —
+ *      no chaining "library card" -> "card games" -> "board games" into one
+ *      blob — so a concept means "all these tags are mutually synonymous in
+ *      centered space", which is exactly the honesty the edge gate needs.
+ *
+ * Returns concepts with >= 2 tags only (a lone tag is its own trivial concept
+ * and needs no folding); the canonical label is the lexically-smallest member.
+ * Fewer than two usable tags -> no concepts (nothing to fold or relate).
+ *
+ * Pure and deterministic: identical inputs -> identical concepts, stable order.
+ */
+export function clusterTagConcepts(
+  tags: EmbeddedTag[],
+  options: { threshold?: number } = {},
+): TagConcept[] {
+  const threshold = options.threshold ?? CONCEPT_THRESHOLD;
+  const distinct = distinctUsableTags(tags);
+  if (distinct.length < 2) return [];
+
+  const centroid = computeCentroid(distinct.map((t) => t.embedding));
+  const residuals = distinct.map((t) => subtract(t.embedding, centroid));
+
+  // Pairwise centered cosine, symmetric. sim[i][j] is the residual cosine.
+  const n = distinct.length;
+  const sim: number[][] = Array.from({ length: n }, () => new Array<number>(n).fill(0));
+  for (let i = 0; i < n; i++) {
+    for (let j = i + 1; j < n; j++) {
+      const s = cosine(residuals[i], residuals[j]);
+      sim[i][j] = s;
+      sim[j][i] = s;
+    }
+  }
+
+  // Agglomerative complete-linkage. Each tag starts as its own cluster (a list
+  // of member indices). Merge the closest pair whose COMPLETE linkage (the
+  // weakest cross-pair) still clears the threshold; stop when none qualifies.
+  let clusters: number[][] = distinct.map((_, i) => [i]);
+
+  const completeLinkage = (ca: number[], cb: number[]): number => {
+    let weakest = Infinity;
+    for (const i of ca) {
+      for (const j of cb) {
+        if (sim[i][j] < weakest) weakest = sim[i][j];
+      }
+    }
+    return weakest;
+  };
+
+  for (;;) {
+    let bestLink = -Infinity;
+    let bestPair: [number, number] | null = null;
+    for (let x = 0; x < clusters.length; x++) {
+      for (let y = x + 1; y < clusters.length; y++) {
+        const link = completeLinkage(clusters[x], clusters[y]);
+        if (link >= threshold && link > bestLink) {
+          bestLink = link;
+          bestPair = [x, y];
+        }
+      }
+    }
+    if (!bestPair) break;
+    const [x, y] = bestPair;
+    const merged = [...clusters[x], ...clusters[y]];
+    clusters = clusters.filter((_, idx) => idx !== x && idx !== y);
+    clusters.push(merged);
+  }
+
+  // Materialize concepts of >= 2 tags. Canonical label = lexically-smallest tag.
+  const concepts: TagConcept[] = [];
+  for (const members of clusters) {
+    if (members.length < 2) continue;
+    const tagStrings = members
+      .map((i) => distinct[i].tag)
+      .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+    concepts.push({ concept: tagStrings[0], tags: tagStrings });
+  }
+  // Stable order: by canonical label.
+  concepts.sort((a, b) => (a.concept < b.concept ? -1 : a.concept > b.concept ? 1 : 0));
+  return concepts;
+}
+
+/**
+ * Build the raw-tag -> canonical-concept display map from a concept set.
+ *
+ * Only tags that fold into a multi-tag concept appear; a tag that stands alone
+ * is its own label and needs no entry (callers display the raw tag unchanged).
+ * Deterministic: the map is derived purely from the (already-sorted) concepts.
+ */
+export function tagConceptMap(concepts: TagConcept[]): Record<string, string> {
+  const map: Record<string, string> = {};
+  for (const c of concepts) {
+    for (const tag of c.tags) map[tag] = c.concept;
+  }
+  return map;
+}
+
+/**
+ * Emit the honest concept edges over a set of tagged templates.
+ *
+ * A concept edge links two templates that EACH carry at least one tag belonging
+ * to the SAME tight concept. The tightness gate already ran in
+ * `clusterTagConcepts` (complete-linkage above the centered-cosine threshold),
+ * so only genuinely synonymous tag groups can ground an edge — never a raw
+ * string match, never register-level proximity. Concepts that no two templates
+ * share emit nothing; if NO tight concept spans two templates, the result is
+ * empty (the honest state at a sparse corpus).
+ *
+ * Within a concept the member templates are linked as a single id-ordered CHAIN
+ * (n-1 edges), not an all-pairs blob — same bounded fan-out as the family edges,
+ * so a future broadly-shared concept doesn't drown the measured twins.
+ *
+ * Pure and deterministic: identical inputs -> identical edges, stable order.
+ * Endpoints normalized so `a <= b`, matching the twin/family edge convention so
+ * the three sources dedupe cleanly downstream.
+ */
+export function conceptEdges(
+  templates: TaggedTemplate[],
+  concepts: TagConcept[],
+): ConceptEdge[] {
+  if (concepts.length === 0) return [];
+
+  // raw tag -> canonical concept (only folded, multi-tag concepts).
+  const tagToConcept = tagConceptMap(concepts);
+
+  // concept label -> the set of template ids that carry any tag in it.
+  const byConcept = new Map<string, Set<string>>();
+  for (const t of templates) {
+    const id = t.id;
+    if (typeof id !== "string" || id.length === 0) continue;
+    if (!Array.isArray(t.tags)) continue;
+    // A template touches a concept at most once, even if it carries several of
+    // its synonyms — we relate templates, not tag occurrences.
+    const touched = new Set<string>();
+    for (const tag of t.tags) {
+      const concept = tagToConcept[tag];
+      if (concept) touched.add(concept);
+    }
+    for (const concept of touched) {
+      const set = byConcept.get(concept);
+      if (set) set.add(id);
+      else byConcept.set(concept, new Set([id]));
+    }
+  }
+
+  const edges: ConceptEdge[] = [];
+  for (const [concept, idSet] of byConcept) {
+    if (idSet.size < 2) continue; // a concept one template carries relates nobody
+    const ids = Array.from(idSet).sort((x, y) => (x < y ? -1 : x > y ? 1 : 0));
+    for (let i = 1; i < ids.length; i++) {
+      const lo = ids[i - 1];
+      const hi = ids[i];
+      const [a, b] = lo <= hi ? [lo, hi] : [hi, lo];
+      edges.push({ a, b, concept, kind: "concept" });
+    }
+  }
+
+  // Stable global order: by endpoints then concept.
+  edges.sort(
+    (e1, e2) =>
+      e1.a < e2.a
+        ? -1
+        : e1.a > e2.a
+          ? 1
+          : e1.b < e2.b
+            ? -1
+            : e1.b > e2.b
+              ? 1
+              : e1.concept < e2.concept
+                ? -1
+                : e1.concept > e2.concept
+                  ? 1
+                  : 0,
+  );
+  return edges;
+}

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -263,14 +263,20 @@ export default defineSchema({
 		districtCounts: v.optional(v.array(v.object({ code: v.string(), count: v.number() }))),
 		tierCounts: v.optional(v.array(v.number())),
 
-		// Semantic embeddings (768-dim Gemini vectors)
+		// Semantic embeddings (768-dim Gemini vectors). All three are SERVER-ONLY:
+		// consumed for vector search, relatedness twins, concept edges, and hue
+		// projection. The public template queries that return raw documents
+		// (`getBySlug`, `list`) run them through `stripEmbeddings` so these fields
+		// never cross the client boundary; the enriched queries (`listPublic`,
+		// `getBySlugPublic`) project explicit field sets that omit them.
 		locationEmbedding: v.optional(v.array(v.float64())),
 		topicEmbedding: v.optional(v.array(v.float64())),
 		// Per-tag embeddings, generated the same way as topicEmbedding (one Gemini
-		// vector per raw tag). Server-only: consumed to cluster tags into concepts
-		// and derive concept edges; never returned to the client (only concept
-		// labels and edge tuples cross out). Co-located with the template like
-		// topicEmbedding so the concept query reads them without a join.
+		// vector per raw tag). Consumed to cluster tags into concepts and derive
+		// concept edges; only concept labels and edge tuples cross out, never the
+		// vectors (stripped by the same projection as the other embeddings).
+		// Co-located with the template like topicEmbedding so the concept query
+		// reads them without a join.
 		tagEmbeddings: v.optional(
 			v.array(v.object({ tag: v.string(), embedding: v.array(v.float64()) }))
 		),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -3044,5 +3044,22 @@ export default defineSchema({
 		event: v.string(),
 		payload: v.string(), // JSON-serialized event payload (same shape as webhook payload)
 		emittedAt: v.number()
-	}).index('by_orgId_emittedAt', ['orgId', 'emittedAt'])
+	}).index('by_orgId_emittedAt', ['orgId', 'emittedAt']),
+
+	// Persisted relatedness normalization (singleton, keyed like smtRoots/treeId).
+	// Holds the public-corpus centroid — the genre common-mode that mean-centering
+	// removes before scoring template twins — plus the calibrated centered-cosine
+	// threshold that was in force when the centroid was fit. The template
+	// relatedness query reads this instead of recomputing the centroid on every
+	// call; a daily cron refits it so the normalization tracks the corpus as it
+	// grows. One canonical row under `key: 'public'`. Recompute is pure Convex
+	// compute — no external/recurring cost.
+	relatednessCalibration: defineTable({
+		key: v.string(), // singleton selector — always 'public'
+		centroid: v.array(v.float64()),
+		threshold: v.float64(),
+		count: v.number(), // usable (embedded) templates the centroid was fit over
+		dim: v.number(), // embedding dimensionality
+		updatedAt: v.number()
+	}).index('by_key', ['key'])
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -266,6 +266,14 @@ export default defineSchema({
 		// Semantic embeddings (768-dim Gemini vectors)
 		locationEmbedding: v.optional(v.array(v.float64())),
 		topicEmbedding: v.optional(v.array(v.float64())),
+		// Per-tag embeddings, generated the same way as topicEmbedding (one Gemini
+		// vector per raw tag). Server-only: consumed to cluster tags into concepts
+		// and derive concept edges; never returned to the client (only concept
+		// labels and edge tuples cross out). Co-located with the template like
+		// topicEmbedding so the concept query reads them without a join.
+		tagEmbeddings: v.optional(
+			v.array(v.object({ tag: v.string(), embedding: v.array(v.float64()) }))
+		),
 		embeddingVersion: v.string(),
 		embeddingsUpdatedAt: v.optional(v.number()),
 		domainHue: v.optional(v.float64()), // oklch hue angle (0-360) projected from topicEmbedding

--- a/convex/templates.ts
+++ b/convex/templates.ts
@@ -12,6 +12,7 @@ import {
 } from "./_individualAuthoringCap";
 import anchorsData from "./domain-anchors.json";
 import { computeTwinEdges, computeCalibration } from "./lib/relatedness";
+import { clusterTagConcepts, conceptEdges, tagConceptMap } from "./lib/tag_concepts";
 
 declare const process: { env: Record<string, string | undefined> };
 
@@ -20,6 +21,8 @@ const getByIdsRef = makeFunctionReference<"query">("templates:getByIds") as unkn
 const textSearchRef = makeFunctionReference<"query">("templates:textSearch") as unknown as FunctionReference<"query", "internal">;
 const listMissingEmbeddingsRef = makeFunctionReference<"query">("templates:listMissingEmbeddings") as unknown as FunctionReference<"query", "internal">;
 const patchEmbeddingsRef = makeFunctionReference<"mutation">("templates:patchEmbeddings") as unknown as FunctionReference<"mutation", "internal">;
+const listMissingTagEmbeddingsRef = makeFunctionReference<"query">("templates:listMissingTagEmbeddings") as unknown as FunctionReference<"query", "internal">;
+const patchTagEmbeddingsRef = makeFunctionReference<"mutation">("templates:patchTagEmbeddings") as unknown as FunctionReference<"mutation", "internal">;
 const listMissingDomainHueRef = makeFunctionReference<"query">("templates:_listMissingDomainHue") as unknown as FunctionReference<"query", "internal">;
 const patchDomainHueRef = makeFunctionReference<"mutation">("templates:_patchDomainHue") as unknown as FunctionReference<"mutation", "internal">;
 
@@ -69,6 +72,23 @@ function resolveDomain(doc: any): string {
   const cat = doc.category;
   if (cat && cat !== 'General') return cat;
   return '';
+}
+
+/**
+ * Normalize a template's `topics` (stored as untyped JSON) into clean tag
+ * strings: non-empty trimmed strings only, de-duplicated, stably ordered. Used
+ * by the tag-embedding backfill and the concept query so both see the same tag
+ * vocabulary regardless of how the raw field was authored.
+ */
+function normalizeTags(topics: unknown): string[] {
+  if (!Array.isArray(topics)) return [];
+  const seen = new Set<string>();
+  for (const t of topics) {
+    if (typeof t !== 'string') continue;
+    const tag = t.trim();
+    if (tag.length > 0) seen.add(tag);
+  }
+  return Array.from(seen).sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
 }
 
 /**
@@ -452,6 +472,77 @@ export const recomputeRelatednessCalibration = internalMutation({
     }
 
     return { updated: true, count: calibration.count, dim: calibration.dim };
+  },
+});
+
+/**
+ * Public: tag-concept relations over the public template set.
+ *
+ * Raw tag strings barely overlap and read as register noise, so they carry no
+ * relation on their own. This query pools every public template's per-tag
+ * embeddings (server-only 768-dim vectors), mean-centers them, and clusters the
+ * tag vocabulary into CONCEPTS in centered space — folding synonyms together
+ * while genre-only proximity falls below the tightness bar. From those tight
+ * concepts it returns:
+ *
+ *   - `conceptMap`: raw tag -> canonical concept label, for consistent display
+ *     (so "libraries" and "library card" show as one topic, not two).
+ *   - `edges`: `kind:'concept'` edges between templates that share a tight
+ *     concept — the additive, honest edge source (subordinate to `twin`,
+ *     comparable to `family`).
+ *
+ * Honest by construction: the same tightness gate that folds tags for display
+ * grounds the edges, so a concept formed by raw-string match or register-level
+ * proximity yields neither a fold nor an edge. If the corpus is too sparse to
+ * form any tight cross-template concept — the honest state at the seed — the
+ * `edges` array is empty. The vectors are consumed here and NEVER leave; only
+ * the concept labels and `{a,b,concept,kind}` tuples cross the boundary.
+ */
+export const conceptRelations = query({
+  args: {},
+  handler: async (
+    ctx,
+  ): Promise<{
+    edges: Array<{ a: string; b: string; concept: string; kind: "concept" }>;
+    conceptMap: Record<string, string>;
+  }> => {
+    const templates = await ctx.db
+      .query("templates")
+      .withIndex("by_status", (q) => q.eq("status", "published"))
+      .collect();
+
+    const publicTemplates = templates.filter((t) => t.isPublic);
+
+    // Pool the tag vocabulary across the corpus: one embedding per distinct tag
+    // (the clusterer de-dupes, but pooling here keeps the centroid honest — a
+    // concept is a property of the whole tag space, not of one template).
+    const tagVectors: Array<{ tag: string; embedding: number[] }> = [];
+    const taggedTemplates: Array<{ id: string; tags: string[] }> = [];
+    const seenTag = new Set<string>();
+
+    for (const t of publicTemplates) {
+      const tags = normalizeTags(t.topics);
+      taggedTemplates.push({ id: t._id as string, tags });
+      const tagEmbeddings = Array.isArray(t.tagEmbeddings) ? t.tagEmbeddings : [];
+      for (const te of tagEmbeddings) {
+        if (
+          te &&
+          typeof te.tag === "string" &&
+          Array.isArray(te.embedding) &&
+          te.embedding.length > 0 &&
+          !seenTag.has(te.tag)
+        ) {
+          seenTag.add(te.tag);
+          tagVectors.push({ tag: te.tag, embedding: te.embedding });
+        }
+      }
+    }
+
+    const concepts = clusterTagConcepts(tagVectors);
+    return {
+      edges: conceptEdges(taggedTemplates, concepts),
+      conceptMap: tagConceptMap(concepts),
+    };
   },
 });
 
@@ -1386,6 +1477,134 @@ export const patchEmbeddings = internalMutation({
       embeddingVersion: "gemini-001-768",
       embeddingsUpdatedAt: Date.now(),
       ...(args.domainHue !== undefined ? { domainHue: args.domainHue } : {}),
+    });
+  },
+});
+
+// =============================================================================
+// BACKFILL: Embed per-tag concepts (denoise the tag space for concept edges)
+// =============================================================================
+
+/**
+ * Internal: public published templates whose tags are not yet embedded.
+ *
+ * A template needs a tag-embedding pass when it carries tags but its stored
+ * `tagEmbeddings` don't cover the current tag set (newly authored, or tags
+ * edited since the last pass). Embedding ~a dozen tags per template is a trivial
+ * one-time Gemini cost, run alongside the topic-embedding backfill.
+ */
+export const listMissingTagEmbeddings = internalQuery({
+  args: {},
+  handler: async (ctx) => {
+    const templates = await ctx.db
+      .query("templates")
+      .filter((q) =>
+        q.and(
+          q.eq(q.field("isPublic"), true),
+          q.eq(q.field("status"), "published"),
+        ),
+      )
+      .collect();
+
+    return templates
+      .map((t) => ({ doc: t, tags: normalizeTags(t.topics) }))
+      .filter(({ doc, tags }) => {
+        if (tags.length === 0) return false; // nothing to embed
+        const covered = new Set(
+          (Array.isArray(doc.tagEmbeddings) ? doc.tagEmbeddings : [])
+            .filter((te) => te && Array.isArray(te.embedding) && te.embedding.length > 0)
+            .map((te) => te.tag),
+        );
+        // Re-embed only when some current tag has no embedding yet.
+        return tags.some((tag) => !covered.has(tag));
+      })
+      .sort((a, b) => b.doc._creationTime - a.doc._creationTime)
+      .map(({ doc, tags }) => ({ _id: doc._id, tags }));
+  },
+});
+
+/**
+ * Backfill per-tag embeddings via Gemini, mirroring the topicEmbedding path
+ * (same model, RETRIEVAL_DOCUMENT task type, 768 dimensions). Each tag is
+ * embedded once; the vectors are stored on the template (server-only) so the
+ * concept query can cluster the tag vocabulary into concepts. No auth — internal.
+ */
+export const backfillTagEmbeddings = internalAction({
+  args: {},
+  handler: async (ctx) => {
+    const missing: Array<{ _id: Id<"templates">; tags: string[] }> =
+      await ctx.runQuery(listMissingTagEmbeddingsRef);
+
+    if (missing.length === 0) {
+      console.log("[backfill-tags] All template tags are embedded.");
+      return { processed: 0 };
+    }
+
+    const apiKey = process.env.GEMINI_API_KEY;
+    if (!apiKey) {
+      console.error("[backfill-tags] GEMINI_API_KEY not configured in Convex env vars.");
+      return { processed: 0, error: "GEMINI_API_KEY missing" };
+    }
+
+    async function embed(text: string): Promise<number[] | null> {
+      const res = await fetch(
+        `https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-001:embedContent?key=${apiKey}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            content: { parts: [{ text }] },
+            taskType: "RETRIEVAL_DOCUMENT",
+            outputDimensionality: 768,
+          }),
+        },
+      );
+      if (!res.ok) return null;
+      const data = await res.json();
+      return data.embedding?.values ?? null;
+    }
+
+    let processed = 0;
+    for (const t of missing) {
+      try {
+        const embedded = await Promise.all(
+          t.tags.map(async (tag) => ({ tag, embedding: await embed(tag) })),
+        );
+        const tagEmbeddings = embedded
+          .filter((e): e is { tag: string; embedding: number[] } => Array.isArray(e.embedding))
+          .map((e) => ({ tag: e.tag, embedding: e.embedding }));
+
+        if (tagEmbeddings.length === 0) {
+          console.error(`[backfill-tags] Gemini returned no tag embeddings for ${t._id}`);
+          continue;
+        }
+
+        await ctx.runMutation(patchTagEmbeddingsRef, {
+          templateId: t._id,
+          tagEmbeddings,
+        });
+        processed++;
+        console.log(`[backfill-tags] Embedded ${tagEmbeddings.length} tags for ${t._id}`);
+      } catch (err) {
+        console.error(`[backfill-tags] Failed for ${t._id}:`, err);
+      }
+    }
+
+    console.log(`[backfill-tags] Done: ${processed}/${missing.length} templates.`);
+    return { processed, total: missing.length };
+  },
+});
+
+/** Internal mutation: store per-tag embeddings (server-only) on a template. */
+export const patchTagEmbeddings = internalMutation({
+  args: {
+    templateId: v.id("templates"),
+    tagEmbeddings: v.array(v.object({ tag: v.string(), embedding: v.array(v.float64()) })),
+  },
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.templateId, {
+      tagEmbeddings: args.tagEmbeddings,
+      embeddingsUpdatedAt: Date.now(),
     });
   },
 });

--- a/convex/templates.ts
+++ b/convex/templates.ts
@@ -92,8 +92,23 @@ function normalizeTags(topics: unknown): string[] {
 }
 
 /**
+ * Strip the server-only embedding vectors from a template document before it
+ * crosses the client boundary. The 768-dim `topicEmbedding` / `locationEmbedding`
+ * and the per-tag `tagEmbeddings` are consumed only server-side (relatedness +
+ * concept edges, vector search); they are never part of a client-returned
+ * template. Every other field is preserved.
+ */
+function stripEmbeddings<T extends Record<string, unknown>>(
+  doc: T,
+): Omit<T, "topicEmbedding" | "locationEmbedding" | "tagEmbeddings"> {
+  const { topicEmbedding, locationEmbedding, tagEmbeddings, ...rest } = doc;
+  return rest;
+}
+
+/**
  * Public: List published templates, ordered by creation time (newest first).
- * Paginated via Convex's built-in pagination.
+ * Paginated via Convex's built-in pagination. Embedding vectors are stripped —
+ * they are server-only and must not reach the client.
  */
 export const list = query({
   args: {
@@ -103,7 +118,7 @@ export const list = query({
     }),
   },
   handler: async (ctx, args) => {
-    return await ctx.db
+    const result = await ctx.db
       .query("templates")
       .withIndex("by_status", (q) => q.eq("status", "published"))
       .order("desc")
@@ -111,6 +126,7 @@ export const list = query({
         numItems: Math.min(args.paginationOpts.numItems, 50),
         cursor: args.paginationOpts.cursor ?? null,
       });
+    return { ...result, page: result.page.map(stripEmbeddings) };
   },
 });
 
@@ -132,7 +148,8 @@ export const getBySlug = query({
       return null;
     }
 
-    return template;
+    // Strip the server-only embedding vectors before returning to the client.
+    return stripEmbeddings(template);
   },
 });
 

--- a/convex/templates.ts
+++ b/convex/templates.ts
@@ -11,7 +11,7 @@ import {
   AUTHORING_QUOTA_EXCEEDED,
 } from "./_individualAuthoringCap";
 import anchorsData from "./domain-anchors.json";
-import { computeTwinEdges } from "./lib/relatedness";
+import { computeTwinEdges, computeCalibration } from "./lib/relatedness";
 
 declare const process: { env: Record<string, string | undefined> };
 
@@ -367,9 +367,91 @@ export const relatednessEdges = query({
       .filter((t) => t.isPublic && Array.isArray(t.topicEmbedding) && t.topicEmbedding.length > 0)
       .map((t) => ({ id: t._id as string, embedding: t.topicEmbedding as number[] }));
 
-    // The corpus centroid is computed inline (cheap at this N). A persisted,
-    // nightly-refreshed centroid can be threaded in here once it exists.
-    return computeTwinEdges(items);
+    // Prefer the persisted, daily-refreshed normalization (centroid + the
+    // threshold calibrated against it). Falling back to inline compute when no
+    // calibration row exists yet — the cold-start path before the first cron
+    // run, and the only path needed if the schedule is ever paused. Stale
+    // calibration is harmless: it only shifts the common-mode subtracted before
+    // scoring, and the daily refit keeps it tracking the corpus.
+    const calibration = await ctx.db
+      .query("relatednessCalibration")
+      .withIndex("by_key", (q) => q.eq("key", RELATEDNESS_CALIBRATION_KEY))
+      .unique();
+
+    // The stored centroid only applies if it was fit in the same dimensionality
+    // as today's embeddings; otherwise let the helper recompute it inline.
+    const dim = items[0]?.embedding.length;
+    const centroid =
+      calibration && calibration.dim === dim ? calibration.centroid : undefined;
+
+    return computeTwinEdges(items, {
+      centroid,
+      threshold: calibration?.threshold,
+    });
+  },
+});
+
+/**
+ * Singleton selector for the persisted relatedness normalization. One canonical
+ * row keyed by this string (the smtRoots/treeId singleton idiom).
+ */
+const RELATEDNESS_CALIBRATION_KEY = "public";
+
+/**
+ * Refit the persisted relatedness normalization over the live public corpus.
+ *
+ * Recomputes the corpus centroid (the genre common-mode removed before scoring
+ * template twins) + the calibrated threshold via the same pure helper the edge
+ * query uses, and upserts the singleton row. Run daily by cron so the
+ * normalization tracks the corpus as templates accumulate or churn.
+ *
+ * Idempotent and side-effect-free beyond the single singleton write: same
+ * corpus → same centroid → same row. Guards the tiny-corpus floor — fewer than
+ * two embedded public templates leaves nothing to fit a common-mode against, so
+ * the write is skipped and any prior calibration is preserved rather than
+ * overwritten with nonsense. Pure Convex compute, no external cost.
+ */
+export const recomputeRelatednessCalibration = internalMutation({
+  args: {},
+  handler: async (
+    ctx,
+  ): Promise<{ updated: boolean; count: number; dim: number }> => {
+    const templates = await ctx.db
+      .query("templates")
+      .withIndex("by_status", (q) => q.eq("status", "published"))
+      .collect();
+
+    const items = templates
+      .filter((t) => t.isPublic && Array.isArray(t.topicEmbedding) && t.topicEmbedding.length > 0)
+      .map((t) => ({ id: t._id as string, embedding: t.topicEmbedding as number[] }));
+
+    const calibration = computeCalibration(items);
+    // Too thin to normalize — keep the prior calibration (if any) untouched.
+    if (!calibration) {
+      return { updated: false, count: items.length, dim: 0 };
+    }
+
+    const existing = await ctx.db
+      .query("relatednessCalibration")
+      .withIndex("by_key", (q) => q.eq("key", RELATEDNESS_CALIBRATION_KEY))
+      .unique();
+
+    const row = {
+      key: RELATEDNESS_CALIBRATION_KEY,
+      centroid: calibration.centroid,
+      threshold: calibration.threshold,
+      count: calibration.count,
+      dim: calibration.dim,
+      updatedAt: Date.now(),
+    };
+
+    if (existing) {
+      await ctx.db.patch(existing._id, row);
+    } else {
+      await ctx.db.insert("relatednessCalibration", row);
+    }
+
+    return { updated: true, count: calibration.count, dim: calibration.dim };
   },
 });
 

--- a/convex/templates.ts
+++ b/convex/templates.ts
@@ -11,6 +11,7 @@ import {
   AUTHORING_QUOTA_EXCEEDED,
 } from "./_individualAuthoringCap";
 import anchorsData from "./domain-anchors.json";
+import { computeTwinEdges } from "./lib/relatedness";
 
 declare const process: { env: Record<string, string | undefined> };
 
@@ -336,6 +337,39 @@ export const listPublic = query({
         createdAt: new Date(creationTime).toISOString(),
       };
     });
+  },
+});
+
+/**
+ * Public: measured-twin relatedness edges over the public template set.
+ *
+ * Loads only the published public templates that carry a topic embedding,
+ * computes mean-centered (common-mode-removed) pairwise cosine, and returns the
+ * pairs that clear the calibrated threshold and survive the leave-one-out
+ * robustness check. The embeddings stay on the server — the payload is ONLY
+ * edge tuples ({a, b, score, kind}) keyed by template id, never any vector.
+ *
+ * Templates without an embedding simply contribute no twin edges (not an
+ * error), so the surface stays honest about a sparse, partly-isolated corpus.
+ */
+export const relatednessEdges = query({
+  args: {},
+  handler: async (ctx): Promise<Array<{ a: string; b: string; score: number; kind: "twin" }>> => {
+    const templates = await ctx.db
+      .query("templates")
+      .withIndex("by_status", (q) => q.eq("status", "published"))
+      .collect();
+
+    // Public templates that actually have a topic embedding. Missing embeddings
+    // contribute nothing (they are not an error). The 768-dim vectors are read
+    // here and consumed only inside the pure helper — they never leave.
+    const items = templates
+      .filter((t) => t.isPublic && Array.isArray(t.topicEmbedding) && t.topicEmbedding.length > 0)
+      .map((t) => ({ id: t._id as string, embedding: t.topicEmbedding as number[] }));
+
+    // The corpus centroid is computed inline (cheap at this N). A persisted,
+    // nightly-refreshed centroid can be threaded in here once it exists.
+    return computeTwinEdges(items);
   },
 });
 

--- a/src/lib/components/template-browser/DescentDive.svelte
+++ b/src/lib/components/template-browser/DescentDive.svelte
@@ -1,0 +1,279 @@
+<script lang="ts">
+	/**
+	 * DescentDive — the one Artifact-over-scrim descent.
+	 *
+	 * Selecting a template anywhere on the landing — a spectrum tile, a relation-map
+	 * node — is falling into it. This is the single implementation of that fall: the
+	 * WHOLE page recedes behind one full-viewport backdrop scrim (blur + a faint warm
+	 * dim) and the chosen template ascends into an Artifact — the one white bounded
+	 * surface for a floated object — wrapping the page's own preview. Because the
+	 * scrim is one fixed plane over everything, the field, the hero beside it, and the
+	 * header above it recede together, as one — no half-sharp seam, one composited blur
+	 * layer. Back / esc / a tap on the scrim reverses the fall: the Artifact settles
+	 * away, the page returns to the EXACT state it left (scroll position, selection
+	 * cleared), and focus lands back on the surface the dive rose from.
+	 *
+	 * It is deliberately not coupled to any one surface's state. Every caller —
+	 * spectrum, graph — passes the same three things: the preview to mount (`dive`),
+	 * whether the descent is `open`, and an `onClose` to report the climb-out. So there
+	 * is exactly ONE descent vocabulary; the surfaces share it rather than each forking
+	 * a modal. A surface that wants focus returned to its originating element on close
+	 * names it with `restoreFocusSelector` (a CSS selector resolved against the
+	 * document); without one, the dive simply releases focus.
+	 *
+	 * SSR-safe: the descent only exists on the client (the effect that opens it never
+	 * runs under SSR), so the window/document reads need no environment guard.
+	 */
+
+	import type { Snippet } from 'svelte';
+	import { tick } from 'svelte';
+	import { Artifact } from '$lib/design';
+	import { TIMING, EASING } from '$lib/design/motion';
+
+	interface Props {
+		/** The chosen template's preview, supplied by the page already wired to its
+		 *  send flow / personalization / proof footer. Mounted inside the risen
+		 *  Artifact unchanged — the descent is a mount and a transition around it,
+		 *  never a fork. */
+		dive: Snippet;
+		/** Whether the descent is engaged. True → the page recedes and the preview
+		 *  ascends; false → nothing renders and the page is at rest. */
+		open: boolean;
+		/** Called when the dive closes (esc, back, or a tap on the receded page behind
+		 *  it). The caller clears its selection here so the page returns to its exact
+		 *  prior state. Required for the descent to be reversible. */
+		onClose: () => void;
+		/** Optional CSS selector for the element the dive rose from (a tile, a node),
+		 *  so focus returns there on close — the field comes back exactly where it
+		 *  left. Absent → focus is simply released. */
+		restoreFocusSelector?: string | null;
+	}
+
+	let { dive, open, onClose, restoreFocusSelector = null }: Props = $props();
+
+	// The body scroll position captured as the dive opens, restored as it closes, so
+	// the page comes back exactly where it was — the reversibility the descent
+	// promises. The element focus was on (the originating tile/node) is restored too.
+	let lockedScrollY = 0;
+	let diveSurface = $state<HTMLElement | null>(null);
+	let restoreSelector: string | null = null;
+
+	function lockFieldScroll() {
+		lockedScrollY = window.scrollY;
+		document.body.style.position = 'fixed';
+		document.body.style.top = `-${lockedScrollY}px`;
+		document.body.style.left = '0';
+		document.body.style.right = '0';
+	}
+
+	function unlockFieldScroll() {
+		document.body.style.position = '';
+		document.body.style.top = '';
+		document.body.style.left = '';
+		document.body.style.right = '';
+		window.scrollTo(0, lockedScrollY);
+	}
+
+	// Open / close is driven by `open`. On open: remember the originating element's
+	// selector, lock the page's scroll, move focus into the Artifact. On close:
+	// restore the scroll and return focus to the originating element. Effects never
+	// run under SSR and the dive only exists on the client, so the window/document
+	// reads need no guard.
+	$effect(() => {
+		if (!open) return;
+		restoreSelector = restoreFocusSelector;
+		lockFieldScroll();
+		// Focus the first focusable inside the risen Artifact once it has mounted.
+		// `preventScroll` so moving focus never nudges the (fixed) body underneath.
+		tick().then(() => {
+			const first = diveSurface?.querySelector<HTMLElement>(
+				'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+			);
+			(first ?? diveSurface)?.focus({ preventScroll: true });
+		});
+		return () => {
+			unlockFieldScroll();
+			// Return focus to the element the dive rose from, so the page knows where it
+			// came back to. `preventScroll` is essential: a bare focus() scrolls that
+			// element into view and would override the exact scroll position we just
+			// restored — the page must come back where it left, not jump to the tile.
+			const selector = restoreSelector;
+			restoreSelector = null;
+			tick().then(() => {
+				if (!selector) return;
+				document.querySelector<HTMLElement>(selector)?.focus({ preventScroll: true });
+			});
+		};
+	});
+
+	function closeDive() {
+		onClose();
+	}
+
+	// Portal the descent layer to <body>. A surface sits inside its own page column,
+	// which is a positioned, z-indexed stacking context, and the hero beside it sits
+	// in a sticky higher-z column — so a scrim left in place would be capped at the
+	// column's z-index and the hero would paint OVER it, leaving one half sharp.
+	// Moving the layer to <body> lifts it to the document root, where its z-index
+	// clears every page context and its backdrop-filter blurs the WHOLE page beneath
+	// it as one. Mirrors the existing body-portal pattern (AnimatedPopover).
+	// Client-only (actions never run under SSR), so the document reads need no guard.
+	function portalToBody(node: HTMLElement) {
+		document.body.appendChild(node);
+		return {
+			destroy() {
+				node.remove();
+			}
+		};
+	}
+
+	// Esc reverses the dive. A keydown on the descent layer is enough — focus is
+	// trapped inside it while diving, so the handler always sees the key.
+	function handleDiveKeydown(event: KeyboardEvent) {
+		if (event.key === 'Escape') {
+			event.preventDefault();
+			closeDive();
+			return;
+		}
+		if (event.key !== 'Tab') return;
+		// Trap focus inside the Artifact: wrap from last → first and first → last so
+		// tab never leaves the risen object for the receded field beneath it.
+		const focusables = diveSurface?.querySelectorAll<HTMLElement>(
+			'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+		);
+		if (!focusables || focusables.length === 0) return;
+		const first = focusables[0];
+		const last = focusables[focusables.length - 1];
+		const active = document.activeElement;
+		if (event.shiftKey && active === first) {
+			event.preventDefault();
+			last.focus();
+		} else if (!event.shiftKey && active === last) {
+			event.preventDefault();
+			first.focus();
+		}
+	}
+</script>
+
+{#if open}
+	<!-- The descent: the chosen template, risen as an Artifact over the whole receded
+	     page. A tap on the scrim, esc, or back reverses it. Focus is trapped inside
+	     the Artifact while it is up and restored to the originating element on close.
+	     The preview inside is the page's own — mounted here, never forked. -->
+	<div class="dive-layer" role="presentation" onkeydown={handleDiveKeydown} use:portalToBody>
+		<!-- The scrim recedes the whole page as one: a fixed full-viewport plane that
+		     blurs and faintly dims everything painted behind it — the field, the hero
+		     beside it, the header above it — so the dive reads as a fall away from the
+		     entire page, not just one column. It is also the way back: a click anywhere
+		     on it closes the dive. A button (not a div) so the keyboard reaches it. -->
+		<button type="button" class="dive-scrim" aria-label="Back to the field" onclick={closeDive}
+		></button>
+
+		<div
+			bind:this={diveSurface}
+			class="dive-surface"
+			role="dialog"
+			aria-modal="true"
+			aria-label="Template preview"
+			tabindex="-1"
+			style="--dive-ascent-ms: {TIMING.SLOW}ms; --dive-ascent-ease: {EASING};"
+		>
+			<Artifact padding="compact" class="dive-artifact">
+				{@render dive()}
+			</Artifact>
+		</div>
+	</div>
+{/if}
+
+<style>
+	/*
+	 * The descent layer — a full-viewport plane the risen Artifact floats in. It
+	 * sits over the whole page; its scrim is the recede AND the way back.
+	 */
+	.dive-layer {
+		position: fixed;
+		inset: 0;
+		z-index: 1000;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: 1.5rem;
+	}
+
+	/*
+	 * The scrim recedes the whole page as one. A fixed full-viewport plane that
+	 * blurs everything painted behind it (one composited backdrop-filter layer, not
+	 * a blurred 300-node subtree) and lays a faint warm dim over it — the modal
+	 * surface token (warm cream) at half alpha, never a hard black overlay. So the
+	 * field, the hero beside it, and the header above it recede together, with no
+	 * half-sharp seam. Clicking it reverses the dive. The blur is the expensive
+	 * channel, so it is dropped under reduced motion (below); the dim stays.
+	 */
+	.dive-scrim {
+		position: absolute;
+		inset: 0;
+		border: none;
+		margin: 0;
+		padding: 0;
+		cursor: pointer;
+		/* Fallback for engines without color-mix: the modal surface token at full
+		   weight; the color-mix below takes it to half alpha where supported. */
+		background: var(--surface-overlay, oklch(0.975 0.005 55));
+		background: color-mix(in oklch, var(--surface-overlay, oklch(0.975 0.005 55)) 50%, transparent);
+		backdrop-filter: blur(4px);
+		-webkit-backdrop-filter: blur(4px);
+	}
+
+	/*
+	 * The risen object. Bounded so the preview keeps its column rhythm, scrollable
+	 * within when the preview is taller than the viewport, and raised above the
+	 * backdrop. The white surface and border belong to the Artifact inside it.
+	 */
+	.dive-surface {
+		position: relative;
+		z-index: 1;
+		width: 100%;
+		max-width: 40rem;
+		max-height: calc(100vh - 3rem);
+		overflow: hidden;
+		display: flex;
+		flex-direction: column;
+		/* The ascent: the Artifact rises on system motion — SLOW (320ms) for the
+		   weight of a surfacing object, with the standard EASING. Both come from
+		   motion.ts via the inline custom properties above (TIMING.SLOW / EASING),
+		   so this transition carries no off-token literal. */
+		animation: dive-ascend var(--dive-ascent-ms) var(--dive-ascent-ease) both;
+	}
+
+	.dive-surface :global(.dive-artifact) {
+		max-height: 100%;
+		overflow-y: auto;
+	}
+
+	@keyframes dive-ascend {
+		from {
+			opacity: 0;
+			transform: translateY(16px) scale(0.985);
+		}
+		to {
+			opacity: 1;
+			transform: translateY(0) scale(1);
+		}
+	}
+
+	/*
+	 * Reduced motion: no blur, no rise. The scrim keeps only its faint warm dim
+	 * (cheap, non-vestibular) so the dive is still legibly set apart, and the
+	 * Artifact appears at once — the descent is instant, not animated.
+	 */
+	@media (prefers-reduced-motion: reduce) {
+		.dive-scrim {
+			backdrop-filter: none;
+			-webkit-backdrop-filter: none;
+		}
+
+		.dive-surface {
+			animation: none;
+		}
+	}
+</style>

--- a/src/lib/components/template-browser/relation/RelationGraph.svelte
+++ b/src/lib/components/template-browser/relation/RelationGraph.svelte
@@ -1,0 +1,593 @@
+<script lang="ts">
+	/**
+	 * RelationGraph — the relatedness map as a hand-built SVG diagram.
+	 *
+	 * Each public template is a node, coloured by its topic hue (the same
+	 * `resolveDomainHue` authority the spectrum bands read, so a template's colour
+	 * here agrees with its colour there). The structure is the EDGES — what relates
+	 * to what — not a position on any axis:
+	 *
+	 *   - a SOLID edge is a measured semantic twin: mean-centered template cosine
+	 *     that cleared the calibrated threshold and survived leave-one-out, computed
+	 *     server-side (the 768-dim vectors never reach here — only the {a,b,score}
+	 *     tuple does). Its weight scales with the score, so a stronger twin reads as
+	 *     a thicker tie.
+	 *   - a DASHED edge is civic-family kinship: the two templates share a domain
+	 *     anchor. Taxonomic, not measured, so it is drawn lighter and subordinate.
+	 *     These are derived right here from the already-shipped `domain` string
+	 *     (`familyEdges`) — no embedding, no widened payload.
+	 *   - an optional third subordinate style carries tag-CONCEPT edges when the
+	 *     server emits any (templates sharing a tight tag cluster). At this corpus
+	 *     it is usually empty, and that is honest.
+	 *
+	 * A template with NO admissible edge is NOT dragged into a cluster or given a
+	 * decorative tie to look less lonely — the layout (`layoutRelationGraph`) seeds
+	 * it on an outer ring so it settles honestly alone at the periphery. At the seed
+	 * this surface is a few small clusters + several solitary concerns; that
+	 * sparsity is the truth, not a defect, and the same rendering blooms denser as
+	 * the corpus grows.
+	 *
+	 * This is our own diagram — SVG + oklch in the existing hand-built idiom, no d3
+	 * or any foreign force/graph library. The layout is a deterministic, SSR-safe
+	 * pure function, so the server and the client agree to the pixel and the map
+	 * never lurches on hydration.
+	 */
+
+	import type { Template, RelationEdge } from '$lib/types/template';
+	import { resolveDomainHue, anchorLabelForHue, matchAnchor } from '$lib/utils/domain-hue';
+	import { familyEdges } from '$lib/core/topic/relation-edges';
+	import { layoutRelationGraph } from '$lib/core/topic/graph-layout';
+
+	interface Props {
+		/** The public templates to relate — one node each. */
+		templates: Template[];
+		/** The measured edges resolved server-side (twin) plus any tag-concept edges.
+		 *  Family edges are derived here from the templates' domains, so a caller
+		 *  passes only what needs a vector to compute. Absent → twin/concept-free,
+		 *  family kinship still renders. */
+		edges?: RelationEdge[];
+		/** The currently selected (diving) template id, threaded down so the dive
+		 *  owner can mark it. Absent → nothing selected. */
+		selectedId?: string | null;
+		/** Called with the template id when a node is activated. */
+		onSelect: (id: string) => void;
+		/** Pointer enter (true) / leave (false) on a node, so a focus layer can light
+		 *  the neighbourhood and a caller can preload the template. */
+		onHover?: (id: string, isHovering: boolean) => void;
+	}
+
+	let { templates, edges = [], selectedId = null, onSelect, onHover }: Props = $props();
+
+	// The drawing canvas the layout falls inside. A fixed coordinate space the SVG
+	// scales responsively into via its viewBox — the same width/height the approved
+	// mock laid out against, so the declump spacing reads as designed.
+	const WIDTH = 1080;
+	const HEIGHT = 600;
+
+	/**
+	 * A node ready to draw: its id, hue, the short label + the plain-English family
+	 * caption that sit beside it. The label is the template's own title (trimmed to
+	 * a readable length); the caption names the civic family the hue belongs to, so
+	 * the colour is redundant with words and never the only carrier of meaning.
+	 */
+	interface GraphNode {
+		id: string;
+		hue: number;
+		label: string;
+		family: string | null;
+	}
+
+	// Trim a title to a single legible line over the field — the label is a
+	// wayfinding mark, not the template's full headline (that waits in the dive).
+	function shortLabel(title: string): string {
+		const trimmed = (title ?? '').trim();
+		if (trimmed.length <= 28) return trimmed;
+		return trimmed.slice(0, 27).trimEnd() + '…';
+	}
+
+	// The plain-English civic family a template's domain belongs to (Housing,
+	// Transportation, …), or null when its domain matches no canonical anchor — a
+	// node with no family caption is, by the same token, one with no family edge.
+	function familyName(template: Pick<Template, 'domain'>): string | null {
+		const domain = typeof template.domain === 'string' ? template.domain.trim() : '';
+		if (!domain) return null;
+		const hue = matchAnchor(domain);
+		return hue === null ? null : anchorLabelForHue(hue);
+	}
+
+	const nodes = $derived<GraphNode[]>(
+		templates.map((t) => ({
+			id: t.id,
+			hue: resolveDomainHue(t),
+			label: shortLabel(t.title),
+			family: familyName(t)
+		}))
+	);
+
+	// The full honest edge set: the measured/concept edges passed in (twin, and
+	// concept when the server emits any) UNION the family kinship derived here. The
+	// two sources are deduped by their normalized (a,b) key so a pair that is both
+	// a measured twin and same-domain kin draws once, as the stronger (measured)
+	// relation — the dashed family tie never overdraws a solid twin.
+	const RANK: Record<RelationEdge['kind'], number> = { twin: 3, concept: 2, family: 1 };
+
+	const allEdges = $derived.by<RelationEdge[]>(() => {
+		const present = new Set(nodes.map((n) => n.id));
+		const byPair = new Map<string, RelationEdge>();
+		const add = (edge: RelationEdge) => {
+			if (!present.has(edge.a) || !present.has(edge.b) || edge.a === edge.b) return;
+			const key = edge.a <= edge.b ? `${edge.a}|${edge.b}` : `${edge.b}|${edge.a}`;
+			const existing = byPair.get(key);
+			if (!existing || RANK[edge.kind] > RANK[existing.kind]) byPair.set(key, edge);
+		};
+		// Measured + concept edges first (they carry the score), then family.
+		for (const edge of edges) add(edge);
+		for (const edge of familyEdges(templates)) add(edge);
+		return Array.from(byPair.values());
+	});
+
+	// Which nodes carry at least one admissible edge. The complement is the set of
+	// honestly-isolated templates — they get NO tie and the layout pushes them out.
+	const connected = $derived.by(() => {
+		const set = new Set<string>();
+		for (const edge of allEdges) {
+			set.add(edge.a);
+			set.add(edge.b);
+		}
+		return set;
+	});
+
+	// Deterministic positions: the same nodes + edges always settle identically, on
+	// the server and again on the client, so the map paints once and never lurches.
+	const positions = $derived(
+		layoutRelationGraph(
+			nodes.map((n) => ({ id: n.id })),
+			// The layout knows two pull strengths: a measured twin pulls hardest, all
+			// taxonomic ties (family + tag-concept, both subordinate) pull as kin.
+			allEdges.map((e) => ({ a: e.a, b: e.b, kind: e.kind === 'twin' ? 'twin' : 'family' })),
+			{ width: WIDTH, height: HEIGHT }
+		)
+	);
+
+	/**
+	 * The twin score maps to a stroke weight in a narrow, legible band. A measured
+	 * twin always reads as the heaviest tie; a stronger score sits a touch thicker.
+	 * Family/concept ties keep their own (lighter) fixed weights, set in CSS.
+	 */
+	function twinWeight(score: number | undefined): number {
+		const s = typeof score === 'number' ? Math.max(0, Math.min(1, score)) : 0.5;
+		return 1.8 + s * 1.4; // ~1.8–3.2px
+	}
+
+	/** A drawable edge: its two endpoints' resolved positions + its kind/weight. */
+	interface DrawEdge {
+		key: string;
+		kind: RelationEdge['kind'];
+		x1: number;
+		y1: number;
+		x2: number;
+		y2: number;
+		cx: number;
+		cy: number;
+		weight: number;
+		/** True when either endpoint is the focused/selected node. */
+		incident: boolean;
+	}
+
+	const drawEdges = $derived.by<DrawEdge[]>(() => {
+		const out: DrawEdge[] = [];
+		for (const edge of allEdges) {
+			const a = positions.get(edge.a);
+			const b = positions.get(edge.b);
+			if (!a || !b) continue;
+			const mx = (a.x + b.x) / 2;
+			const my = (a.y + b.y) / 2;
+			out.push({
+				key: `${edge.a}|${edge.b}|${edge.kind}`,
+				kind: edge.kind,
+				x1: a.x,
+				y1: a.y,
+				x2: b.x,
+				y2: b.y,
+				cx: mx,
+				cy: my - 14, // the mock's gentle arc, so parallel ties separate
+				weight: edge.kind === 'twin' ? twinWeight(edge.score) : 0,
+				incident: edge.a === focusId || edge.b === focusId
+			});
+		}
+		return out;
+	});
+
+	/** A drawable node: position + presentation, plus where its label sits. */
+	interface DrawNode extends GraphNode {
+		x: number;
+		y: number;
+		/** Label baseline — above the node in the lower half, below it in the upper
+		 *  half, so a label never collides with the edges fanning toward the centre. */
+		labelY: number;
+		metaY: number;
+		isolated: boolean;
+	}
+
+	const drawNodes = $derived.by<DrawNode[]>(() =>
+		nodes.map((n) => {
+			const p = positions.get(n.id) ?? { x: WIDTH / 2, y: HEIGHT / 2 };
+			const below = p.y <= HEIGHT / 2;
+			const labelY = below ? p.y + 24 : p.y - 18;
+			return {
+				...n,
+				x: p.x,
+				y: p.y,
+				labelY,
+				metaY: labelY + 13,
+				isolated: !connected.has(n.id)
+			};
+		})
+	);
+
+	// The focused node lights its neighbourhood (this node + everything an edge
+	// reaches). On the bare surface (before the focus interaction layer mounts) the
+	// selection IS the focus, so a dived template stays lit beneath the descent.
+	// The hover focus is local, transient state; pointer leave clears it.
+	let hoverId = $state<string | null>(null);
+	const focusId = $derived(hoverId ?? selectedId);
+
+	// The lit set: the focused node + every node an admissible edge connects to it.
+	// Empty when nothing is focused → the whole field reads at full presence (no
+	// node is dimmed just because nothing is hovered).
+	const litSet = $derived.by(() => {
+		const set = new Set<string>();
+		if (!focusId) return set;
+		set.add(focusId);
+		for (const edge of allEdges) {
+			if (edge.a === focusId) set.add(edge.b);
+			else if (edge.b === focusId) set.add(edge.a);
+		}
+		return set;
+	});
+
+	function isLit(id: string): boolean {
+		// No focus → everything is at presence. With a focus → only the neighbourhood.
+		return litSet.size === 0 || litSet.has(id);
+	}
+
+	function handleEnter(id: string) {
+		hoverId = id;
+		onHover?.(id, true);
+	}
+	function handleLeave(id: string) {
+		if (hoverId === id) hoverId = null;
+		onHover?.(id, false);
+	}
+
+	// Node fill + stroke at three chroma levels off the template's hue — the same
+	// oklch register the spectrum tiles use, so a node reads as the tile's glyph,
+	// not a generic dot.
+	function nodeFill(hue: number): string {
+		return `oklch(0.62 0.16 ${hue})`;
+	}
+	function nodeStroke(hue: number): string {
+		return `oklch(0.42 0.12 ${hue})`;
+	}
+</script>
+
+<figure class="relation-graph" aria-label="Templates related by measured semantic kinship and civic family">
+	<figcaption class="relation-graph__title font-brand">
+		The commons, by relation
+		<span class="relation-graph__subtitle"
+			>linked by meaning; the topically-isolated fall to the edges</span
+		>
+	</figcaption>
+
+	{#if drawNodes.length > 0}
+		<svg
+			class="relation-graph__svg"
+			viewBox="0 0 {WIDTH} {HEIGHT}"
+			role="group"
+			aria-label="Relation map"
+			class:has-focus={litSet.size > 0}
+		>
+			<!-- Edges first, so nodes and labels sit over them. -->
+			<g class="relation-graph__edges" aria-hidden="true">
+				{#each drawEdges as edge (edge.key)}
+					<path
+						d="M{edge.x1.toFixed(1)} {edge.y1.toFixed(1)} Q{edge.cx.toFixed(1)} {edge.cy.toFixed(
+							1
+						)} {edge.x2.toFixed(1)} {edge.y2.toFixed(1)}"
+						class="relation-edge relation-edge--{edge.kind}"
+						class:relation-edge--incident={edge.incident}
+						data-edge-kind={edge.kind}
+						style={edge.kind === 'twin' ? `stroke-width: ${edge.weight.toFixed(2)}px;` : ''}
+					/>
+				{/each}
+			</g>
+
+			<!-- Nodes + their haloed labels. -->
+			<g class="relation-graph__nodes">
+				{#each drawNodes as node (node.id)}
+					<g
+						class="relation-node"
+						class:relation-node--selected={node.id === selectedId}
+						class:relation-node--isolated={node.isolated}
+						class:relation-node--lit={isLit(node.id)}
+						class:relation-node--dimmed={!isLit(node.id)}
+						data-template-id={node.id}
+						data-isolated={node.isolated}
+						data-testid="relation-node-{node.id}"
+						role="button"
+						tabindex="0"
+						aria-label="{node.label}{node.family ? `, ${node.family}` : ''}"
+						onclick={() => onSelect(node.id)}
+						onkeydown={(e) => {
+							if (e.key === 'Enter' || e.key === ' ') {
+								e.preventDefault();
+								onSelect(node.id);
+							}
+						}}
+						onmouseenter={() => handleEnter(node.id)}
+						onmouseleave={() => handleLeave(node.id)}
+						onfocus={() => handleEnter(node.id)}
+						onblur={() => handleLeave(node.id)}
+					>
+						<!-- A generous transparent hit-target so a node is easy to reach with a
+						     pointer or thumb without enlarging the glyph itself. -->
+						<circle class="relation-node__hit" cx={node.x.toFixed(1)} cy={node.y.toFixed(1)} r="22" />
+						<circle
+							class="relation-node__glyph"
+							cx={node.x.toFixed(1)}
+							cy={node.y.toFixed(1)}
+							r="10"
+							fill={nodeFill(node.hue)}
+							stroke={nodeStroke(node.hue)}
+						/>
+						<text class="relation-node__label" x={node.x.toFixed(1)} y={node.labelY.toFixed(1)}>
+							{node.label}
+						</text>
+						{#if node.family}
+							<text class="relation-node__meta" x={node.x.toFixed(1)} y={node.metaY.toFixed(1)}>
+								{node.family}
+							</text>
+						{/if}
+					</g>
+				{/each}
+			</g>
+		</svg>
+
+		<!-- The legend names the relation kinds in plain English. The two line samples
+		     echo the edge styles above so the eye learns the encoding once. -->
+		<ul class="relation-graph__legend font-brand" aria-label="What the edges mean">
+			<li class="relation-legend__item">
+				<svg class="relation-legend__swatch" viewBox="0 0 40 8" aria-hidden="true">
+					<line class="relation-edge relation-edge--twin" x1="2" y1="4" x2="38" y2="4" />
+				</svg>
+				<span>measured semantic twin (survives leave-one-out)</span>
+			</li>
+			<li class="relation-legend__item">
+				<svg class="relation-legend__swatch" viewBox="0 0 40 8" aria-hidden="true">
+					<line class="relation-edge relation-edge--family" x1="2" y1="4" x2="38" y2="4" />
+				</svg>
+				<span>shared civic family</span>
+			</li>
+			{#if allEdges.some((e) => e.kind === 'concept')}
+				<li class="relation-legend__item">
+					<svg class="relation-legend__swatch" viewBox="0 0 40 8" aria-hidden="true">
+						<line class="relation-edge relation-edge--concept" x1="2" y1="4" x2="38" y2="4" />
+					</svg>
+					<span>shared tag concept</span>
+				</li>
+			{/if}
+		</ul>
+	{:else}
+		<!-- Honest empty state: no field to relate yet. Plain English, no dead map. -->
+		<div class="relation-graph__empty">
+			<p class="font-brand relation-graph__empty-head">No templates yet.</p>
+			<p class="font-brand relation-graph__empty-sub">You can write the first one.</p>
+		</div>
+	{/if}
+</figure>
+
+<style>
+	/*
+	 * The graph carries no chrome of its own — the warm-cream ground shows through,
+	 * the edges and the void between clusters are the structure. The figure is a
+	 * full-width field; the SVG scales responsively into it via its viewBox.
+	 */
+	.relation-graph {
+		margin: 0;
+		padding: 0.5rem 0 1.5rem;
+		width: 100%;
+	}
+
+	.relation-graph__title {
+		display: block;
+		text-align: center;
+		font-size: 0.9375rem;
+		font-weight: 650;
+		color: oklch(0.34 0.02 60);
+		padding: 0 1rem 0.5rem;
+		line-height: 1.4;
+	}
+
+	.relation-graph__subtitle {
+		display: block;
+		font-weight: 450;
+		font-size: 0.8125rem;
+		color: oklch(0.5 0.02 60);
+		margin-top: 0.125rem;
+	}
+
+	.relation-graph__svg {
+		display: block;
+		width: 100%;
+		height: auto;
+		max-height: 70vh;
+		/* Let the field breathe to its natural aspect; never overflow horizontally. */
+		overflow: visible;
+	}
+
+	/* ─── Edges ──────────────────────────────────────────────────────────────
+	 * Three kinds, three encodings. The colours are warm neutrals (not the topic
+	 * hue — a tie is not a topic), so the hue stays the node's alone. Twin is the
+	 * heaviest, solid; family is dashed + lighter; concept is the lightest dashed.
+	 */
+	.relation-edge {
+		fill: none;
+		transition: opacity 150ms cubic-bezier(0.4, 0, 0.2, 1);
+	}
+
+	.relation-edge--twin {
+		stroke: oklch(0.5 0.06 60);
+		stroke-width: 2.2px; /* default; the node sets a score-scaled width inline */
+		opacity: 0.75;
+	}
+
+	.relation-edge--family {
+		stroke: oklch(0.6 0.03 60);
+		stroke-width: 1.3px;
+		opacity: 0.45;
+		stroke-dasharray: 2 4;
+	}
+
+	.relation-edge--concept {
+		stroke: oklch(0.62 0.04 60);
+		stroke-width: 1.2px;
+		opacity: 0.4;
+		stroke-dasharray: 1 5;
+	}
+
+	/* When a node is focused, its incident ties brighten and the rest recede, so
+	 * "what is near this one" answers at a glance. Only applies once something is
+	 * focused (`.has-focus`); at rest every tie reads at full presence. */
+	.relation-graph__svg.has-focus .relation-edge {
+		opacity: 0.12;
+	}
+	.relation-graph__svg.has-focus .relation-edge--incident {
+		opacity: 0.85;
+	}
+
+	/* ─── Nodes ──────────────────────────────────────────────────────────────── */
+	.relation-node {
+		cursor: pointer;
+	}
+
+	.relation-node__hit {
+		fill: transparent;
+	}
+
+	.relation-node__glyph {
+		stroke-width: 1.6px;
+		transition:
+			transform 150ms cubic-bezier(0.4, 0, 0.2, 1),
+			opacity 150ms cubic-bezier(0.4, 0, 0.2, 1);
+		transform-box: fill-box;
+		transform-origin: center;
+	}
+
+	.relation-node:hover .relation-node__glyph,
+	.relation-node:focus-visible .relation-node__glyph,
+	.relation-node--selected .relation-node__glyph {
+		transform: scale(1.25);
+	}
+
+	/* The focused neighbourhood stays at presence; the rest of the field dims to a
+	 * composed void so the lit cluster reads as the strong center. */
+	.relation-node--dimmed {
+		opacity: 0.28;
+	}
+	.relation-node--lit {
+		opacity: 1;
+	}
+
+	/*
+	 * Node labels: the template's short title in Satoshi, haloed with the
+	 * warm-cream ground (paint-order: stroke) so the words stay legible wherever
+	 * they cross an edge or a neighbour. The meta line names the civic family in a
+	 * quieter neutral — provenance under the label, the same role the tile's topic
+	 * ground plays.
+	 */
+	.relation-node__label {
+		font-family: 'Satoshi', ui-sans-serif, system-ui, sans-serif;
+		font-size: 12px;
+		font-weight: 650;
+		fill: oklch(0.3 0.03 60);
+		text-anchor: middle;
+		paint-order: stroke;
+		stroke: oklch(0.985 0.006 70);
+		stroke-width: 4px;
+		stroke-linejoin: round;
+		pointer-events: none;
+	}
+
+	.relation-node__meta {
+		font-family: 'Satoshi', ui-sans-serif, system-ui, sans-serif;
+		font-size: 9px;
+		fill: oklch(0.57 0.02 60);
+		text-anchor: middle;
+		paint-order: stroke;
+		stroke: oklch(0.985 0.006 70);
+		stroke-width: 3px;
+		stroke-linejoin: round;
+		pointer-events: none;
+	}
+
+	/* Keyboard focus ring — a ring on the glyph, not the whole group, so it tracks
+	 * the visible mark. */
+	.relation-node:focus-visible {
+		outline: none;
+	}
+	.relation-node:focus-visible .relation-node__glyph {
+		stroke: oklch(0.42 0.14 250);
+		stroke-width: 2.4px;
+	}
+
+	/* ─── Legend ─────────────────────────────────────────────────────────────── */
+	.relation-graph__legend {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.25rem 1.5rem;
+		justify-content: center;
+		margin: 0.5rem auto 0;
+		padding: 0 1rem;
+		list-style: none;
+		max-width: 56rem;
+	}
+
+	.relation-legend__item {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.5rem;
+		font-size: 0.6875rem;
+		color: oklch(0.5 0.02 60);
+	}
+
+	.relation-legend__swatch {
+		width: 40px;
+		height: 8px;
+		flex-shrink: 0;
+	}
+
+	/* ─── Empty ──────────────────────────────────────────────────────────────── */
+	.relation-graph__empty {
+		padding: 3rem 1.5rem;
+		text-align: center;
+	}
+	.relation-graph__empty-head {
+		font-size: 1rem;
+		font-weight: 600;
+		color: oklch(0.32 0.02 250);
+		margin: 0;
+	}
+	.relation-graph__empty-sub {
+		font-size: 0.875rem;
+		color: oklch(0.5 0.02 250);
+		margin: 0.5rem 0 0;
+	}
+
+	/* Respect vestibular preferences: no glyph scaling transition, no edge fade. */
+	@media (prefers-reduced-motion: reduce) {
+		.relation-node__glyph,
+		.relation-edge {
+			transition: none;
+		}
+	}
+</style>

--- a/src/lib/components/template-browser/relation/RelationGraph.svelte
+++ b/src/lib/components/template-browser/relation/RelationGraph.svelte
@@ -140,6 +140,14 @@
 		return set;
 	});
 
+	// At-rest honesty caption: the live corpus size + measured-kinship count, so the
+	// sparsity reads as a growing record rather than an empty surface. Never hardcoded —
+	// both numbers derive from the live data and rise as the commons grows.
+	const relationCounts = $derived.by(() => ({
+		concerns: templates.length,
+		measured: allEdges.filter((e) => e.kind === 'twin').length
+	}));
+
 	// Deterministic positions: the same nodes + edges always settle identically, on
 	// the server and again on the client, so the map paints once and never lurches.
 	// The compute is quadratic, so it runs through the MEMOIZED entry point — keyed
@@ -492,6 +500,11 @@
 		The commons, by relation
 		<span class="relation-graph__subtitle"
 			>linked by meaning; the topically-isolated fall to the edges</span
+		>
+		<span class="relation-graph__count"
+			>{relationCounts.concerns} concerns · {relationCounts.measured} measured {relationCounts.measured === 1
+				? 'kinship'
+				: 'kinships'} so far — the map fills as the commons grows</span
 		>
 	</figcaption>
 
@@ -868,6 +881,15 @@
 		font-size: 0.8125rem;
 		color: oklch(0.5 0.02 60);
 		margin-top: 0.125rem;
+	}
+
+	.relation-graph__count {
+		display: block;
+		font-weight: 450;
+		font-size: 0.75rem;
+		color: oklch(0.58 0.015 60);
+		margin-top: 0.25rem;
+		font-variant-numeric: tabular-nums;
 	}
 
 	/* ─── Search — recognition navigation ─────────────────────────────────────

--- a/src/lib/components/template-browser/relation/RelationGraph.svelte
+++ b/src/lib/components/template-browser/relation/RelationGraph.svelte
@@ -39,6 +39,7 @@
 	import { layoutRelationGraph } from '$lib/core/topic/graph-layout';
 	import { spring as svelteSpring } from 'svelte/motion';
 	import { SPRINGS } from '$lib/design/motion';
+	import { Search } from '@lucide/svelte';
 
 	interface Props {
 		/** The public templates to relate — one node each. */
@@ -238,7 +239,48 @@
 	// "this one is the dive owner" marker on its single node — it dims nothing.
 	let hoverId = $state<string | null>(null);
 	let focusedId = $state<string | null>(null);
-	const focusId = $derived(hoverId ?? focusedId);
+
+	// Recognition navigation: the viewer types a fragment they remember and the
+	// matching node comes to them — pulled to the centre, its neighbourhood lit, the
+	// rest of the field receding. This is recognition over recall: you don't reconstruct
+	// where a template sits, you name a piece of it and the map answers. The match runs
+	// CLIENT-SIDE over the already-loaded nodes (no server round-trip at this size), so
+	// it is immediate and causal — the field responds as you type.
+	let searchQuery = $state('');
+
+	// The node a query selects: the FIRST loaded node whose title or civic family
+	// contains the trimmed query (case-insensitive). First-in-stable-order is a stable,
+	// repeatable pick — the same query always lands on the same node. Empty query → no
+	// match, so the field rests un-panned and un-focused.
+	const searchMatch = $derived.by<GraphNode | null>(() => {
+		const q = searchQuery.trim().toLowerCase();
+		if (!q) return null;
+		return (
+			nodes.find(
+				(n) => n.label.toLowerCase().includes(q) || (n.family?.toLowerCase().includes(q) ?? false)
+			) ?? null
+		);
+	});
+	const searchMatchId = $derived(searchMatch?.id ?? null);
+
+	// How many loaded nodes the query touches — the plain-English feedback line reads
+	// from this. (The PAN/focus lands on the first; the count tells the viewer whether
+	// their query was specific.) A query with no match reports zero, honestly.
+	const searchHitCount = $derived.by<number>(() => {
+		const q = searchQuery.trim().toLowerCase();
+		if (!q) return 0;
+		return nodes.filter(
+			(n) => n.label.toLowerCase().includes(q) || (n.family?.toLowerCase().includes(q) ?? false)
+		).length;
+	});
+
+	// Focus precedence: a live hover or keyboard focus is the viewer's immediate,
+	// transient act and wins; the search match is the standing recognition target
+	// underneath. So a search centres + lights a node, and the viewer can still hover a
+	// neighbour to read ITS ties without the search fighting back — on mouse-leave the
+	// field falls back to the search-focused neighbourhood, not to nothing. Clearing the
+	// search drops searchMatchId and the field returns to full presence.
+	const focusId = $derived(hoverId ?? focusedId ?? searchMatchId);
 
 	// Whether the viewer asked for less motion. Read once, on the client, via the
 	// same matchMedia probe the dimensional primitives use — server-side it stays
@@ -264,6 +306,30 @@
 		// spring carry it — its first frame already moves, so the onset is causal.
 		focusDepth.set(target, prefersReducedMotion ? { hard: true } : undefined);
 	});
+
+	// Search centres a match by PANNING the field, never by relaying it out — the
+	// layout is the viewer's spatial memory and must not scramble. The whole
+	// drawn field is one rigid `<g>` that slides so the matched node lands at canvas
+	// centre; every node keeps its relative place, the map just translates beneath the
+	// viewport. At rest (no match) the pan is (0,0) and the field sits as laid out.
+	// The translation rides ENTRANCE — a firm arrival with no bounce — so the match
+	// settles at centre without overshoot. Reduced motion snaps it.
+	// svelte-ignore state_referenced_locally — the rest value is captured once per instance
+	const pan = svelteSpring({ x: 0, y: 0 }, SPRINGS.ENTRANCE);
+	$effect(() => {
+		const p = searchMatchId ? positions.get(searchMatchId) : null;
+		// Bring the matched node to the canvas centre; with no match, rest at origin.
+		const target = p ? { x: WIDTH / 2 - p.x, y: HEIGHT / 2 - p.y } : { x: 0, y: 0 };
+		pan.set(target, prefersReducedMotion ? { hard: true } : undefined);
+	});
+
+	// Clearing the search query restores the field: the spring carries the pan back to
+	// origin and dropping searchMatchId returns every node to full presence. Escape and
+	// the clear button both route here so the field always returns to exactly where it
+	// rested before the search.
+	function clearSearch() {
+		searchQuery = '';
+	}
 
 	// The lit set: the focused node + every node an admissible edge connects to it.
 	// Empty when nothing is focused → the whole field reads at full presence (no
@@ -325,6 +391,60 @@
 	</figcaption>
 
 	{#if drawNodes.length > 0}
+		<!-- Recognition navigation: name a fragment you remember and the map brings the
+		     matching node to the centre, lit, the rest receding. Reuses the template
+		     search vocabulary (the same search glyph + type=search field), but the copy
+		     speaks to relation — you are finding a concern in the field, not filtering a
+		     list. Matching is client-side over the loaded nodes, so it answers as you type. -->
+		<div class="relation-graph__search">
+			<div class="relation-search__field">
+				<Search class="relation-search__icon" size={16} aria-hidden="true" />
+				<input
+					type="search"
+					class="relation-search__input font-brand"
+					placeholder="Find a concern by name…"
+					aria-label="Find a template by name or civic family"
+					bind:value={searchQuery}
+					data-testid="relation-search-input"
+					onkeydown={(e) => {
+						// Escape clears the field and returns the map to full presence.
+						if (e.key === 'Escape') {
+							e.preventDefault();
+							clearSearch();
+						}
+						// Enter commits the recognition: keep the current match centred and
+						// drop the soft keyboard, so the viewer can read the lit neighbourhood
+						// without the field changing under them.
+						if (e.key === 'Enter') {
+							e.preventDefault();
+							(e.currentTarget as HTMLInputElement).blur();
+						}
+					}}
+				/>
+				{#if searchQuery}
+					<button
+						type="button"
+						class="relation-search__clear font-brand"
+						onclick={clearSearch}
+						aria-label="Clear search"
+					>
+						Clear
+					</button>
+				{/if}
+			</div>
+			{#if searchQuery.trim()}
+				<p class="relation-search__feedback font-brand" aria-live="polite" data-testid="relation-search-feedback">
+					{#if searchMatch}
+						Centred on “{searchMatch.label}”{searchHitCount > 1
+							? `, ${searchHitCount} match the search`
+							: ''}.
+					{:else}
+						Nothing here by that name yet.
+					{/if}
+				</p>
+			{/if}
+		</div>
+
 		<svg
 			class="relation-graph__svg"
 			viewBox="0 0 {WIDTH} {HEIGHT}"
@@ -333,6 +453,13 @@
 			class:has-focus={litSet.size > 0}
 			style="--focus-depth: {$focusDepth};"
 		>
+			<!-- The whole field rides one panning group. Search slides this so the matched
+			     node reaches the centre — a translate, never a relayout, so the viewer's
+			     spatial memory of the map survives. At rest the translate is (0,0). -->
+			<g
+				class="relation-graph__pan"
+				transform="translate({$pan.x.toFixed(2)} {$pan.y.toFixed(2)})"
+			>
 			<!-- Edges first, so nodes and labels sit over them. -->
 			<g class="relation-graph__edges" aria-hidden="true">
 				{#each drawEdges as edge (edge.key)}
@@ -410,6 +537,7 @@
 					</g>
 				{/each}
 			</g>
+		</g>
 		</svg>
 
 		<!-- The legend names the relation kinds in plain English. The two line samples
@@ -473,6 +601,80 @@
 		font-size: 0.8125rem;
 		color: oklch(0.5 0.02 60);
 		margin-top: 0.125rem;
+	}
+
+	/* ─── Search — recognition navigation ─────────────────────────────────────
+	 * A single field centred over the map. It carries no heavy chrome: a thin warm
+	 * underline-and-border on the cream ground (no white box, no pill), the search
+	 * glyph at the lead, and a quiet feedback line below that names where the field
+	 * just centred. The field is the only affordance that pulls the map; everything
+	 * else is the map itself. */
+	.relation-graph__search {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 0.3rem;
+		margin: 0 auto 0.75rem;
+		max-width: 24rem;
+		padding: 0 1rem;
+	}
+
+	.relation-search__field {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		width: 100%;
+		padding: 0.4rem 0.6rem;
+		border: 1px solid oklch(0.82 0.02 70);
+		border-radius: 0.5rem;
+		background: oklch(0.99 0.005 80);
+		transition: border-color 150ms cubic-bezier(0.4, 0, 0.2, 1);
+	}
+	.relation-search__field:focus-within {
+		border-color: var(--coord-share-solid);
+	}
+
+	.relation-search__field :global(.relation-search__icon) {
+		flex-shrink: 0;
+		color: oklch(0.6 0.02 70);
+	}
+
+	.relation-search__input {
+		flex: 1;
+		min-width: 0;
+		border: none;
+		background: transparent;
+		font-size: 0.875rem;
+		color: oklch(0.3 0.02 60);
+		outline: none;
+	}
+	.relation-search__input::placeholder {
+		color: oklch(0.62 0.02 70);
+	}
+	/* Suppress the native search-clear control — we render our own plain-English one. */
+	.relation-search__input::-webkit-search-cancel-button {
+		appearance: none;
+	}
+
+	.relation-search__clear {
+		flex-shrink: 0;
+		border: none;
+		background: transparent;
+		padding: 0.1rem 0.25rem;
+		font-size: 0.75rem;
+		color: oklch(0.5 0.02 60);
+		cursor: pointer;
+		transition: color 150ms cubic-bezier(0.4, 0, 0.2, 1);
+	}
+	.relation-search__clear:hover {
+		color: oklch(0.34 0.02 60);
+	}
+
+	.relation-search__feedback {
+		margin: 0;
+		font-size: 0.75rem;
+		color: oklch(0.5 0.02 60);
+		text-align: center;
 	}
 
 	.relation-graph__svg {

--- a/src/lib/components/template-browser/relation/RelationGraph.svelte
+++ b/src/lib/components/template-browser/relation/RelationGraph.svelte
@@ -37,6 +37,8 @@
 	import { resolveDomainHue, anchorLabelForHue, matchAnchor } from '$lib/utils/domain-hue';
 	import { familyEdges } from '$lib/core/topic/relation-edges';
 	import { layoutRelationGraph } from '$lib/core/topic/graph-layout';
+	import { spring as svelteSpring } from 'svelte/motion';
+	import { SPRINGS } from '$lib/design/motion';
 
 	interface Props {
 		/** The public templates to relate — one node each. */
@@ -238,6 +240,31 @@
 	let focusedId = $state<string | null>(null);
 	const focusId = $derived(hoverId ?? focusedId);
 
+	// Whether the viewer asked for less motion. Read once, on the client, via the
+	// same matchMedia probe the dimensional primitives use — server-side it stays
+	// false (no window), and the spring starts at rest, so SSR and first paint
+	// agree. With it on, the focus transition jumps hard rather than springing.
+	const prefersReducedMotion =
+		typeof window !== 'undefined'
+			? window.matchMedia('(prefers-reduced-motion: reduce)').matches
+			: false;
+
+	// The neighbourhood read is spring-driven, not a fixed CSS fade: a single 0→1
+	// value (`--focus-depth`) that the SCORE_BAR spring drives toward 1 the instant
+	// a node takes focus and back to 0 when focus clears. SCORE_BAR is snappy
+	// (stiffness 0.3) so the dim deepens with a causal sub-100ms onset — the field
+	// answers "what is near this one" immediately, then settles, never lurching.
+	// The CSS interpolates the dim/lit opacities against this depth, so at rest
+	// (depth 0) every node and tie reads at full presence and nothing is dimmed.
+	// svelte-ignore state_referenced_locally — the rest value is captured once per instance
+	const focusDepth = svelteSpring(0, SPRINGS.SCORE_BAR);
+	$effect(() => {
+		const target = focusId ? 1 : 0;
+		// Reduced motion: snap to the target with no travel. Otherwise let the
+		// spring carry it — its first frame already moves, so the onset is causal.
+		focusDepth.set(target, prefersReducedMotion ? { hard: true } : undefined);
+	});
+
 	// The lit set: the focused node + every node an admissible edge connects to it.
 	// Empty when nothing is focused → the whole field reads at full presence (no
 	// node is dimmed just because nothing is hovered).
@@ -304,6 +331,7 @@
 			role="group"
 			aria-label="Relation map"
 			class:has-focus={litSet.size > 0}
+			style="--focus-depth: {$focusDepth};"
 		>
 			<!-- Edges first, so nodes and labels sit over them. -->
 			<g class="relation-graph__edges" aria-hidden="true">
@@ -320,7 +348,11 @@
 				{/each}
 			</g>
 
-			<!-- Nodes + their haloed labels. -->
+			<!-- Nodes + their haloed labels. The nodes render in `drawNodes` order —
+			     which is the `templates` prop order, the same stable order the layout
+			     seeds from — so Tab walks the field in a deterministic, repeatable
+			     sequence and keyboard focus lights one node's neighbourhood at a time,
+			     identically to hover. -->
 			<g class="relation-graph__nodes">
 				{#each drawNodes as node (node.id)}
 					<g
@@ -350,6 +382,15 @@
 						<!-- A generous transparent hit-target so a node is easy to reach with a
 						     pointer or thumb without enlarging the glyph itself. -->
 						<circle class="relation-node__hit" cx={node.x.toFixed(1)} cy={node.y.toFixed(1)} r="22" />
+						<!-- The keyboard focus ring: a sharing-indigo halo that appears only on
+						     :focus-visible, so a tabbing reader always sees which node holds
+						     focus. Drawn behind the glyph so it reads as a ring around it. -->
+						<circle
+							class="relation-node__focus-ring"
+							cx={node.x.toFixed(1)}
+							cy={node.y.toFixed(1)}
+							r="16"
+						/>
 						<circle
 							class="relation-node__glyph"
 							cx={node.x.toFixed(1)}
@@ -441,46 +482,51 @@
 		max-height: 70vh;
 		/* Let the field breathe to its natural aspect; never overflow horizontally. */
 		overflow: visible;
+		/* The neighbourhood read's depth (0 at rest → 1 focused), the value the
+		 * SCORE_BAR spring carries in. Defaults to 0 so a server-rendered SVG (no
+		 * inline var yet) paints at full presence and the map never lurches. */
+		--focus-depth: 0;
 	}
 
 	/* ─── Edges ──────────────────────────────────────────────────────────────
 	 * Three kinds, three encodings. The colours are warm neutrals (not the topic
 	 * hue — a tie is not a topic), so the hue stays the node's alone. Twin is the
 	 * heaviest, solid; family is dashed + lighter; concept is the lightest dashed.
-	 */
+	 * Each tie's opacity interpolates from its rest presence toward a recede target
+	 * as `--focus-depth` climbs; an incident tie brightens instead. No CSS
+	 * transition — the spring is the animation, so the change is causal, never
+	 * double-eased. */
 	.relation-edge {
 		fill: none;
-		transition: opacity 150ms cubic-bezier(0.4, 0, 0.2, 1);
+		/* rest presence → recede target, mixed by the spring depth. */
+		opacity: calc(var(--edge-rest) - (var(--edge-rest) - 0.12) * var(--focus-depth));
 	}
 
 	.relation-edge--twin {
 		stroke: oklch(0.5 0.06 60);
 		stroke-width: 2.2px; /* default; the node sets a score-scaled width inline */
-		opacity: 0.75;
+		--edge-rest: 0.75;
 	}
 
 	.relation-edge--family {
 		stroke: oklch(0.6 0.03 60);
 		stroke-width: 1.3px;
-		opacity: 0.45;
+		--edge-rest: 0.45;
 		stroke-dasharray: 2 4;
 	}
 
 	.relation-edge--concept {
 		stroke: oklch(0.62 0.04 60);
 		stroke-width: 1.2px;
-		opacity: 0.4;
+		--edge-rest: 0.4;
 		stroke-dasharray: 1 5;
 	}
 
-	/* When a node is focused, its incident ties brighten and the rest recede, so
-	 * "what is near this one" answers at a glance. Only applies once something is
-	 * focused (`.has-focus`); at rest every tie reads at full presence. */
-	.relation-graph__svg.has-focus .relation-edge {
-		opacity: 0.12;
-	}
-	.relation-graph__svg.has-focus .relation-edge--incident {
-		opacity: 0.85;
+	/* An incident tie (one endpoint is the focused node) brightens toward full as
+	 * the depth climbs, so "what is near this one" answers at a glance while the
+	 * rest of the field recedes into composed void. */
+	.relation-edge--incident {
+		opacity: calc(var(--edge-rest) + (0.85 - var(--edge-rest)) * var(--focus-depth));
 	}
 
 	/* ─── Nodes ──────────────────────────────────────────────────────────────── */
@@ -494,9 +540,9 @@
 
 	.relation-node__glyph {
 		stroke-width: 1.6px;
-		transition:
-			transform 150ms cubic-bezier(0.4, 0, 0.2, 1),
-			opacity 150ms cubic-bezier(0.4, 0, 0.2, 1);
+		/* Only the hover/focus lift is a CSS micro-interaction; the focus DIM is
+		 * spring-driven on the group (below), so it is not eased here. */
+		transition: transform 150ms cubic-bezier(0.4, 0, 0.2, 1);
 		transform-box: fill-box;
 		transform-origin: center;
 	}
@@ -514,10 +560,13 @@
 		stroke-width: 2.6px;
 	}
 
-	/* The focused neighbourhood stays at presence; the rest of the field dims to a
-	 * composed void so the lit cluster reads as the strong center. */
+	/* The focused neighbourhood holds at presence; a non-neighbour recedes toward a
+	 * composed void as the spring depth climbs. The floor (0.28) is deliberate — a
+	 * dimmed node stays PERCEIVABLE so the global shape never disappears; the dim
+	 * composes the void, it does not erase it. With no focus (depth 0) every node
+	 * sits at 1, the full even field. No CSS transition — the spring is the motion. */
 	.relation-node--dimmed {
-		opacity: 0.28;
+		opacity: calc(1 - 0.72 * var(--focus-depth));
 	}
 	.relation-node--lit {
 		opacity: 1;
@@ -555,14 +604,24 @@
 		pointer-events: none;
 	}
 
-	/* Keyboard focus ring — a ring on the glyph, not the whole group, so it tracks
-	 * the visible mark. */
+	/* Keyboard focus ring — a sharing-indigo halo around the glyph, visible only on
+	 * :focus-visible so it never shows for a mouse click. The default SVG outline is
+	 * suppressed in favour of this ring, which tracks the mark and reads clearly
+	 * against the warm-cream ground at the small glyph scale. */
 	.relation-node:focus-visible {
 		outline: none;
 	}
-	.relation-node:focus-visible .relation-node__glyph {
-		stroke: var(--indigo-share);
-		stroke-width: 2.4px;
+	.relation-node__focus-ring {
+		fill: none;
+		stroke: var(--coord-share-solid);
+		stroke-width: 2px;
+		opacity: 0;
+		transform-box: fill-box;
+		transform-origin: center;
+		pointer-events: none;
+	}
+	.relation-node:focus-visible .relation-node__focus-ring {
+		opacity: 0.9;
 	}
 
 	/* ─── Legend ─────────────────────────────────────────────────────────────── */
@@ -608,10 +667,11 @@
 		margin: 0.5rem 0 0;
 	}
 
-	/* Respect vestibular preferences: no glyph scaling transition, no edge fade. */
+	/* Respect vestibular preferences: no glyph scaling transition. The focus dim is
+	 * already suppressed in JS — the spring hard-sets `--focus-depth` under reduced
+	 * motion, so the neighbourhood read snaps in with no travel rather than easing. */
 	@media (prefers-reduced-motion: reduce) {
-		.relation-node__glyph,
-		.relation-edge {
+		.relation-node__glyph {
 			transition: none;
 		}
 	}

--- a/src/lib/components/template-browser/relation/RelationGraph.svelte
+++ b/src/lib/components/template-browser/relation/RelationGraph.svelte
@@ -225,12 +225,18 @@
 		})
 	);
 
-	// The focused node lights its neighbourhood (this node + everything an edge
-	// reaches). On the bare surface (before the focus interaction layer mounts) the
-	// selection IS the focus, so a dived template stays lit beneath the descent.
-	// The hover focus is local, transient state; pointer leave clears it.
+	// What lights its neighbourhood and dims the rest is FOCUS — and focus is the
+	// reader's own, transient act, never the store's auto-selection. The landing's
+	// template store auto-selects the first template on hydration, so `selectedId`
+	// is essentially always set; if it drove the dim, the map would paint in the
+	// dimmed-to-one-node focus state at rest and never read as a full, navigable
+	// relation map. So the at-rest state is decoupled from `selectedId`: focus
+	// engages ONLY on hover (and an explicit graph-local focus). With neither, the
+	// whole field paints at full presence. `selectedId` is kept solely as a quiet
+	// "this one is the dive owner" marker on its single node — it dims nothing.
 	let hoverId = $state<string | null>(null);
-	const focusId = $derived(hoverId ?? selectedId);
+	let focusedId = $state<string | null>(null);
+	const focusId = $derived(hoverId ?? focusedId);
 
 	// The lit set: the focused node + every node an admissible edge connects to it.
 	// Empty when nothing is focused → the whole field reads at full presence (no
@@ -257,6 +263,18 @@
 	}
 	function handleLeave(id: string) {
 		if (hoverId === id) hoverId = null;
+		onHover?.(id, false);
+	}
+	// Keyboard focus engages the same neighbourhood read as hover, but through a
+	// distinct graph-local channel so tabbing through the field lights one node's
+	// ties at a time. Like hover, it is transient — blur clears it — and it never
+	// touches the store's `selectedId`, so the at-rest map stays at full presence.
+	function handleFocus(id: string) {
+		focusedId = id;
+		onHover?.(id, true);
+	}
+	function handleBlur(id: string) {
+		if (focusedId === id) focusedId = null;
 		onHover?.(id, false);
 	}
 
@@ -326,8 +344,8 @@
 						}}
 						onmouseenter={() => handleEnter(node.id)}
 						onmouseleave={() => handleLeave(node.id)}
-						onfocus={() => handleEnter(node.id)}
-						onblur={() => handleLeave(node.id)}
+						onfocus={() => handleFocus(node.id)}
+						onblur={() => handleBlur(node.id)}
 					>
 						<!-- A generous transparent hit-target so a node is easy to reach with a
 						     pointer or thumb without enlarging the glyph itself. -->
@@ -484,9 +502,16 @@
 	}
 
 	.relation-node:hover .relation-node__glyph,
-	.relation-node:focus-visible .relation-node__glyph,
-	.relation-node--selected .relation-node__glyph {
+	.relation-node:focus-visible .relation-node__glyph {
 		transform: scale(1.25);
+	}
+
+	/* The selected (dive-owner) node carries a quiet marker, not the hover lift —
+	 * a slightly heavier glyph stroke so it reads as "this one is open" without
+	 * scaling up into a competing strong center or dimming any of its neighbours.
+	 * At rest the map is still a full, even field; this only annotates one node. */
+	.relation-node--selected .relation-node__glyph {
+		stroke-width: 2.6px;
 	}
 
 	/* The focused neighbourhood stays at presence; the rest of the field dims to a
@@ -536,7 +561,7 @@
 		outline: none;
 	}
 	.relation-node:focus-visible .relation-node__glyph {
-		stroke: oklch(0.42 0.14 250);
+		stroke: var(--indigo-share);
 		stroke-width: 2.4px;
 	}
 

--- a/src/lib/components/template-browser/relation/RelationGraph.svelte
+++ b/src/lib/components/template-browser/relation/RelationGraph.svelte
@@ -36,7 +36,7 @@
 	import type { Template, RelationEdge } from '$lib/types/template';
 	import { resolveDomainHue, anchorLabelForHue, matchAnchor } from '$lib/utils/domain-hue';
 	import { familyEdges } from '$lib/core/topic/relation-edges';
-	import { layoutRelationGraph } from '$lib/core/topic/graph-layout';
+	import { layoutRelationGraphMemo } from '$lib/core/topic/graph-layout';
 	import { spring as svelteSpring } from 'svelte/motion';
 	import { SPRINGS } from '$lib/design/motion';
 	import { Search } from '@lucide/svelte';
@@ -142,8 +142,14 @@
 
 	// Deterministic positions: the same nodes + edges always settle identically, on
 	// the server and again on the client, so the map paints once and never lurches.
+	// The compute is quadratic, so it runs through the MEMOIZED entry point — keyed
+	// on (nodeIds, edgeKey, size) — and is paid once at mount, not on every hover or
+	// keystroke. The key invalidates only when the node set or an admissible edge
+	// genuinely changes, so a transient interaction never relays the field and a new
+	// edge set never serves a stale map. SSR computes the same key as the client (the
+	// templates hydrate from the same SSR payload), so both render the identical map.
 	const positions = $derived(
-		layoutRelationGraph(
+		layoutRelationGraphMemo(
 			nodes.map((n) => ({ id: n.id })),
 			// The layout knows two pull strengths: a measured twin pulls hardest, all
 			// taxonomic ties (family + tag-concept, both subordinate) pull as kin.
@@ -941,8 +947,14 @@
 	.relation-graph__svg {
 		display: block;
 		width: 100%;
+		/* Reserve the box at the viewBox's own ratio (1080:600) so the field claims
+		 * its full height from the first layout pass — before the browser has parsed
+		 * the SVG's intrinsic size and before hydration. Without this the height is
+		 * resolved late and the map (and everything below it) jumps on mount; with it
+		 * there is no CLS. The ratio is the WIDTH:HEIGHT constants the layout uses, so
+		 * the reserved box matches the painted field exactly. */
+		aspect-ratio: 1080 / 600;
 		height: auto;
-		max-height: 70vh;
 		/* Let the field breathe to its natural aspect; never overflow horizontally. */
 		overflow: visible;
 		/* The neighbourhood read's depth (0 at rest → 1 focused), the value the

--- a/src/lib/components/template-browser/relation/RelationGraph.svelte
+++ b/src/lib/components/template-browser/relation/RelationGraph.svelte
@@ -380,6 +380,105 @@
 	function nodeStroke(hue: number): string {
 		return `oklch(0.42 0.12 ${hue})`;
 	}
+
+	// ─── Mobile: a focus-centered relation view ───────────────────────────────
+	//
+	// A force-laid field of a dozen sub-tap dots is wrong on a phone — the thumb
+	// can't land on a 14px glyph and the labels collide. So below the breakpoint the
+	// SAME relation data takes a focus-centered form: one chosen concern is brought to
+	// the centre, its kin pulled close as full-size tappable cards (each NAMING the tie
+	// that binds it — a measured twin or a shared civic family), and the rest of the
+	// field reachable as a list, with the honestly-isolated held apart so their
+	// aloneness still reads. It expresses RELATION (the edges, who is near whom), not a
+	// flat list — picking a kin re-centres the view on it, so you navigate the graph by
+	// following ties, one neighbourhood at a time. Tapping the focus concern itself
+	// falls into the template through the same touch dive the rest of the surface uses.
+	//
+	// The split is pointer-aware, not width-only (the same probe the spectrum overview
+	// uses): a coarse pointer gets the focus-centered form at any width (a tablet in
+	// portrait is wide but all thumb), a fine pointer on a wide screen keeps the
+	// pannable SVG. Server-side it is false (no window), so SSR renders the desktop
+	// graph and the client reconciles to the real pointer/width on mount — no layout
+	// the server can't reproduce.
+	let narrow = $state(false);
+	$effect(() => {
+		const mq = window.matchMedia('(max-width: 767px), (pointer: coarse)');
+		const sync = () => (narrow = mq.matches);
+		sync();
+		mq.addEventListener('change', sync);
+		return () => mq.removeEventListener('change', sync);
+	});
+
+	// The concern at the centre of the mobile view. Null until the viewer picks one —
+	// then it derives to a stable default: the first CONNECTED node in stable order (a
+	// node with kin, so the centred view opens already showing a relation), falling
+	// back to the very first node when nothing is connected. Deterministic: the same
+	// corpus always opens on the same concern.
+	let mobileFocusPick = $state<string | null>(null);
+	const mobileFocusId = $derived.by<string | null>(() => {
+		if (mobileFocusPick && nodes.some((n) => n.id === mobileFocusPick)) return mobileFocusPick;
+		const firstConnected = nodes.find((n) => connected.has(n.id));
+		return firstConnected?.id ?? nodes[0]?.id ?? null;
+	});
+	const mobileFocusNode = $derived<DrawNode | null>(
+		drawNodes.find((n) => n.id === mobileFocusId) ?? null
+	);
+
+	/** A kin of the focused concern in the mobile view: the neighbour node plus the
+	 *  edge kind (and score) that ties it to the focus, so the card can name the tie. */
+	interface MobileKin {
+		node: DrawNode;
+		kind: RelationEdge['kind'];
+		score?: number;
+	}
+
+	// The kin of the mobile focus: every node an admissible edge connects to it, each
+	// carrying the kind of tie. Strongest relation first (a measured twin outranks
+	// taxonomic kin), then by score, so the closest concern sits at the top.
+	const mobileKin = $derived.by<MobileKin[]>(() => {
+		const id = mobileFocusId;
+		if (!id) return [];
+		const byId = new Map(drawNodes.map((n) => [n.id, n]));
+		const out: MobileKin[] = [];
+		for (const edge of allEdges) {
+			const otherId = edge.a === id ? edge.b : edge.b === id ? edge.a : null;
+			if (!otherId) continue;
+			const node = byId.get(otherId);
+			if (!node) continue;
+			out.push({ node, kind: edge.kind, score: edge.score });
+		}
+		out.sort((p, q) => {
+			const r = RANK[q.kind] - RANK[p.kind];
+			if (r !== 0) return r;
+			return (q.score ?? 0) - (p.score ?? 0);
+		});
+		return out;
+	});
+
+	// The rest of the field, reachable but not in the focus's neighbourhood: every node
+	// that is neither the focus nor one of its kin. Held in stable order, and split so
+	// the honestly-isolated read as a separate, intentionally-alone set rather than
+	// being folded in with the merely-not-adjacent.
+	const mobileRest = $derived.by<DrawNode[]>(() => {
+		const near = new Set<string>([mobileFocusId ?? '', ...mobileKin.map((k) => k.node.id)]);
+		return drawNodes.filter((n) => !near.has(n.id));
+	});
+	const mobileRestConnected = $derived(mobileRest.filter((n) => !n.isolated));
+	const mobileRestIsolated = $derived(mobileRest.filter((n) => n.isolated));
+
+	// Re-centre the mobile view on a concern (follow a tie to its neighbourhood) — a
+	// transform of which node is focal, never a relayout. Picking a kin walks the graph
+	// one neighbourhood at a time.
+	function centreMobile(id: string) {
+		mobileFocusPick = id;
+	}
+
+	// Plain-English name for the tie a kin card carries.
+	function kinTieLabel(kind: RelationEdge['kind']): string {
+		if (kind === 'twin') return 'measured semantic twin';
+		if (kind === 'concept') return 'shared tag concept';
+		return 'shared civic family';
+	}
 </script>
 
 <figure class="relation-graph" aria-label="Templates related by measured semantic kinship and civic family">
@@ -391,6 +490,7 @@
 	</figcaption>
 
 	{#if drawNodes.length > 0}
+		{#if !narrow}
 		<!-- Recognition navigation: name a fragment you remember and the map brings the
 		     matching node to the centre, lit, the rest receding. Reuses the template
 		     search vocabulary (the same search glyph + type=search field), but the copy
@@ -564,6 +664,167 @@
 				</li>
 			{/if}
 		</ul>
+		{:else}
+			<!-- ─── Mobile: the focus-centered relation view ───────────────────────────
+			     The same relation data as the SVG, re-shaped for the thumb. One concern is
+			     held at the centre; its kin are pulled close as full-size tappable cards,
+			     each naming the tie that binds it; the rest of the field is a reachable
+			     list, with the honestly-isolated held apart so their aloneness still reads.
+			     Following a tie re-centres the view on that concern — you navigate the graph
+			     a neighbourhood at a time, not a free-pan cloud of sub-tap dots. -->
+			{#if mobileFocusNode}
+				<div class="relation-focus" data-testid="relation-focus-view">
+					<!-- The concern at the centre: a full-width card, the hue its glyph, the
+					     civic family named under the title. Tapping it falls into the template
+					     through the same touch dive the rest of the surface uses. -->
+					<button
+						type="button"
+						class="relation-focus__centre font-brand"
+						style="--card-hue: {mobileFocusNode.hue};"
+						data-template-id={mobileFocusNode.id}
+						data-testid="relation-focus-centre"
+						aria-label="Open “{mobileFocusNode.label}”{mobileFocusNode.family
+							? `, ${mobileFocusNode.family}`
+							: ''}"
+						onclick={() => onSelect(mobileFocusNode!.id)}
+					>
+						<span
+							class="relation-focus__glyph"
+							style="background: {nodeFill(mobileFocusNode.hue)}; border-color: {nodeStroke(
+								mobileFocusNode.hue
+							)};"
+							aria-hidden="true"
+						></span>
+						<span class="relation-focus__centre-text">
+							<span class="relation-focus__centre-label">{mobileFocusNode.label}</span>
+							{#if mobileFocusNode.family}
+								<span class="relation-focus__centre-family">{mobileFocusNode.family}</span>
+							{/if}
+						</span>
+						<span class="relation-focus__open" aria-hidden="true">Open</span>
+					</button>
+
+					{#if mobileKin.length > 0}
+						<!-- Kin brought close: each names the tie (a measured twin, or a shared
+						     civic family) so the RELATION is the structure, not a flat list. The
+						     card centres the view on that concern (follow the tie); a separate
+						     control opens it. -->
+						<p class="relation-focus__heading font-brand">Closest to this</p>
+						<ul class="relation-focus__kin" aria-label="Concerns related to this one">
+							{#each mobileKin as kin (kin.node.id)}
+								<li class="relation-focus__kin-item">
+									<button
+										type="button"
+										class="relation-kin font-brand relation-kin--{kin.kind}"
+										style="--card-hue: {kin.node.hue};"
+										data-template-id={kin.node.id}
+										data-kin-kind={kin.kind}
+										data-testid="relation-kin-{kin.node.id}"
+										aria-label="Centre on “{kin.node.label}” — {kinTieLabel(kin.kind)}"
+										onclick={() => centreMobile(kin.node.id)}
+									>
+										<span class="relation-kin__tie" aria-hidden="true">
+											<span class="relation-kin__tie-line"></span>
+										</span>
+										<span
+											class="relation-kin__glyph"
+											style="background: {nodeFill(kin.node.hue)}; border-color: {nodeStroke(
+												kin.node.hue
+											)};"
+											aria-hidden="true"
+										></span>
+										<span class="relation-kin__text">
+											<span class="relation-kin__label">{kin.node.label}</span>
+											<span class="relation-kin__tie-name">{kinTieLabel(kin.kind)}</span>
+										</span>
+									</button>
+								</li>
+							{/each}
+						</ul>
+					{:else}
+						<!-- Honest: the focused concern stands alone — no admissible tie. Say so. -->
+						<p class="relation-focus__alone font-brand">
+							Stands alone — no close kin in the field yet.
+						</p>
+					{/if}
+
+					{#if mobileRestConnected.length > 0 || mobileRestIsolated.length > 0}
+						<!-- The rest of the field, reachable. Centring on any of them follows the
+						     graph to its neighbourhood. The isolated are held in their own group so
+						     their aloneness reads as intentional, not lost in the list. -->
+						{#if mobileRestConnected.length > 0}
+							<p class="relation-focus__heading font-brand">Elsewhere in the field</p>
+							<ul class="relation-focus__rest" aria-label="Other related concerns">
+								{#each mobileRestConnected as other (other.id)}
+									<li>
+										<button
+											type="button"
+											class="relation-other font-brand"
+											style="--card-hue: {other.hue};"
+											data-template-id={other.id}
+											data-testid="relation-other-{other.id}"
+											aria-label="Centre on “{other.label}”{other.family
+												? `, ${other.family}`
+												: ''}"
+											onclick={() => centreMobile(other.id)}
+										>
+											<span
+												class="relation-other__glyph"
+												style="background: {nodeFill(other.hue)}; border-color: {nodeStroke(
+													other.hue
+												)};"
+												aria-hidden="true"
+											></span>
+											<span class="relation-other__text">
+												<span class="relation-other__label">{other.label}</span>
+												{#if other.family}
+													<span class="relation-other__family">{other.family}</span>
+												{/if}
+											</span>
+										</button>
+									</li>
+								{/each}
+							</ul>
+						{/if}
+						{#if mobileRestIsolated.length > 0}
+							<p class="relation-focus__heading font-brand">Standing alone</p>
+							<ul class="relation-focus__rest" aria-label="Concerns with no close kin">
+								{#each mobileRestIsolated as other (other.id)}
+									<li>
+										<button
+											type="button"
+											class="relation-other relation-other--isolated font-brand"
+											style="--card-hue: {other.hue};"
+											data-template-id={other.id}
+											data-isolated="true"
+											data-testid="relation-other-{other.id}"
+											aria-label="Centre on “{other.label}”{other.family
+												? `, ${other.family}`
+												: ''}, standing alone"
+											onclick={() => centreMobile(other.id)}
+										>
+											<span
+												class="relation-other__glyph"
+												style="background: {nodeFill(other.hue)}; border-color: {nodeStroke(
+													other.hue
+												)};"
+												aria-hidden="true"
+											></span>
+											<span class="relation-other__text">
+												<span class="relation-other__label">{other.label}</span>
+												{#if other.family}
+													<span class="relation-other__family">{other.family}</span>
+												{/if}
+											</span>
+										</button>
+									</li>
+								{/each}
+							</ul>
+						{/if}
+					{/if}
+				</div>
+			{/if}
+		{/if}
 	{:else}
 		<!-- Honest empty state: no field to relate yet. Plain English, no dead map. -->
 		<div class="relation-graph__empty">
@@ -867,6 +1128,221 @@
 		font-size: 0.875rem;
 		color: oklch(0.5 0.02 250);
 		margin: 0.5rem 0 0;
+	}
+
+	/* ─── Mobile: the focus-centered relation view ─────────────────────────────
+	 * Below the breakpoint the SVG field gives way to this. It carries the same
+	 * vocabulary — the warm-cream ground shows through, the hue is each concern's
+	 * glyph, the tie kinds keep the solid/dashed encoding the edges use — re-shaped
+	 * into thumb-sized cards. No white box, no pill, max rounded-lg, every control
+	 * at least 44px tall so the thumb lands cleanly. */
+	.relation-focus {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+		padding: 0 1rem 0.5rem;
+		width: 100%;
+		box-sizing: border-box;
+	}
+
+	/* The concern at the centre — the strong center of the view. A full-width card on
+	 * the cream ground, its hue carried as a left edge + glyph. Tapping it dives. */
+	.relation-focus__centre {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		width: 100%;
+		min-height: 56px;
+		box-sizing: border-box;
+		text-align: left;
+		padding: 0.75rem 0.875rem;
+		border: 1px solid oklch(0.8 0.03 var(--card-hue, 60));
+		border-left: 4px solid oklch(0.6 0.14 var(--card-hue, 60));
+		border-radius: 0.5rem;
+		background: oklch(0.99 0.008 var(--card-hue, 60));
+		cursor: pointer;
+		transition: border-color 150ms cubic-bezier(0.4, 0, 0.2, 1);
+	}
+	.relation-focus__centre:active {
+		border-color: oklch(0.6 0.12 var(--card-hue, 60));
+	}
+
+	.relation-focus__glyph {
+		flex-shrink: 0;
+		width: 22px;
+		height: 22px;
+		border-radius: 50%;
+		border: 1.6px solid;
+	}
+
+	.relation-focus__centre-text {
+		flex: 1;
+		min-width: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.0625rem;
+	}
+	.relation-focus__centre-label {
+		font-size: 0.9375rem;
+		font-weight: 650;
+		color: oklch(0.3 0.03 60);
+		line-height: 1.25;
+	}
+	.relation-focus__centre-family {
+		font-size: 0.75rem;
+		color: oklch(0.55 0.02 60);
+	}
+	.relation-focus__open {
+		flex-shrink: 0;
+		font-size: 0.8125rem;
+		font-weight: 600;
+		color: var(--coord-share-solid);
+	}
+
+	/* Section headings — quiet, plain English, naming the relation each group carries. */
+	.relation-focus__heading {
+		margin: 0.5rem 0 0;
+		font-size: 0.6875rem;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+		color: oklch(0.55 0.02 60);
+	}
+
+	.relation-focus__alone {
+		margin: 0.25rem 0 0;
+		font-size: 0.8125rem;
+		color: oklch(0.5 0.02 60);
+	}
+
+	.relation-focus__kin,
+	.relation-focus__rest {
+		display: flex;
+		flex-direction: column;
+		gap: 0.375rem;
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	/* A kin card: the tie sample (echoing the edge encoding — solid twin, dashed
+	 * family) at the lead, then the hue glyph, the concern's name, and the plain tie
+	 * name. Tapping it re-centres the view on this concern. */
+	.relation-kin {
+		display: flex;
+		align-items: center;
+		gap: 0.625rem;
+		width: 100%;
+		min-height: 48px;
+		box-sizing: border-box;
+		text-align: left;
+		padding: 0.5rem 0.75rem;
+		border: 1px solid oklch(0.84 0.02 70);
+		border-radius: 0.5rem;
+		background: oklch(0.985 0.006 70);
+		cursor: pointer;
+		transition: border-color 150ms cubic-bezier(0.4, 0, 0.2, 1);
+	}
+	.relation-kin:active {
+		border-color: oklch(0.7 0.03 70);
+	}
+
+	/* The tie sample mirrors the SVG edge encoding so the eye reads the same language
+	 * in both forms: a solid heavier line for a measured twin, a dashed lighter line
+	 * for shared family / concept. */
+	.relation-kin__tie {
+		flex-shrink: 0;
+		width: 26px;
+		display: flex;
+		align-items: center;
+	}
+	.relation-kin__tie-line {
+		width: 100%;
+		height: 0;
+	}
+	.relation-kin--twin .relation-kin__tie-line {
+		border-top: 2.4px solid oklch(0.5 0.06 60);
+	}
+	.relation-kin--family .relation-kin__tie-line {
+		border-top: 1.6px dashed oklch(0.6 0.03 60);
+	}
+	.relation-kin--concept .relation-kin__tie-line {
+		border-top: 1.4px dotted oklch(0.62 0.04 60);
+	}
+
+	.relation-kin__glyph {
+		flex-shrink: 0;
+		width: 16px;
+		height: 16px;
+		border-radius: 50%;
+		border: 1.4px solid;
+	}
+	.relation-kin__text {
+		flex: 1;
+		min-width: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.0625rem;
+	}
+	.relation-kin__label {
+		font-size: 0.875rem;
+		font-weight: 600;
+		color: oklch(0.3 0.03 60);
+		line-height: 1.25;
+	}
+	.relation-kin__tie-name {
+		font-size: 0.6875rem;
+		color: oklch(0.55 0.02 60);
+	}
+
+	/* A reachable-but-not-adjacent concern. Lighter than a kin card (no tie sample),
+	 * still a full 44px+ target. Centring on it follows the graph to its neighbourhood. */
+	.relation-other {
+		display: flex;
+		align-items: center;
+		gap: 0.625rem;
+		width: 100%;
+		min-height: 44px;
+		box-sizing: border-box;
+		text-align: left;
+		padding: 0.5rem 0.75rem;
+		border: 1px solid transparent;
+		border-radius: 0.5rem;
+		background: transparent;
+		cursor: pointer;
+		transition: background-color 150ms cubic-bezier(0.4, 0, 0.2, 1);
+	}
+	.relation-other:active {
+		background: oklch(0.97 0.008 var(--card-hue, 60));
+	}
+	/* An isolated concern is held visibly apart — a dotted edge marks its aloneness,
+	 * the same honesty the periphery loners carry in the SVG. */
+	.relation-other--isolated {
+		border: 1px dashed oklch(0.84 0.02 70);
+	}
+	.relation-other__glyph {
+		flex-shrink: 0;
+		width: 14px;
+		height: 14px;
+		border-radius: 50%;
+		border: 1.4px solid;
+	}
+	.relation-other__text {
+		flex: 1;
+		min-width: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.0625rem;
+	}
+	.relation-other__label {
+		font-size: 0.875rem;
+		font-weight: 600;
+		color: oklch(0.32 0.03 60);
+		line-height: 1.25;
+	}
+	.relation-other__family {
+		font-size: 0.6875rem;
+		color: oklch(0.56 0.02 60);
 	}
 
 	/* Respect vestibular preferences: no glyph scaling transition. The focus dim is

--- a/src/lib/components/template-browser/spectrum/SpectrumLandscape.svelte
+++ b/src/lib/components/template-browser/spectrum/SpectrumLandscape.svelte
@@ -29,7 +29,6 @@
 	 */
 
 	import type { Snippet } from 'svelte';
-	import { tick } from 'svelte';
 	import type { Template, TemplateGroup } from '$lib/types/template';
 	import { groupByDomain, bandDomId } from '$lib/core/topic/domain-grouping';
 	import { toPlaceBands } from '$lib/core/topic/place-bands';
@@ -37,8 +36,9 @@
 	import DomainBand from './DomainBand.svelte';
 	import LensToggle, { type Lens } from './LensToggle.svelte';
 	import SpectrumOverview from './SpectrumOverview.svelte';
-	import { Artifact, EntityCluster } from '$lib/design';
-	import { TIMING, EASING } from '$lib/design/motion';
+	import DescentDive from '../DescentDive.svelte';
+	import { EntityCluster } from '$lib/design';
+	import { TIMING } from '$lib/design/motion';
 
 	interface Props {
 		/** The public templates to lay out as a topical field. */
@@ -273,124 +273,27 @@
 
 	// ─── The dive: a descent into the chosen template ─────────────────────────
 	//
-	// Selecting a tile is falling into it. The WHOLE page recedes behind a single
-	// full-viewport backdrop scrim (blur + a faint warm dim) and the chosen template
-	// ascends into an Artifact — the one white bounded surface for a floated object —
-	// wrapping the page's own preview. Because the scrim is one fixed plane over
-	// everything, the hero beside the field and the header above it recede with the
-	// field, as one — no half-sharp seam, one composited blur layer. Back / esc / a
-	// tap on the scrim reverses the fall: the Artifact settles away, the page returns
-	// to the EXACT state it left (scroll position, lens, selection cleared), and
-	// focus lands back on the tile it rose from. Reversible, no hidden state.
+	// Selecting a tile is falling into it — through the SAME descent the relation map
+	// uses, so the landing speaks one modal vocabulary, not two. The shared
+	// `DescentDive` recedes the whole page behind a single full-viewport scrim and
+	// raises the chosen template into an Artifact; back / esc / a tap on the scrim
+	// climbs out and restores the page (scroll, lens, selection cleared) with focus
+	// back on the tile it rose from. The orchestration — scroll-lock, focus trap,
+	// portal — lives there, not forked here.
 	//
 	// The dive is on only when the page supplies the preview snippet AND a tile is
 	// selected; without the snippet the surface keeps the split-view behaviour (the
 	// preview lives in its own column) and nothing here engages.
 	const diving = $derived(!!dive && !!selectedId);
 
-	// The body scroll position captured as the dive opens, restored as it closes,
-	// so the field comes back exactly where it was — the reversibility the descent
-	// promises. The element focus was on (the originating tile) is restored too.
-	let lockedScrollY = 0;
-	let diveSurface = $state<HTMLElement | null>(null);
-	let restoreFocusId: string | null = null;
-
-	function lockFieldScroll() {
-		lockedScrollY = window.scrollY;
-		document.body.style.position = 'fixed';
-		document.body.style.top = `-${lockedScrollY}px`;
-		document.body.style.left = '0';
-		document.body.style.right = '0';
-	}
-
-	function unlockFieldScroll() {
-		document.body.style.position = '';
-		document.body.style.top = '';
-		document.body.style.left = '';
-		document.body.style.right = '';
-		window.scrollTo(0, lockedScrollY);
-	}
-
-	// Open / close is driven by `diving`. On open: remember the originating tile,
-	// lock the field's scroll, move focus into the Artifact. On close: restore the
-	// scroll and return focus to the tile. Effects never run under SSR and the dive
-	// only exists on the client, so the window/document reads need no guard.
-	$effect(() => {
-		if (!diving) return;
-		restoreFocusId = selectedId;
-		lockFieldScroll();
-		// Focus the first focusable inside the risen Artifact once it has mounted.
-		// `preventScroll` so moving focus never nudges the (fixed) body underneath.
-		tick().then(() => {
-			const first = diveSurface?.querySelector<HTMLElement>(
-				'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-			);
-			(first ?? diveSurface)?.focus({ preventScroll: true });
-		});
-		return () => {
-			unlockFieldScroll();
-			// Return focus to the tile the dive rose from, so the body knows where it
-			// came back to. `preventScroll` is essential: a bare focus() scrolls the
-			// tile into view and would override the exact scroll position we just
-			// restored — the field must come back where it left, not jump to the tile.
-			const id = restoreFocusId;
-			restoreFocusId = null;
-			tick().then(() => {
-				if (!id) return;
-				document
-					.querySelector<HTMLElement>(`[data-template-button][data-template-id="${id}"]`)
-					?.focus({ preventScroll: true });
-			});
-		};
-	});
+	// The originating tile to return focus to on close — the descent resolves this
+	// selector against the document so the field comes back exactly where it left.
+	const diveRestoreSelector = $derived(
+		selectedId ? `[data-template-button][data-template-id="${selectedId}"]` : null
+	);
 
 	function closeDive() {
 		onClose?.();
-	}
-
-	// Portal the descent layer to <body>. The field sits inside the page's
-	// `.template-list-column`, which is a `position: relative; z-index: 1` stacking
-	// context, and the hero beside it sits in a sticky `z-index: 10` column — so a
-	// scrim left in place would be capped at z-index 1 and the hero (z-index 10)
-	// would paint OVER it, leaving the left half sharp. Moving the layer to <body>
-	// lifts it to the document root, where its z-index clears every page context and
-	// its backdrop-filter blurs the WHOLE page beneath it as one. Mirrors the
-	// existing body-portal pattern (AnimatedPopover). Client-only (actions never run
-	// under SSR), so the document reads need no guard.
-	function portalToBody(node: HTMLElement) {
-		document.body.appendChild(node);
-		return {
-			destroy() {
-				node.remove();
-			}
-		};
-	}
-
-	// Esc reverses the dive. A keydown on the descent layer is enough — focus is
-	// trapped inside it while diving, so the handler always sees the key.
-	function handleDiveKeydown(event: KeyboardEvent) {
-		if (event.key === 'Escape') {
-			event.preventDefault();
-			closeDive();
-			return;
-		}
-		if (event.key !== 'Tab') return;
-		// Trap focus inside the Artifact: wrap from last → first and first → last so
-		// tab never leaves the risen object for the receded field beneath it.
-		const focusables = diveSurface?.querySelectorAll<HTMLElement>(
-			'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-		);
-		if (!focusables || focusables.length === 0) return;
-		const first = focusables[0];
-		const last = focusables[focusables.length - 1];
-		const active = document.activeElement;
-		if (event.shiftKey && active === first) {
-			event.preventDefault();
-			last.focus();
-		} else if (!event.shiftKey && active === last) {
-			event.preventDefault();
-			first.focus();
-		}
 	}
 </script>
 
@@ -440,43 +343,19 @@
 	{/if}
 </div>
 
-{#if diving}
-	<!-- The descent: the chosen template, risen as an Artifact over the whole
-	     receded page. A tap on the scrim, esc, or back reverses it. Focus is trapped
-	     inside the Artifact while it is up and restored to the originating tile on
-	     close. The preview inside is the page's own — mounted here, never forked. -->
-	<div
-		class="dive-layer"
-		role="presentation"
-		onkeydown={handleDiveKeydown}
-		use:portalToBody
-	>
-		<!-- The scrim recedes the whole page as one: a fixed full-viewport plane that
-		     blurs and faintly dims everything painted behind it — this field, the hero
-		     beside it, the header above it — so the dive reads as a fall away from the
-		     entire page, not just one column. It is also the way back: a click anywhere
-		     on it closes the dive. A button (not a div) so the keyboard reaches it. -->
-		<button
-			type="button"
-			class="dive-scrim"
-			aria-label="Back to the field"
-			onclick={closeDive}
-		></button>
-
-		<div
-			bind:this={diveSurface}
-			class="dive-surface"
-			role="dialog"
-			aria-modal="true"
-			aria-label="Template preview"
-			tabindex="-1"
-			style="--dive-ascent-ms: {TIMING.SLOW}ms; --dive-ascent-ease: {EASING};"
-		>
-			<Artifact padding="compact" class="dive-artifact">
-				{@render dive?.()}
-			</Artifact>
-		</div>
-	</div>
+<!-- The descent: the chosen template, risen as an Artifact over the whole receded
+     page. The one shared dive — a tap on the scrim, esc, or back reverses it; focus
+     is trapped inside the Artifact while it is up and restored to the originating
+     tile on close. The preview inside is the page's own — mounted here, never
+     forked. `dive` is always set when `diving` is true (it is part of the guard), so
+     the snippet hands straight through. -->
+{#if diving && dive}
+	<DescentDive
+		{dive}
+		open={diving}
+		onClose={closeDive}
+		restoreFocusSelector={diveRestoreSelector}
+	/>
 {/if}
 
 <style>
@@ -529,96 +408,5 @@
 	 */
 	.spectrum-field.field-inert {
 		pointer-events: none;
-	}
-
-	/*
-	 * The descent layer — a full-viewport plane the risen Artifact floats in. It
-	 * sits over the whole page; its scrim is the recede AND the way back.
-	 */
-	.dive-layer {
-		position: fixed;
-		inset: 0;
-		z-index: 1000;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		padding: 1.5rem;
-	}
-
-	/*
-	 * The scrim recedes the whole page as one. A fixed full-viewport plane that
-	 * blurs everything painted behind it (one composited backdrop-filter layer, not
-	 * a blurred 300-node subtree) and lays a faint warm dim over it — the modal
-	 * surface token (warm cream) at half alpha, never a hard black overlay. So the
-	 * field, the hero beside it, and the header above it recede together, with no
-	 * half-sharp seam. Clicking it reverses the dive. The blur is the expensive
-	 * channel, so it is dropped under reduced motion (below); the dim stays.
-	 */
-	.dive-scrim {
-		position: absolute;
-		inset: 0;
-		border: none;
-		margin: 0;
-		padding: 0;
-		cursor: pointer;
-		/* Fallback for engines without color-mix: the modal surface token at full
-		   weight; the color-mix below takes it to half alpha where supported. */
-		background: var(--surface-overlay, oklch(0.975 0.005 55));
-		background: color-mix(in oklch, var(--surface-overlay, oklch(0.975 0.005 55)) 50%, transparent);
-		backdrop-filter: blur(4px);
-		-webkit-backdrop-filter: blur(4px);
-	}
-
-	/*
-	 * The risen object. Bounded so the preview keeps its column rhythm, scrollable
-	 * within when the preview is taller than the viewport, and raised above the
-	 * backdrop. The white surface and border belong to the Artifact inside it.
-	 */
-	.dive-surface {
-		position: relative;
-		z-index: 1;
-		width: 100%;
-		max-width: 40rem;
-		max-height: calc(100vh - 3rem);
-		overflow: hidden;
-		display: flex;
-		flex-direction: column;
-		/* The ascent: the Artifact rises on system motion — SLOW (320ms) for the
-		   weight of a surfacing object, with the standard EASING. Both come from
-		   motion.ts via the inline custom properties above (TIMING.SLOW / EASING),
-		   so this transition carries no off-token literal. */
-		animation: dive-ascend var(--dive-ascent-ms) var(--dive-ascent-ease) both;
-	}
-
-	.dive-surface :global(.dive-artifact) {
-		max-height: 100%;
-		overflow-y: auto;
-	}
-
-	@keyframes dive-ascend {
-		from {
-			opacity: 0;
-			transform: translateY(16px) scale(0.985);
-		}
-		to {
-			opacity: 1;
-			transform: translateY(0) scale(1);
-		}
-	}
-
-	/*
-	 * Reduced motion: no blur, no rise. The scrim keeps only its faint warm dim
-	 * (cheap, non-vestibular) so the dive is still legibly set apart, and the
-	 * Artifact appears at once — the descent is instant, not animated.
-	 */
-	@media (prefers-reduced-motion: reduce) {
-		.dive-scrim {
-			backdrop-filter: none;
-			-webkit-backdrop-filter: none;
-		}
-
-		.dive-surface {
-			animation: none;
-		}
 	}
 </style>

--- a/src/lib/core/topic/graph-layout.ts
+++ b/src/lib/core/topic/graph-layout.ts
@@ -103,8 +103,10 @@ const FORCE_ITERATIONS = 400;
 const DECLUMP_ITERATIONS = 300;
 /** Ideal edge length in the unit (pre-scale) field; the FR `k`. */
 const IDEAL_DISTANCE = 1.4;
-/** Repulsion gain — the mock's 1.3× over the bare k²/d. */
-const REPULSION_GAIN = 1.3;
+/** Repulsion gain over the bare k²/d. Raised above the mock's 1.3 so separate
+ *  clusters + isolated nodes push further apart — cleaner void between the real
+ *  knots without touching the declump floor (connected nodes still settle at it). */
+const REPULSION_GAIN = 1.7;
 /** Pull weight per relation kind. Measured twins pull harder than kin (mock). */
 const TWIN_PULL = 1.4;
 const FAMILY_PULL = 0.7;

--- a/src/lib/core/topic/graph-layout.ts
+++ b/src/lib/core/topic/graph-layout.ts
@@ -33,6 +33,28 @@
  * Pull weights (twin > family) reproduce the mock's edge stiffness; the FR
  * constants (repulsion gain, cooling) are the mock's, tuned there against the
  * live seed so the four measured twin-pairs cluster while the loners drift out.
+ *
+ * COST CEILING (worker boundary, documented not built). The layout is
+ * O(FORCE_ITERATIONS · N²) — every pair repels each of 400 iterations — plus two
+ * O(DECLUMP_ITERATIONS · N²) relaxation passes. That is fine for the live corpus
+ * and well past it, but it grows quadratically. Measured on the dev machine's
+ * main thread (warm, averaged):
+ *
+ *     N= 13 (the seed)  ~2.6ms     N= 90   ~85ms
+ *     N= 50            ~28ms       N=110  ~118ms
+ *     N= 75            ~55ms       N=150  ~224ms
+ *
+ * The compute runs ONCE per distinct (nodeIds, edgeKey, size, seed) — memoized by
+ * {@link layoutRelationGraphMemo}, so it is a one-time mount cost, never per
+ * frame. Up to ~N=40 it lands inside a single 16ms frame; by ~N=100 it is a
+ * ~100ms main-thread stall the viewer would feel on the first paint. The honest
+ * ceiling: keep this on the main thread while the public corpus stays under ~100
+ * templates. PAST that, move the compute off-thread (a Web Worker returning the
+ * position map, the component painting from a reserved box meanwhile) or switch
+ * the repulsion to a Barnes–Hut quadtree (O(N log N)). Neither is built now — at
+ * a dozen-odd templates it would be speculative engineering for load that does
+ * not exist; this note is the trigger to revisit when the corpus approaches the
+ * ceiling.
  */
 
 /** A node to lay out. Only the stable `id` is required; `hue` rides along for
@@ -405,4 +427,86 @@ export function layoutRelationGraph(
 		result.set(ids[i], { x, y });
 	}
 	return result;
+}
+
+// --- Memoized entry point ---------------------------------------------------
+//
+// The compute above is quadratic (see the COST CEILING note at the top), so a
+// reactive surface must not re-run it on every tick — a hover or a search must
+// never pay for a relayout. This wrapper makes the layout a one-time mount cost:
+// it computes a STABLE KEY from exactly the inputs that move a node — the present
+// id set, the canonical (lo,hi,kind) edge set, the canvas size, the seed, and the
+// separation — and returns the cached map whenever that key recurs. Two different
+// edge sets produce two different keys, so a stale graph can never be served
+// across a genuine change (the R9 memoization risk): the key invalidates the
+// instant any admissible relation is added or dropped.
+
+/**
+ * Build the memo key. It folds in only what the geometry depends on, in a
+ * canonical, order-independent form, so the SAME logical graph keys identically
+ * however the caller ordered its arrays — the same invariance the layout itself
+ * guarantees. Node ids are sorted; edges are normalized to sorted (lo|hi|kind)
+ * tuples and sorted, so a flipped or reordered edge list yields the same key.
+ */
+function layoutKey(
+	nodes: GraphLayoutNode[],
+	edges: GraphLayoutEdge[],
+	opts: GraphLayoutOptions
+): string {
+	const ids = nodes
+		.map((nd) => nd?.id)
+		.filter((id): id is string => typeof id === 'string' && id.length > 0)
+		.sort((x, y) => x.localeCompare(y));
+	const edgeKeys = edges
+		.filter((e) => e && typeof e.a === 'string' && typeof e.b === 'string' && e.a !== e.b)
+		.map((e) => {
+			const [lo, hi] = e.a <= e.b ? [e.a, e.b] : [e.b, e.a];
+			return `${lo}|${hi}|${e.kind}`;
+		})
+		.sort();
+	const seed = opts.seed ?? 0;
+	const minSep = opts.minSeparation ?? DEFAULT_MIN_SEPARATION;
+	// Length prefixes keep the segments unambiguous (no id can forge a boundary).
+	return [
+		`${opts.width}x${opts.height}`,
+		`s${seed}`,
+		`m${minSep}`,
+		`n${ids.length}:${ids.join(',')}`,
+		`e${edgeKeys.length}:${edgeKeys.join(',')}`
+	].join('§');
+}
+
+/** A tiny bounded cache. The surface lays out one or two graphs (the live set,
+ *  maybe a search-filtered one), so a handful of entries is plenty; the bound
+ *  keeps a long-running tab from accreting stale maps. Oldest-out on overflow. */
+const MEMO_LIMIT = 8;
+const layoutMemo = new Map<string, Map<string, Point>>();
+
+/**
+ * Lay out the relation graph, memoized by its inputs. Same `(nodeIds, edgeKey,
+ * size, seed, minSeparation)` ⇒ the identical `Map` returned without recomputing;
+ * any genuine change to that key recomputes. Use this from the reactive surface —
+ * {@link layoutRelationGraph} stays exported as the pure, un-cached primitive the
+ * determinism tests pin.
+ */
+export function layoutRelationGraphMemo(
+	nodes: GraphLayoutNode[],
+	edges: GraphLayoutEdge[],
+	opts: GraphLayoutOptions
+): Map<string, Point> {
+	const key = layoutKey(nodes, edges, opts);
+	const hit = layoutMemo.get(key);
+	if (hit) {
+		// Refresh recency so the genuinely-current graph survives eviction.
+		layoutMemo.delete(key);
+		layoutMemo.set(key, hit);
+		return hit;
+	}
+	const computed = layoutRelationGraph(nodes, edges, opts);
+	layoutMemo.set(key, computed);
+	if (layoutMemo.size > MEMO_LIMIT) {
+		const oldest = layoutMemo.keys().next().value;
+		if (oldest !== undefined) layoutMemo.delete(oldest);
+	}
+	return computed;
 }

--- a/src/lib/core/topic/graph-layout.ts
+++ b/src/lib/core/topic/graph-layout.ts
@@ -1,0 +1,323 @@
+/**
+ * Relation-graph layout — a deterministic, SSR-safe force + declump engine.
+ *
+ * Places the relatedness graph's nodes in a 2-D field so that:
+ *   - templates joined by an edge (measured twin or civic-family kin) settle
+ *     near each other — the connected clusters read as the structure;
+ *   - templates with NO admissible edge sit honestly alone at the periphery,
+ *     never dragged inward to look less lonely (R4);
+ *   - connected clusters never overlap — a declump pass enforces a minimum
+ *     centre-to-centre separation so two families don't pile on one spot.
+ *
+ * This is our own layout, ported from the approved mock — no d3, no foreign
+ * force/graph library (R8). Two stages, matching the mock:
+ *
+ *   1. Fruchterman–Reingold: every pair repels (k²/d); every edge attracts
+ *      (d²/k, scaled by the relation's pull weight — a measured twin pulls
+ *      harder than taxonomic kin); a cooling schedule freezes the field over a
+ *      bounded iteration count.
+ *   2. Screen-space declump: a bounded relaxation that pushes any two nodes
+ *      closer than `minSeparation` apart, then clamps every node inside the
+ *      canvas. Connected nodes have already been pulled together in stage 1, so
+ *      this only resolves overlaps — it does not tear clusters apart.
+ *
+ * DETERMINISM is load-bearing (R9): the surface renders on the server and again
+ * on the client and the two MUST agree to the pixel, or the graph lurches on
+ * hydration. So this module reads no wall-clock, no randomness and no browser
+ * globals — every value is a pure function of its inputs. The initial layout is
+ * seeded from a pure hash of each node's id (folded with the `seed` option),
+ * which also makes the result independent of input ORDER — shuffling the node
+ * array yields the identical positions. Same `(nodeIds, edgeKey, size, seed)` ⇒
+ * byte-identical `Map`, so the caller can memoize on those keys.
+ *
+ * Pull weights (twin > family) reproduce the mock's edge stiffness; the FR
+ * constants (repulsion gain, cooling) are the mock's, tuned there against the
+ * live seed so the four measured twin-pairs cluster while the loners drift out.
+ */
+
+/** A node to lay out. Only the stable `id` is required; `hue` rides along for
+ *  the renderer but does not affect geometry. The layout reads `id` alone. */
+export interface GraphLayoutNode {
+	/** Stable template id — the seed for this node's deterministic placement. */
+	id: string;
+}
+
+/** An undirected relation between two node ids. Mirrors `RelationEdge` (the
+ *  shipped edge tuple) without importing it, so the layout has no opinion on
+ *  where edges come from — it lays out whatever honest edge set it is given. */
+export interface GraphLayoutEdge {
+	/** One endpoint id. */
+	a: string;
+	/** The other endpoint id. */
+	b: string;
+	/** The relation kind. A measured twin pulls harder than taxonomic kin. */
+	kind: 'twin' | 'family';
+}
+
+/** Options. `width`/`height` are the canvas the positions fall inside; `seed`
+ *  folds into the per-node hash so a caller can re-roll the arrangement without
+ *  touching the data (still fully deterministic per seed). */
+export interface GraphLayoutOptions {
+	width: number;
+	height: number;
+	/** Folded into each node's placement hash. Default 0. */
+	seed?: number;
+	/** Minimum centre-to-centre separation the declump pass enforces, in px.
+	 *  Defaults to a spacing that keeps a labelled node from colliding. */
+	minSeparation?: number;
+}
+
+/** A laid-out position. */
+export interface Point {
+	x: number;
+	y: number;
+}
+
+// --- Tunable constants (the mock's, kept together and named) ----------------
+
+/** Force-layout iterations. Bounded so the function always terminates (R9). */
+const FORCE_ITERATIONS = 400;
+/** Declump relaxation iterations; exits early once nothing moves. */
+const DECLUMP_ITERATIONS = 300;
+/** Ideal edge length in the unit (pre-scale) field; the FR `k`. */
+const IDEAL_DISTANCE = 1.4;
+/** Repulsion gain — the mock's 1.3× over the bare k²/d. */
+const REPULSION_GAIN = 1.3;
+/** Pull weight per relation kind. Measured twins pull harder than kin (mock). */
+const TWIN_PULL = 1.4;
+const FAMILY_PULL = 0.7;
+/** Cooling schedule: temperature falls linearly from PEAK to FLOOR over the run. */
+const TEMP_PEAK = 0.09;
+const TEMP_FLOOR = 0.004;
+/** Inset from the canvas edge the laid-out field is scaled into. */
+const PADDING = 150;
+/** Default declump minimum separation (px) — the mock's MIN. */
+const DEFAULT_MIN_SEPARATION = 132;
+/** Guard against divide-by-zero when two nodes coincide. */
+const EPSILON = 1e-3;
+
+// --- Deterministic seeded init ---------------------------------------------
+
+/**
+ * A pure 32-bit string hash (djb2 variant, the same idiom as `topic-hue`).
+ * Deterministic and SSR-safe — no globals, no clock. Used to derive a stable
+ * starting angle/radius per node, so the layout never reaches for randomness.
+ */
+function hashString(value: string): number {
+	let hash = 5381;
+	for (let i = 0; i < value.length; i++) {
+		hash = ((hash << 5) + hash + value.charCodeAt(i)) | 0;
+	}
+	return hash >>> 0; // unsigned
+}
+
+/** Map a hash to the unit interval [0, 1). */
+function unit(hash: number): number {
+	return (hash % 100000) / 100000;
+}
+
+// --- The layout -------------------------------------------------------------
+
+/**
+ * Lay out the relation graph deterministically.
+ *
+ * @param nodes - the nodes to place (read by stable `id`)
+ * @param edges - the honest relations between them (twin = solid, family = dashed)
+ * @param opts  - canvas size, optional seed + min separation
+ * @returns a `Map` from node id to its `{x, y}` inside `[0, width] × [0, height]`
+ *
+ * Determinism contract: same `(nodes-by-id, edges, width, height, seed)` ⇒
+ * byte-identical map, regardless of the order `nodes`/`edges` are passed in.
+ */
+export function layoutRelationGraph(
+	nodes: GraphLayoutNode[],
+	edges: GraphLayoutEdge[],
+	opts: GraphLayoutOptions
+): Map<string, Point> {
+	const { width, height } = opts;
+	const seed = opts.seed ?? 0;
+	const minSeparation = opts.minSeparation ?? DEFAULT_MIN_SEPARATION;
+
+	// Dedupe + order-independence: collapse to a stable, id-sorted node list so
+	// the geometry depends only on WHICH ids are present, not their array order.
+	const byId = new Map<string, GraphLayoutNode>();
+	for (const node of nodes) {
+		if (typeof node?.id === 'string' && node.id.length > 0 && !byId.has(node.id)) {
+			byId.set(node.id, node);
+		}
+	}
+	const ids = Array.from(byId.keys()).sort((x, y) => x.localeCompare(y));
+	const n = ids.length;
+	const result = new Map<string, Point>();
+	if (n === 0) return result;
+
+	const index = new Map<string, number>();
+	for (let i = 0; i < n; i++) index.set(ids[i], i);
+
+	// Which nodes carry at least one admissible edge. Edges referencing an id
+	// not in the node set are ignored (the layout lays out the nodes it is given).
+	const connected = new Array<boolean>(n).fill(false);
+	// Normalised, deduped edges as (lo, hi, weight) index triples — endpoints
+	// ordered lo<hi, sorted into a canonical order below (see the sort comment).
+	const weightByPair = new Map<string, { lo: number; hi: number; w: number }>();
+	for (const edge of edges) {
+		const ai = index.get(edge.a);
+		const bi = index.get(edge.b);
+		if (ai === undefined || bi === undefined || ai === bi) continue;
+		const lo = Math.min(ai, bi);
+		const hi = Math.max(ai, bi);
+		const key = `${lo}-${hi}`;
+		const w = edge.kind === 'twin' ? TWIN_PULL : FAMILY_PULL;
+		const existing = weightByPair.get(key);
+		// If both a twin and a family edge join the same pair, keep the stronger
+		// pull (the measured relation dominates) — order-independent by max.
+		if (!existing || w > existing.w) weightByPair.set(key, { lo, hi, w });
+		connected[lo] = true;
+		connected[hi] = true;
+	}
+	// Sort into a CANONICAL (lo, hi) order so the force accumulation visits edges
+	// in the same sequence no matter how the caller ordered or oriented them.
+	// Float addition is not associative, so a fixed visitation order is what makes
+	// the result byte-identical across SSR and client (R9 parity).
+	const triples = Array.from(weightByPair.values()).sort((p, q) =>
+		p.lo === q.lo ? p.hi - q.hi : p.lo - q.lo
+	);
+	const linkA = triples.map((t) => t.lo);
+	const linkB = triples.map((t) => t.hi);
+	const linkW = triples.map((t) => t.w);
+
+	// Single node: centre it (no relations to lay out against).
+	if (n === 1) {
+		result.set(ids[0], { x: width / 2, y: height / 2 });
+		return result;
+	}
+
+	// --- Seeded deterministic init ----------------------------------------
+	// Connected nodes start on an inner ring, isolated nodes on an OUTER ring —
+	// a structural head start toward the periphery so a no-kin template reads as
+	// honestly alone (R4) rather than relying on repulsion alone to expel it.
+	// Angle + a small radial jitter come from a pure hash of (id, seed), so the
+	// arrangement is reproducible and order-independent, with no two nodes
+	// landing exactly on top of each other.
+	const pos: Array<[number, number]> = new Array(n);
+	for (let i = 0; i < n; i++) {
+		const h = hashString(`${ids[i]}#${seed}`);
+		const angle = unit(h) * Math.PI * 2;
+		// A second hash decorrelates the radial jitter from the angle.
+		const jitter = unit(hashString(`${ids[i]}~${seed}`)) * 0.25;
+		const baseRadius = connected[i] ? 0.55 : 1.15;
+		const radius = baseRadius + jitter;
+		pos[i] = [Math.cos(angle) * radius, Math.sin(angle) * radius];
+	}
+
+	// --- Stage 1: Fruchterman–Reingold ------------------------------------
+	const k = IDEAL_DISTANCE;
+	for (let it = 0; it < FORCE_ITERATIONS; it++) {
+		const disp: Array<[number, number]> = new Array(n);
+		for (let i = 0; i < n; i++) disp[i] = [0, 0];
+
+		// Repulsion between every pair.
+		for (let i = 0; i < n; i++) {
+			for (let j = 0; j < n; j++) {
+				if (i === j) continue;
+				const dx = pos[i][0] - pos[j][0];
+				const dy = pos[i][1] - pos[j][1];
+				const d = Math.hypot(dx, dy) || EPSILON;
+				const force = ((k * k) / d) * REPULSION_GAIN;
+				disp[i][0] += (dx / d) * force;
+				disp[i][1] += (dy / d) * force;
+			}
+		}
+
+		// Attraction along edges (pull weight by relation kind).
+		for (let e = 0; e < linkA.length; e++) {
+			const a = linkA[e];
+			const b = linkB[e];
+			const dx = pos[a][0] - pos[b][0];
+			const dy = pos[a][1] - pos[b][1];
+			const d = Math.hypot(dx, dy) || EPSILON;
+			const force = ((d * d) / k) * linkW[e];
+			disp[a][0] -= (dx / d) * force;
+			disp[a][1] -= (dy / d) * force;
+			disp[b][0] += (dx / d) * force;
+			disp[b][1] += (dy / d) * force;
+		}
+
+		// Cool: bound each node's step by the falling temperature.
+		const temp = TEMP_PEAK * (1 - it / FORCE_ITERATIONS) + TEMP_FLOOR;
+		for (let i = 0; i < n; i++) {
+			const len = Math.hypot(disp[i][0], disp[i][1]) || EPSILON;
+			const step = Math.min(len, temp);
+			pos[i][0] += (disp[i][0] / len) * step;
+			pos[i][1] += (disp[i][1] / len) * step;
+		}
+	}
+
+	// --- Scale the unit field into the padded canvas ----------------------
+	let minX = Infinity;
+	let maxX = -Infinity;
+	let minY = Infinity;
+	let maxY = -Infinity;
+	for (let i = 0; i < n; i++) {
+		if (pos[i][0] < minX) minX = pos[i][0];
+		if (pos[i][0] > maxX) maxX = pos[i][0];
+		if (pos[i][1] < minY) minY = pos[i][1];
+		if (pos[i][1] > maxY) maxY = pos[i][1];
+	}
+	const spanX = maxX - minX + 1e-9;
+	const spanY = maxY - minY + 1e-9;
+	const usableW = width - 2 * PADDING;
+	const usableH = height - 2 * PADDING;
+	const screen: Array<[number, number]> = new Array(n);
+	for (let i = 0; i < n; i++) {
+		screen[i] = [
+			PADDING + ((pos[i][0] - minX) / spanX) * usableW,
+			PADDING + ((pos[i][1] - minY) / spanY) * usableH
+		];
+	}
+
+	// --- Stage 2: declump (enforce min separation, then clamp) ------------
+	// Isolated nodes are allowed to ride a little past the inner padding band
+	// toward the true edge, so they read as peripheral; connected nodes stay
+	// within the inner field. The clamp keeps everyone on-canvas (R-risk).
+	const loEdgeX = PADDING - 40;
+	const hiEdgeX = width - PADDING + 40;
+	const loEdgeY = PADDING - 30;
+	const hiEdgeY = height - PADDING + 30;
+	for (let pass = 0; pass < DECLUMP_ITERATIONS; pass++) {
+		let moved = false;
+		for (let i = 0; i < n; i++) {
+			for (let j = i + 1; j < n; j++) {
+				const dx = screen[i][0] - screen[j][0];
+				const dy = screen[i][1] - screen[j][1];
+				const d = Math.hypot(dx, dy) || EPSILON;
+				if (d < minSeparation) {
+					const push = (minSeparation - d) / 2;
+					const ux = dx / d;
+					const uy = dy / d;
+					screen[i][0] += ux * push;
+					screen[i][1] += uy * push;
+					screen[j][0] -= ux * push;
+					screen[j][1] -= uy * push;
+					moved = true;
+				}
+			}
+		}
+		// Clamp into the (slightly extended) canvas every pass so the push above
+		// never walks a node off-screen.
+		for (let i = 0; i < n; i++) {
+			screen[i][0] = Math.min(hiEdgeX, Math.max(loEdgeX, screen[i][0]));
+			screen[i][1] = Math.min(hiEdgeY, Math.max(loEdgeY, screen[i][1]));
+		}
+		if (!moved) break;
+	}
+
+	// Final hard clamp into the real bounds [0, width] × [0, height] so a caller
+	// can trust every position is on-canvas regardless of declump residue.
+	for (let i = 0; i < n; i++) {
+		const x = Math.min(width, Math.max(0, screen[i][0]));
+		const y = Math.min(height, Math.max(0, screen[i][1]));
+		result.set(ids[i], { x, y });
+	}
+	return result;
+}

--- a/src/lib/core/topic/graph-layout.ts
+++ b/src/lib/core/topic/graph-layout.ts
@@ -312,6 +312,91 @@ export function layoutRelationGraph(
 		if (!moved) break;
 	}
 
+	// --- Seat edge-free nodes on the rim ----------------------------------
+	// The outer-ring seed gives isolates a head start, but FR repulsion from the
+	// dense connected core, the scale-to-bounds normalization, and the declump
+	// above can all pull a loner back in among the connected nodes — so live, the
+	// no-kin templates read as intermixed, not "at the edges". This deterministic
+	// final step seats each edge-free node out on the rim, after declump (so the
+	// declump's tighter interior band can't cap it) and before the on-canvas clamp
+	// below (which keeps it in bounds).
+	//
+	// The loners are handed EVENLY-SPREAD rim bearings rather than pushed along
+	// wherever FR left them: sort by id (order-independent, deterministic), fan
+	// them around the circle, and fold a per-id-set hash into the fan's phase so
+	// the bearing is data-driven, not a fixed compass rose. With three loners that
+	// is ≥120° apart at the rim — hundreds of px — so they never collide with each
+	// other, and the connected core sits well inside the rim, so they clear it
+	// too. The connected nodes are left exactly where declump settled them.
+	const cx = width / 2;
+	const cy = height / 2;
+	const halfW = width / 2;
+	const halfH = height / 2;
+	// The rim, in AXIS-NORMALIZED (elliptical) space so a bearing toward the short
+	// axis seats just as peripherally as one toward the long axis — on a wide
+	// canvas a loner fanned to the top still reads as "at the edge", not stranded
+	// mid-field. A small inset under 1.0 keeps the glyph + its label on-canvas
+	// rather than clipped at the very edge by the hard clamp.
+	const RIM_FRACTION = 0.9;
+	const ellipseFraction = (x: number, y: number) =>
+		Math.hypot((x - cx) / halfW, (y - cy) / halfH);
+	const isolateIds = ids.filter((_, i) => !connected[i]).sort((x, y) => x.localeCompare(y));
+	const isolateCount = isolateIds.length;
+	if (isolateCount > 0) {
+		const phase = unit(hashString(`${isolateIds.join('|')}@rim#${seed}`)) * Math.PI * 2;
+		for (let k = 0; k < isolateCount; k++) {
+			const i = index.get(isolateIds[k]);
+			if (i === undefined) continue;
+			const angle = phase + (k / isolateCount) * Math.PI * 2;
+			const targetX = cx + Math.cos(angle) * RIM_FRACTION * halfW;
+			const targetY = cy + Math.sin(angle) * RIM_FRACTION * halfH;
+			// Only ever seat a loner FURTHER out (in ellipse space) than it already
+			// sits — never drag one the force pass already expelled past the rim
+			// back inward.
+			if (ellipseFraction(targetX, targetY) > ellipseFraction(screen[i][0], screen[i][1])) {
+				screen[i][0] = targetX;
+				screen[i][1] = targetY;
+			}
+		}
+
+		// A rim seat can land a loner within the minimum separation of a node the
+		// first declump already settled (e.g. one clamped against an edge). Run the
+		// SAME separation relaxation once more so the no-overlap invariant still
+		// holds after seating. The seat gave every loner a strong outward start, so
+		// at the default spacing this only nudges, leaving the rim read intact; a
+		// caller that asks for a separation too large for the rim to hold sees the
+		// loners relax inward just enough to honour it — overlap-freedom wins.
+		for (let pass = 0; pass < DECLUMP_ITERATIONS; pass++) {
+			let moved = false;
+			for (let i = 0; i < n; i++) {
+				for (let j = i + 1; j < n; j++) {
+					const dx = screen[i][0] - screen[j][0];
+					const dy = screen[i][1] - screen[j][1];
+					const d = Math.hypot(dx, dy) || EPSILON;
+					if (d < minSeparation) {
+						const push = (minSeparation - d) / 2;
+						const ux = dx / d;
+						const uy = dy / d;
+						screen[i][0] += ux * push;
+						screen[i][1] += uy * push;
+						screen[j][0] -= ux * push;
+						screen[j][1] -= uy * push;
+						moved = true;
+					}
+				}
+			}
+			// Clamp into the FULL canvas (not the tighter interior band the first
+			// declump used) so the rim seating is preserved — a loner fanned toward
+			// the short axis stays out near the true edge instead of being re-capped
+			// into the interior. The final hard clamp below is into these same bounds.
+			for (let i = 0; i < n; i++) {
+				screen[i][0] = Math.min(width, Math.max(0, screen[i][0]));
+				screen[i][1] = Math.min(height, Math.max(0, screen[i][1]));
+			}
+			if (!moved) break;
+		}
+	}
+
 	// Final hard clamp into the real bounds [0, width] × [0, height] so a caller
 	// can trust every position is on-canvas regardless of declump residue.
 	for (let i = 0; i < n; i++) {

--- a/src/lib/core/topic/landing-surface.ts
+++ b/src/lib/core/topic/landing-surface.ts
@@ -1,18 +1,47 @@
 /**
  * Landing surface selection.
  *
- * The landing page offers two browsing worlds over the same templates: the
- * hue-ordered topical landscape (the default) and the flat geographic list (a
- * working fallback kept reachable without a code change). Which one shows is
- * derived purely from the `spectrum` URL parameter, so the choice is a function
- * of the URL alone — addressable, shareable, and testable without rendering the
- * page.
+ * The landing page offers three browsing worlds over the same templates: the
+ * relatedness GRAPH (a map whose edges are measured semantic twins + civic-family
+ * kinship), the hue-ordered topical SPECTRUM (the current default), and the flat
+ * geographic LIST (a working fallback kept reachable without a code change). Which
+ * one shows is derived purely from the URL, so the choice is a function of the URL
+ * alone — addressable, shareable, and testable without rendering the page. The
+ * page and its tests share this one source of truth rather than each re-reading
+ * the parameters, so the default cannot silently drift apart between them.
  *
- * The rule: the landscape is the default, and the list opens ONLY on an explicit
- * `spectrum=0`. Any other value (or no parameter) resolves to the landscape, so
- * the default cannot silently move and a typo never strands the visitor on the
- * fallback.
+ * The rules, in precedence order:
+ *
+ *   1. `?view=graph` opens the relatedness graph. It is the most explicit opt-in,
+ *      so it wins over the spectrum/list toggle — the graph view-swap is reachable
+ *      on its own regardless of the `spectrum` parameter.
+ *   2. Otherwise the spectrum is the default, and the list opens ONLY on an
+ *      explicit `?spectrum=0`. Any other `spectrum` value (or none) resolves to
+ *      the spectrum, so the default cannot silently move and a typo never strands
+ *      the visitor on the fallback.
+ */
+
+/** The three discovery surfaces the landing can render. */
+export type LandingSurface = 'graph' | 'spectrum' | 'list';
+
+/** Resolve which discovery surface the landing renders for a given URL. */
+export function selectLandingSurface(url: URL): LandingSurface {
+	// The relatedness graph is the most explicit opt-in — an active `view=graph`
+	// wins over the orthogonal spectrum/list toggle so the map stays reachable on
+	// its own. (The graph is not yet the default; that flip is a separate change.)
+	if (url.searchParams.get('view') === 'graph') return 'graph';
+
+	// Otherwise the spectrum is the default; the list opens only on the explicit
+	// opt-out so neither a missing nor a malformed parameter strands the visitor.
+	return url.searchParams.get('spectrum') === '0' ? 'list' : 'spectrum';
+}
+
+/**
+ * Whether the topical spectrum shows for this URL. Retained as the spectrum's own
+ * predicate (the spectrum is true unless an explicit opt-out or the graph view
+ * swap takes over) and expressed through {@link selectLandingSurface} so the two
+ * cannot disagree.
  */
 export function shouldShowSpectrum(url: URL): boolean {
-	return url.searchParams.get('spectrum') !== '0';
+	return selectLandingSurface(url) === 'spectrum';
 }

--- a/src/lib/core/topic/landing-surface.ts
+++ b/src/lib/core/topic/landing-surface.ts
@@ -3,22 +3,21 @@
  *
  * The landing page offers three browsing worlds over the same templates: the
  * relatedness GRAPH (a map whose edges are measured semantic twins + civic-family
- * kinship), the hue-ordered topical SPECTRUM (the current default), and the flat
- * geographic LIST (a working fallback kept reachable without a code change). Which
- * one shows is derived purely from the URL, so the choice is a function of the URL
- * alone — addressable, shareable, and testable without rendering the page. The
- * page and its tests share this one source of truth rather than each re-reading
- * the parameters, so the default cannot silently drift apart between them.
+ * kinship — now the default), the hue-ordered topical SPECTRUM (an explicit opt-in),
+ * and the flat geographic LIST (a working fallback kept reachable without a code
+ * change). Which one shows is derived purely from the URL, so the choice is a
+ * function of the URL alone — addressable, shareable, and testable without rendering
+ * the page. The page and its tests share this one source of truth rather than each
+ * re-reading the parameters, so the default cannot silently drift apart between them.
  *
  * The rules, in precedence order:
  *
- *   1. `?view=graph` opens the relatedness graph. It is the most explicit opt-in,
- *      so it wins over the spectrum/list toggle — the graph view-swap is reachable
- *      on its own regardless of the `spectrum` parameter.
- *   2. Otherwise the spectrum is the default, and the list opens ONLY on an
- *      explicit `?spectrum=0`. Any other `spectrum` value (or none) resolves to
- *      the spectrum, so the default cannot silently move and a typo never strands
- *      the visitor on the fallback.
+ *   1. `?view=spectrum` opens the hue-ordered topical spectrum (the former default,
+ *      kept as an explicit opt-in).
+ *   2. `?view=list` — or the back-compatible `?spectrum=0` — opens the flat list.
+ *   3. Anything else (an explicit `?view=graph`, or no parameter at all) resolves to
+ *      the relatedness graph: it is the default front door, so a missing or malformed
+ *      parameter lands the visitor on the map rather than stranding them elsewhere.
  */
 
 /** The three discovery surfaces the landing can render. */
@@ -26,14 +25,17 @@ export type LandingSurface = 'graph' | 'spectrum' | 'list';
 
 /** Resolve which discovery surface the landing renders for a given URL. */
 export function selectLandingSurface(url: URL): LandingSurface {
-	// The relatedness graph is the most explicit opt-in — an active `view=graph`
-	// wins over the orthogonal spectrum/list toggle so the map stays reachable on
-	// its own. (The graph is not yet the default; that flip is a separate change.)
-	if (url.searchParams.get('view') === 'graph') return 'graph';
+	const view = url.searchParams.get('view');
 
-	// Otherwise the spectrum is the default; the list opens only on the explicit
-	// opt-out so neither a missing nor a malformed parameter strands the visitor.
-	return url.searchParams.get('spectrum') === '0' ? 'list' : 'spectrum';
+	// The spectrum and the list are explicit opt-ins off the graph default. The
+	// list keeps its back-compatible `?spectrum=0` opt-out alongside `?view=list`.
+	if (view === 'spectrum') return 'spectrum';
+	if (view === 'list' || url.searchParams.get('spectrum') === '0') return 'list';
+
+	// The relatedness graph is the default front door; an explicit `?view=graph`
+	// resolves here too, and so does a missing or malformed parameter — the visitor
+	// lands on the map rather than being stranded on a fallback.
+	return 'graph';
 }
 
 /**

--- a/src/lib/core/topic/relation-edges.ts
+++ b/src/lib/core/topic/relation-edges.ts
@@ -1,0 +1,102 @@
+/**
+ * Civic-family kinship edges — the taxonomic relation, derivable on the client.
+ *
+ * Two public templates are civic-family kin when their domains resolve to the
+ * SAME canonical anchor (Healthcare, Housing, Transportation, …). This is the
+ * dashed, visually-subordinate relation of the relatedness graph: it asserts a
+ * real taxonomic fact ("both are transportation concerns"), not a measured
+ * semantic similarity. The solid `twin` edges (mean-centered embedding cosine,
+ * computed server-side) carry the measured signal; family edges carry the
+ * shared-category one.
+ *
+ * Honest, by construction:
+ *
+ *   - The kinship key is the canonical anchor a domain's WORDING points at,
+ *     read straight from `matchAnchor` (the same anchor table that fixes the
+ *     spectrum hue). A template whose domain matches no anchor — a hashed
+ *     unknown, or a blank/null domain — gets NO family edge. It renders
+ *     honestly isolated unless a measured twin connects it. There is no
+ *     fabricated "Other" family that would invent kinship between unrelated
+ *     loners (R4).
+ *   - No embeddings are needed or touched: this runs from the already-shipped
+ *     `domain` string alone, so it is fully client-derivable and never widens
+ *     the wire payload (R8).
+ *
+ * Bounded fan-out (R7 — blooms with the corpus): within a same-anchor group the
+ * members are linked as a single connected CHAIN, ordered by template id, not
+ * as a complete graph. A group of n members yields n − 1 edges (every member
+ * reachable from every other through the chain) instead of n(n − 1)/2. At the
+ * seed every family is tiny, but the chain keeps a future 30-member domain from
+ * exploding into a 435-edge blob that would drown the measured twins.
+ *
+ * Pure, deterministic, SSR-safe: no wall-clock reads, no randomness, no browser
+ * globals. The same template set always yields the identical edge list, in a
+ * stable order, with each edge's endpoints normalized so the lexically-smaller
+ * id is `a` (matching the `twin` edges so the two sources dedupe cleanly).
+ */
+
+import type { Template, RelationEdge } from '$lib/types/template';
+import { matchAnchor } from '$lib/utils/domain-hue';
+
+/** The minimum the smaller-of-pair endpoint, so `a < b` holds on every edge. */
+function orderedPair(x: string, y: string): { a: string; b: string } {
+	return x <= y ? { a: x, b: y } : { a: y, b: x };
+}
+
+/**
+ * The canonical-anchor key two templates must SHARE to be civic-family kin, or
+ * `null` when the template resolves to no anchor (and so has no admissible
+ * family). Keyed on the domain WORDING via `matchAnchor` rather than the hue
+ * projection, so kinship is the plain taxonomic fact ("Public Library" and
+ * "Library Workforce" are both Education) regardless of whether the embedding
+ * hue backfill has run.
+ */
+function familyKey(template: Pick<Template, 'domain'>): number | null {
+	const domain = typeof template.domain === 'string' ? template.domain.trim() : '';
+	if (!domain) return null;
+	return matchAnchor(domain);
+}
+
+/**
+ * Derive the civic-family (`kind: 'family'`) edges for a set of public templates.
+ *
+ * Templates are bucketed by their shared canonical anchor; each non-trivial
+ * bucket (≥ 2 members) is linked as an id-ordered chain so the whole family is
+ * connected without an all-pairs blob. Templates with no anchor are dropped from
+ * the family graph entirely — they stand alone unless a measured twin reaches them.
+ *
+ * @param templates - the public templates to relate
+ * @returns the family edges, deterministically ordered (by `a` then `b`)
+ */
+export function familyEdges(templates: Pick<Template, 'id' | 'domain'>[]): RelationEdge[] {
+	// Bucket by shared canonical anchor; skip the anchorless (honestly isolated).
+	const byAnchor = new Map<number, string[]>();
+	for (const template of templates) {
+		const key = familyKey(template);
+		if (key === null) continue;
+		const id = template.id;
+		if (typeof id !== 'string' || id.length === 0) continue;
+		const bucket = byAnchor.get(key);
+		if (bucket) bucket.push(id);
+		else byAnchor.set(key, [id]);
+	}
+
+	const edges: RelationEdge[] = [];
+	for (const ids of byAnchor.values()) {
+		// One template is not a family; a chain needs at least a pair.
+		if (ids.length < 2) continue;
+		// Stable id order so the chain — and thus the whole edge set — is
+		// reproducible regardless of input ordering. A duplicate id in the set
+		// collapses to a single node, never a self-loop.
+		const unique = Array.from(new Set(ids)).sort((x, y) => x.localeCompare(y));
+		for (let i = 1; i < unique.length; i++) {
+			const { a, b } = orderedPair(unique[i - 1], unique[i]);
+			edges.push({ a, b, kind: 'family' });
+		}
+	}
+
+	// Global stable order so two runs over the same input return an identical
+	// array (the layout consumes this directly; determinism is load-bearing).
+	edges.sort((e1, e2) => (e1.a === e2.a ? e1.b.localeCompare(e2.b) : e1.a.localeCompare(e2.a)));
+	return edges;
+}

--- a/src/lib/types/template.ts
+++ b/src/lib/types/template.ts
@@ -492,6 +492,10 @@ export interface NextTierPreview {
  *   Drawn solid. `score` is the (conservative) centered-cosine similarity.
  * - `family`: civic-family kinship — the two templates share a domain anchor.
  *   Drawn dashed. Taxonomic, so `score` is absent.
+ * - `concept`: a shared tag-concept — the two templates carry tags that cluster
+ *   tightly in mean-centered space (synonymous facets folded into one concept).
+ *   Additive and subordinate, drawn in a third quiet style. Emitted only for
+ *   tight clusters; absent at a corpus too thin to form any.
  */
 export interface RelationEdge {
 	/** One endpoint template id (the lexically-smaller of the pair). */
@@ -499,7 +503,7 @@ export interface RelationEdge {
 	/** The other endpoint template id. */
 	b: string;
 	/** The kind of relation this edge asserts. */
-	kind: 'twin' | 'family';
-	/** Centered-cosine similarity for measured twins; omitted for family kin. */
+	kind: 'twin' | 'family' | 'concept';
+	/** Centered-cosine similarity for measured twins; omitted for taxonomic kin. */
 	score?: number;
 }

--- a/src/lib/types/template.ts
+++ b/src/lib/types/template.ts
@@ -482,3 +482,24 @@ export interface NextTierPreview {
 	/** Callback when user clicks */
 	onClick: () => void;
 }
+
+/**
+ * An honest relatedness edge between two public templates, as exposed to the
+ * client. Endpoints are template ids; embeddings never cross this boundary.
+ *
+ * - `twin`: a measured semantic twin — mean-centered template cosine that
+ *   cleared the calibrated threshold and survived the leave-one-out check.
+ *   Drawn solid. `score` is the (conservative) centered-cosine similarity.
+ * - `family`: civic-family kinship — the two templates share a domain anchor.
+ *   Drawn dashed. Taxonomic, so `score` is absent.
+ */
+export interface RelationEdge {
+	/** One endpoint template id (the lexically-smaller of the pair). */
+	a: string;
+	/** The other endpoint template id. */
+	b: string;
+	/** The kind of relation this edge asserts. */
+	kind: 'twin' | 'family';
+	/** Centered-cosine similarity for measured twins; omitted for family kin. */
+	score?: number;
+}

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -22,5 +22,18 @@ export const load: PageServerLoad = async ({ depends }) => {
 		return [];
 	});
 
-	return { templates };
+	// The measured-twin relatedness edges over the public set. The server-only
+	// embeddings stay server-only — this returns ONLY {a, b, score, kind} tuples
+	// keyed by template id, never a vector. Guarded the same way as the templates
+	// load so a transient Convex timeout degrades to a no-edge map (every template
+	// honestly alone), never a hard 500.
+	const relationEdges = await serverQuery(api.templates.relatednessEdges, {}).catch((err) => {
+		console.error(
+			'[Page] templates.relatednessEdges failed (transient):',
+			err instanceof Error ? err.message : String(err)
+		);
+		return [];
+	});
+
+	return { templates, relationEdges };
 };

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -35,5 +35,23 @@ export const load: PageServerLoad = async ({ depends }) => {
 		return [];
 	});
 
-	return { templates, relationEdges };
+	// The shared-concept relations over the same public set: tags that cluster
+	// tightly in mean-centered space fold into one concept, and templates sharing
+	// a tight concept get a subordinate `kind:'concept'` edge. The server-only tag
+	// vectors are consumed there and never cross — only `{a,b,concept,kind}` tuples
+	// and a tag→concept label map do. Guarded the same way as the edges above so a
+	// transient Convex timeout degrades to no concept edges (the graph still paints
+	// twin + family), never a hard 500. At a corpus too thin to form any tight
+	// cross-template concept — the honest state at the seed, before tag embeddings
+	// are backfilled — `edges` is simply empty, and the graph's concept legend item
+	// stays hidden. That empty result is expected, not a failure.
+	const conceptRelations = await serverQuery(api.templates.conceptRelations, {}).catch((err) => {
+		console.error(
+			'[Page] templates.conceptRelations failed (transient):',
+			err instanceof Error ? err.message : String(err)
+		);
+		return { edges: [], conceptMap: {} };
+	});
+
+	return { templates, relationEdges, conceptRelations };
 };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -37,6 +37,7 @@
 	import TemplateCreator from '$lib/components/template/TemplateCreator.svelte';
 	import SpectrumLandscape from '$lib/components/template-browser/spectrum/SpectrumLandscape.svelte';
 	import RelationGraph from '$lib/components/template-browser/relation/RelationGraph.svelte';
+	import DescentDive from '$lib/components/template-browser/DescentDive.svelte';
 	import AuthoringUpgradeCard from '$lib/components/billing/AuthoringUpgradeCard.svelte';
 	import { AppError, ERROR_CODES } from '$lib/types/errors';
 	import { CreationSpark, CoordinationExplainer } from '$lib/components/activation';
@@ -383,6 +384,16 @@
 	const surface = $derived(selectLandingSurface($page.url));
 	const showGraph = $derived(surface === 'graph');
 	const showSpectrum = $derived(surface === 'spectrum');
+
+	// The desktop descent shared by both spatial surfaces. A dive engages only after
+	// a user-initiated selection (the store auto-selects the first template on
+	// hydration, so the dive must NOT auto-open on it) and only on desktop — mobile
+	// keeps the TouchModal preview. The spectrum renders its own DescentDive
+	// internally (the page hands it the snippet via the `dive` prop); the graph has
+	// no internal dive, so the page raises the SAME shared descent over it here. One
+	// gesture, one modal vocabulary, across both surfaces.
+	const diveOpen = $derived(!!selectedTemplate && userInitiatedSelection && isDesktopView);
+	const graphDiving = $derived(showGraph && diveOpen);
 
 	// The relation edges the graph draws beyond the family kinship it derives
 	// itself: the measured-twin tuples and the shared-concept tuples, both resolved
@@ -821,13 +832,18 @@
 						     measured semantic twins (solid) and civic-family kinship (dashed),
 						     with the topically-isolated falling honestly to the periphery.
 						     Reachable at `?view=graph` while it is built out; the spectrum
-						     stays the default surface. -->
-						<RelationGraph
-							templates={allTemplates}
-							edges={relationEdges}
-							selectedId={templateStore.selectedId}
-							onSelect={handleTemplateSelect}
-						/>
+						     stays the default surface. Selecting a node falls into the template
+						     through the SAME descent the spectrum uses — the field goes inert
+						     beneath the risen Artifact (the shared DescentDive below), never a
+						     second modal. -->
+						<div class="graph-field" class:graph-field--inert={graphDiving}>
+							<RelationGraph
+								templates={allTemplates}
+								edges={relationEdges}
+								selectedId={templateStore.selectedId}
+								onSelect={handleTemplateSelect}
+							/>
+						</div>
 					{:else if showSpectrum}
 						<!-- Topical field: templates grouped into hue-ordered domain bands,
 						     with a lens toggle to re-organise the same templates by place
@@ -840,9 +856,7 @@
 							placeGroups={filteredGroups}
 							selectedId={templateStore.selectedId}
 							onSelect={handleTemplateSelect}
-							dive={selectedTemplate && userInitiatedSelection && isDesktopView
-								? templateDive
-								: undefined}
+							dive={diveOpen ? templateDive : undefined}
 							onClose={closeDive}
 						/>
 					{:else}
@@ -900,10 +914,11 @@
 	</div>
 </section>
 
-<!-- The template preview, defined once and rendered in two places: in its own
-     column in the list fallback, and as the spectrum dive (risen in an Artifact
-     over the receded field). The SAME component with the SAME wiring in both —
-     send flow, personalization persistence, and proof footer are not forked. -->
+<!-- The template preview, defined once and rendered in three places: in its own
+     column in the list fallback, and as the descent dive over either spatial surface
+     (the spectrum or the relation map), risen in an Artifact over the receded page.
+     The SAME component with the SAME wiring everywhere — send flow, personalization
+     persistence, and proof footer are not forked. -->
 {#snippet templateDive()}
 	{#if selectedTemplate}
 		<TemplatePreview
@@ -914,6 +929,22 @@
 		/>
 	{/if}
 {/snippet}
+
+<!-- The relation map's descent: selecting a node falls into the template through the
+     SAME shared dive the spectrum uses (the spectrum mounts its own DescentDive
+     internally; the graph has none, so the page raises it here). Back / esc / a tap
+     on the scrim climbs out and clears the selection, restoring the map with focus
+     back on the node it rose from — no relayout, no second modal vocabulary. -->
+{#if graphDiving}
+	<DescentDive
+		dive={templateDive}
+		open={graphDiving}
+		onClose={closeDive}
+		restoreFocusSelector={templateStore.selectedId
+			? `[data-template-id="${templateStore.selectedId}"]`
+			: null}
+	/>
+{/if}
 
 <!-- Mobile Preview Modal -->
 {#if showMobilePreview && selectedTemplate}
@@ -1348,6 +1379,19 @@
 		min-width: 0;
 		position: relative;
 		z-index: 1;
+	}
+
+	/*
+	 * While the relation map's dive is open the map goes inert — it must not catch
+	 * clicks or focus, because the whole page is being read through the descent's
+	 * scrim. The recede itself is NOT applied here: the page (this map, the hero
+	 * beside it, the header above it) is blurred and dimmed as one by the shared
+	 * DescentDive's full-viewport scrim. No per-column filter, so there is no
+	 * half-sharp seam — the same inert posture the spectrum field takes under its
+	 * own dive.
+	 */
+	.graph-field--inert {
+		pointer-events: none;
 	}
 
 	.template-preview-column {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -278,10 +278,10 @@
 
 		if (isMobile()) {
 			showMobilePreview = true;
-		} else if (!showSpectrum) {
+		} else if (!showSpectrum && !showGraph) {
 			// List fallback: the preview lives in its own column — scroll it into view.
-			// In the spectrum the dive owns its own entrance (the field recedes and the
-			// preview rises as an Artifact), so no scroll-into-view is needed.
+			// The spectrum and the graph each own their dive entrance (the field recedes
+			// and the preview rises as an Artifact), so no scroll-into-view is needed.
 			tick().then(() => {
 				document
 					.querySelector('.template-preview-column')

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -22,7 +22,12 @@
 	import { page } from '$app/stores';
 	import { goto, preloadData, onNavigate } from '$app/navigation';
 	import { onMount, tick } from 'svelte';
-	import type { Template, TemplateCreationContext, TemplateGroup } from '$lib/types/template';
+	import type {
+		Template,
+		TemplateCreationContext,
+		TemplateGroup,
+		RelationEdge
+	} from '$lib/types/template';
 	import type { PageData } from './$types';
 	import { coordinated } from '$lib/utils/timerCoordinator';
 	import { analyzeEmailFlow } from '$lib/services/emailService';
@@ -379,9 +384,18 @@
 	const showGraph = $derived(surface === 'graph');
 	const showSpectrum = $derived(surface === 'spectrum');
 
-	// The measured-twin edge tuples from the server (embeddings never cross the
-	// wire). Family kinship is derived inside the graph from the templates' domains.
-	const relationEdges = $derived(data.relationEdges ?? []);
+	// The relation edges the graph draws beyond the family kinship it derives
+	// itself: the measured-twin tuples and the shared-concept tuples, both resolved
+	// server-side (embeddings and tag vectors never cross the wire — only the
+	// {a,b,kind[,score]} tuples do). Concept edges are usually empty at this corpus
+	// (tag embeddings unbackfilled), so this normally reduces to the twin set; the
+	// graph's concept legend item stays hidden while there are none. Both sources
+	// are independently guarded in the loader, so a transient failure of either
+	// degrades to its empty default rather than dropping the whole edge set.
+	const relationEdges = $derived<RelationEdge[]>([
+		...(data.relationEdges ?? []),
+		...(data.conceptRelations?.edges ?? [])
+	]);
 
 	// Sort templates within a group by display score (send_count, recency)
 	// so the homepage order matches what TemplateList renders

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -50,7 +50,7 @@
 	import { getUserLocation } from '$lib/core/location/inference-engine';
 	import type { TemplateWithJurisdictions } from '$lib/core/location/types';
 	import { scoreTemplate, sortTemplatesByScore } from '$lib/utils/template-scoring';
-	import { shouldShowSpectrum } from '$lib/core/topic/landing-surface';
+	import { selectLandingSurface } from '$lib/core/topic/landing-surface';
 	import { persistAddressCompletion } from '$lib/core/identity/address-completion-persistence';
 	import { persistGroundVaultForAddress } from '$lib/core/identity/ground-vault-persistence';
 	import type { ClientCellProofResult } from '$lib/core/shadow-atlas/browser-client';
@@ -368,18 +368,16 @@
 		)
 	);
 
-	// Topical-field swap. The hue-ordered landscape is the default surface; the
-	// flat geographic list stays a working fallback, reachable with `?spectrum=0`
-	// so it can be re-enabled without code changes. The rule lives in a pure util so
-	// the page and its tests share one source of truth. Reading the param off the
-	// page store keeps it reactive and SSR-safe (no window access).
-	const showSpectrum = $derived(shouldShowSpectrum($page.url));
-
-	// The relatedness graph mounts behind `?view=graph` — a preliminary surface
-	// swap so the map is reachable while it is built out; the spectrum stays the
-	// default and the list (`?spectrum=0`) stays a working fallback. The full
-	// gating + fallback wiring lands with the surface that promotes the graph.
-	const showGraph = $derived($page.url.searchParams.get('view') === 'graph');
+	// Discovery-surface swap. Three worlds over the same templates: the relatedness
+	// GRAPH (reachable at `?view=graph`), the hue-ordered topical SPECTRUM (the
+	// current default), and the flat geographic LIST (a working fallback reachable
+	// with `?spectrum=0`). The selection rule lives in one pure util so the page and
+	// its tests share a single source of truth and the worlds cannot drift apart.
+	// Reading the param off the page store keeps it reactive and SSR-safe (no
+	// window access).
+	const surface = $derived(selectLandingSurface($page.url));
+	const showGraph = $derived(surface === 'graph');
+	const showSpectrum = $derived(surface === 'spectrum');
 
 	// The measured-twin edge tuples from the server (embeddings never cross the
 	// wire). Family kinship is derived inside the graph from the templates' domains.

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -31,6 +31,7 @@
 
 	import TemplateCreator from '$lib/components/template/TemplateCreator.svelte';
 	import SpectrumLandscape from '$lib/components/template-browser/spectrum/SpectrumLandscape.svelte';
+	import RelationGraph from '$lib/components/template-browser/relation/RelationGraph.svelte';
 	import AuthoringUpgradeCard from '$lib/components/billing/AuthoringUpgradeCard.svelte';
 	import { AppError, ERROR_CODES } from '$lib/types/errors';
 	import { CreationSpark, CoordinationExplainer } from '$lib/components/activation';
@@ -373,6 +374,16 @@
 	// the page and its tests share one source of truth. Reading the param off the
 	// page store keeps it reactive and SSR-safe (no window access).
 	const showSpectrum = $derived(shouldShowSpectrum($page.url));
+
+	// The relatedness graph mounts behind `?view=graph` — a preliminary surface
+	// swap so the map is reachable while it is built out; the spectrum stays the
+	// default and the list (`?spectrum=0`) stays a working fallback. The full
+	// gating + fallback wiring lands with the surface that promotes the graph.
+	const showGraph = $derived($page.url.searchParams.get('view') === 'graph');
+
+	// The measured-twin edge tuples from the server (embeddings never cross the
+	// wire). Family kinship is derived inside the graph from the templates' domains.
+	const relationEdges = $derived(data.relationEdges ?? []);
 
 	// Sort templates within a group by display score (send_count, recency)
 	// so the homepage order matches what TemplateList renders
@@ -788,12 +799,24 @@
 			     hidden preview track left as dead space beside it. -->
 			<div
 				class="template-browser"
-				class:template-browser--spectrum={showSpectrum}
+				class:template-browser--spectrum={showSpectrum || showGraph}
 				id="template-browser"
 			>
 				<!-- Template List -->
 				<div class="template-list-column">
-					{#if showSpectrum}
+					{#if showGraph}
+						<!-- Relatedness graph: each template a hue-coloured node, linked by
+						     measured semantic twins (solid) and civic-family kinship (dashed),
+						     with the topically-isolated falling honestly to the periphery.
+						     Reachable at `?view=graph` while it is built out; the spectrum
+						     stays the default surface. -->
+						<RelationGraph
+							templates={allTemplates}
+							edges={relationEdges}
+							selectedId={templateStore.selectedId}
+							onSelect={handleTemplateSelect}
+						/>
+					{:else if showSpectrum}
 						<!-- Topical field: templates grouped into hue-ordered domain bands,
 						     with a lens toggle to re-organise the same templates by place
 						     (the existing geographic precision grouping). Selecting a tile
@@ -821,11 +844,11 @@
 				</div>
 
 				<!-- Template Preview. In the list (fallback) it lives in its own column
-				     beside the list. In the spectrum, the preview is the dive: it rises as
-				     an Artifact over the receded field (rendered by SpectrumLandscape via
-				     the snippet below), so the side column is not shown. The preview itself
-				     is identical in both — the snippet wraps the SAME component. -->
-				{#if !showSpectrum}
+				     beside the list. In the spectrum and the relation graph, the preview is
+				     the dive: it rises as an Artifact over the receded field, so the side
+				     column is not shown. The preview itself is identical in both — the
+				     snippet wraps the SAME component. -->
+				{#if !showSpectrum && !showGraph}
 					<div class="template-preview-column">
 						{#if hasError}
 							<div class="border-y border-slate-200 px-6 py-8 text-center">

--- a/tests/unit/components/DescentDive.test.ts
+++ b/tests/unit/components/DescentDive.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent, render, waitFor } from '@testing-library/svelte';
+import { createRawSnippet } from 'svelte';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// svelte/motion (pulled in transitively by the design primitives) reads
+// prefers-reduced-motion via window.matchMedia at module evaluation. Shim it
+// before the component loads so the import does not throw under jsdom.
+if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
+	Object.defineProperty(window, 'matchMedia', {
+		value: (query: string) => ({
+			matches: false,
+			media: query,
+			onchange: null,
+			addEventListener: () => {},
+			removeEventListener: () => {},
+			addListener: () => {},
+			removeListener: () => {},
+			dispatchEvent: () => false
+		}),
+		writable: true,
+		configurable: true
+	});
+}
+
+const DescentDive = (
+	await import('$lib/components/template-browser/DescentDive.svelte')
+).default;
+
+const COMPONENT_PATH = 'src/lib/components/template-browser/DescentDive.svelte';
+
+/** A `dive` snippet standing in for the page's preview: a labelled button so the
+ *  focus-into-dive and focus-trap behaviour have a real focusable to land on. */
+function diveSnippet(label = 'Send this message') {
+	return createRawSnippet(() => ({
+		render: () => `<button type="button" data-testid="dive-cta">${label}</button>`
+	}));
+}
+
+/** The risen dialog (the Artifact-wrapped preview floating over the field). The
+ *  descent layer portals to document.body (so the full-viewport scrim escapes any
+ *  ancestor stacking/overflow context), so look there, not in the container. */
+function diveDialog(container: HTMLElement): HTMLElement | null {
+	return container.ownerDocument.body.querySelector('[role="dialog"]');
+}
+
+/** The full-viewport backdrop scrim — the single plane that recedes the WHOLE page
+ *  behind the dive, and the way back. */
+function scrim(container: HTMLElement): HTMLButtonElement | null {
+	return container.ownerDocument.body.querySelector('.dive-scrim');
+}
+
+describe('DescentDive — the one shared Artifact-over-scrim descent', () => {
+	it('renders nothing while closed — the page is at rest', () => {
+		const { container } = render(DescentDive, {
+			props: { dive: diveSnippet(), open: false, onClose: vi.fn() }
+		});
+		expect(diveDialog(container)).toBeNull();
+		expect(scrim(container)).toBeNull();
+	});
+
+	it('opens: the preview rises in a modal dialog over a single full-viewport scrim', () => {
+		const { container, getByTestId } = render(DescentDive, {
+			props: { dive: diveSnippet(), open: true, onClose: vi.fn() }
+		});
+		const dialog = diveDialog(container);
+		expect(dialog).toBeTruthy();
+		expect(dialog?.getAttribute('aria-modal')).toBe('true');
+		// The supplied preview is mounted inside the risen surface, not forked.
+		expect(getByTestId('dive-cta')).toBeTruthy();
+		// Exactly one scrim plane (which blurs the whole page as one), not a per-
+		// column filter.
+		expect(container.ownerDocument.body.querySelectorAll('.dive-scrim').length).toBe(1);
+	});
+
+	it('floats the preview in an Artifact (the only bounded white surface), no foreign chrome', () => {
+		const { container } = render(DescentDive, {
+			props: { dive: diveSnippet(), open: true, onClose: vi.fn() }
+		});
+		// The risen surface wraps its content in an Artifact, not a hand-rolled box.
+		expect(diveDialog(container)?.querySelector('.artifact')).toBeTruthy();
+		// No oversized radius or pill chrome on the descent layer.
+		const layer = container.ownerDocument.body.querySelector('.dive-layer') as HTMLElement;
+		expect(layer.className).not.toMatch(/rounded-(xl|2xl|3xl|full)\b/);
+	});
+
+	it('moves focus into the risen preview on open', async () => {
+		const { container, getByTestId } = render(DescentDive, {
+			props: { dive: diveSnippet(), open: true, onClose: vi.fn() }
+		});
+		await waitFor(() => expect(document.activeElement).toBe(getByTestId('dive-cta')));
+		expect(diveDialog(container)?.contains(document.activeElement)).toBe(true);
+	});
+
+	it('climbs out on escape — reporting the close up so the surface can restore', async () => {
+		const onClose = vi.fn();
+		const { container } = render(DescentDive, {
+			props: { dive: diveSnippet(), open: true, onClose }
+		});
+		await fireEvent.keyDown(diveDialog(container)!.parentElement!, { key: 'Escape' });
+		expect(onClose).toHaveBeenCalledTimes(1);
+	});
+
+	it('climbs out when the scrim is tapped (back to the field)', async () => {
+		const onClose = vi.fn();
+		const { container } = render(DescentDive, {
+			props: { dive: diveSnippet(), open: true, onClose }
+		});
+		const back = scrim(container)!;
+		expect(back.getAttribute('aria-label')).toBe('Back to the field');
+		await fireEvent.click(back);
+		expect(onClose).toHaveBeenCalledTimes(1);
+	});
+
+	it('round-trips: closing the descent tears down the dialog and scrim, page restored', async () => {
+		// Reversible with no hidden state — re-render with `open` false (what the page
+		// does on close) and the dialog and scrim are gone, exactly as before the dive.
+		const { container, rerender } = render(DescentDive, {
+			props: { dive: diveSnippet(), open: true, onClose: vi.fn() }
+		});
+		expect(diveDialog(container)).toBeTruthy();
+		expect(scrim(container)).toBeTruthy();
+
+		await rerender({ dive: diveSnippet(), open: false, onClose: vi.fn() });
+
+		expect(diveDialog(container)).toBeNull();
+		expect(scrim(container)).toBeNull();
+	});
+
+	it('returns focus to the originating element on close (the field comes back where it left)', async () => {
+		// A node/tile in the document the dive rose from. On close the descent must
+		// return focus to it via the supplied selector, so the surface lands back on
+		// the exact element — not stranded on <body>.
+		const origin = document.createElement('button');
+		origin.setAttribute('data-template-id', 'origin-node');
+		origin.textContent = 'origin';
+		document.body.appendChild(origin);
+		origin.focus();
+
+		try {
+			const { rerender, getByTestId } = render(DescentDive, {
+				props: {
+					dive: diveSnippet(),
+					open: true,
+					onClose: vi.fn(),
+					restoreFocusSelector: '[data-template-id="origin-node"]'
+				}
+			});
+			// Focus moved into the risen preview on open.
+			await waitFor(() => expect(document.activeElement).toBe(getByTestId('dive-cta')));
+
+			// Close → focus climbs back out to the originating element.
+			await rerender({
+				dive: diveSnippet(),
+				open: false,
+				onClose: vi.fn(),
+				restoreFocusSelector: '[data-template-id="origin-node"]'
+			});
+			await waitFor(() => expect(document.activeElement).toBe(origin));
+		} finally {
+			origin.remove();
+		}
+	});
+
+	it('uses motion.ts timing for the ascent (no off-token literal)', () => {
+		const src = readFileSync(resolve(process.cwd(), COMPONENT_PATH), 'utf8');
+		// The ascent rides motion.ts TIMING/EASING (imported, not inlined ms/cubic).
+		expect(src).toMatch(/from\s+['"]\$lib\/design\/motion['"]/);
+		expect(src).toMatch(/TIMING\.SLOW/);
+		// No hand-rolled millisecond literal on the ascent animation.
+		expect(src).not.toMatch(/animation:\s*dive-ascend\s+\d+ms/);
+	});
+
+	it('honors reduced motion: the scrim blur is dropped, the warm dim stays', () => {
+		// The blur is the expensive, vestibular channel. Under prefers-reduced-motion
+		// the scrim drops its backdrop-filter while the (cheap, non-vestibular) warm
+		// dim remains. The scoped CSS is not injected into jsdom, so assert the
+		// structural contract against the source.
+		const src = readFileSync(resolve(process.cwd(), COMPONENT_PATH), 'utf8');
+		const scrimRule = src.match(/\.dive-scrim\s*\{[^}]*\}/s)?.[0] ?? '';
+		expect(scrimRule).toMatch(/backdrop-filter:\s*blur/);
+		const reducedBlock =
+			src.match(/@media\s*\(prefers-reduced-motion:\s*reduce\)\s*\{.*\}/s)?.[0] ?? '';
+		const reducedScrim = reducedBlock.match(/\.dive-scrim\s*\{[^}]*\}/s)?.[0] ?? '';
+		expect(reducedScrim).toMatch(/backdrop-filter:\s*none/);
+		// The rise is also stilled under reduced motion (no travel).
+		const reducedSurface = reducedBlock.match(/\.dive-surface\s*\{[^}]*\}/s)?.[0] ?? '';
+		expect(reducedSurface).toMatch(/animation:\s*none/);
+	});
+
+	it('is the single descent vocabulary — no second Artifact-over-scrim implementation', () => {
+		// The whole landing speaks ONE modal vocabulary for the dive. The spectrum and
+		// the relation map both mount this component rather than forking their own
+		// scrim. Assert the dive surface (.dive-surface) is declared in exactly one
+		// component source across the template-browser surfaces.
+		const surfaces = [
+			'src/lib/components/template-browser/DescentDive.svelte',
+			'src/lib/components/template-browser/spectrum/SpectrumLandscape.svelte',
+			'src/lib/components/template-browser/relation/RelationGraph.svelte'
+		];
+		const declarers = surfaces.filter((p) => {
+			const src = readFileSync(resolve(process.cwd(), p), 'utf8');
+			// A real CSS declaration of the scrim plane (the rule body), not a prose
+			// mention. The shared component is the only place it lives.
+			return /\.dive-scrim\s*\{/.test(src);
+		});
+		expect(declarers).toEqual(['src/lib/components/template-browser/DescentDive.svelte']);
+	});
+});

--- a/tests/unit/components/RelationGraph.test.ts
+++ b/tests/unit/components/RelationGraph.test.ts
@@ -1,0 +1,281 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent, render } from '@testing-library/svelte';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { Template, RelationEdge } from '$lib/types/template';
+import { resolveDomainHue } from '$lib/utils/domain-hue';
+import { familyEdges } from '$lib/core/topic/relation-edges';
+
+// svelte/motion (pulled in transitively by the design primitives) reads
+// prefers-reduced-motion via window.matchMedia at module evaluation. Shim it
+// before the component loads so the import does not throw under jsdom.
+if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
+	Object.defineProperty(window, 'matchMedia', {
+		value: (query: string) => ({
+			matches: false,
+			media: query,
+			onchange: null,
+			addEventListener: () => {},
+			removeEventListener: () => {},
+			addListener: () => {},
+			removeListener: () => {},
+			dispatchEvent: () => false
+		}),
+		writable: true,
+		configurable: true
+	});
+}
+
+const RelationGraph = (
+	await import('$lib/components/template-browser/relation/RelationGraph.svelte')
+).default;
+
+const COMPONENT_PATH =
+	'src/lib/components/template-browser/relation/RelationGraph.svelte';
+
+/** A minimal valid template; overrides pin only what an assertion is about. */
+function makeTemplate(overrides: Partial<Template> = {}): Template {
+	return {
+		id: 't1',
+		slug: 'restore-clinic-hours',
+		title: 'Restore the clinic hours',
+		description: 'Ask the county to fund evening hours at the public clinic.',
+		domain: 'Healthcare',
+		type: 'advocacy',
+		deliveryMethod: 'direct',
+		message_body: 'Body',
+		delivery_config: {},
+		recipient_config: {},
+		coordinationScale: 0,
+		isNew: false,
+		status: 'published',
+		is_public: true,
+		send_count: 0,
+		createdAt: '2026-06-01T00:00:00.000Z',
+		updatedAt: '2026-06-01T00:00:00.000Z',
+		...overrides
+	} as Template;
+}
+
+/** Every node group rendered in the SVG. */
+function nodes(container: HTMLElement): Element[] {
+	return Array.from(container.querySelectorAll('.relation-node'));
+}
+
+/** Every edge path drawn in the SVG field (excludes the legend swatches, which
+ *  are <line> samples, not field <path> edges). */
+function fieldEdges(container: HTMLElement): Element[] {
+	return Array.from(
+		container.querySelectorAll('.relation-graph__edges .relation-edge')
+	);
+}
+
+/** Isolated nodes — the honestly-alone templates. */
+function isolatedNodes(container: HTMLElement): Element[] {
+	return Array.from(container.querySelectorAll('.relation-node--isolated'));
+}
+
+describe('RelationGraph — the relatedness map', () => {
+	it('draws one node per template (node count == template count)', () => {
+		const templates = [
+			makeTemplate({ id: 'a', domain: 'Healthcare', title: 'Clinic hours' }),
+			makeTemplate({ id: 'b', domain: 'Housing', title: 'Zoning reform' }),
+			makeTemplate({ id: 'c', domain: 'Transportation', title: 'Bike lanes' })
+		];
+		const { container } = render(RelationGraph, {
+			props: { templates, onSelect: vi.fn() }
+		});
+		expect(nodes(container).length).toBe(templates.length);
+	});
+
+	it('colors each node via resolveDomainHue (the shared hue authority, not a generic dot)', () => {
+		const templates = [
+			makeTemplate({ id: 'a', domain: 'Healthcare' }),
+			makeTemplate({ id: 'b', domain: 'Transportation' })
+		];
+		const { container } = render(RelationGraph, {
+			props: { templates, onSelect: vi.fn() }
+		});
+		for (const t of templates) {
+			const glyph = container.querySelector(
+				`[data-template-id="${t.id}"] .relation-node__glyph`
+			) as SVGCircleElement;
+			expect(glyph).toBeTruthy();
+			const expectedHue = resolveDomainHue(t);
+			// The fill cites the resolver's hue — colour is the topic, not a constant.
+			expect(glyph.getAttribute('fill')).toContain(String(expectedHue));
+		}
+	});
+
+	it('renders exactly the admissible edges — no decorative or placeholder ties', () => {
+		// Two templates in the same family (a family edge), one in a family of its
+		// own (no kin, no measured twin → isolated). The only edge that may exist is
+		// the one same-family pair; the lone template gets none.
+		const templates = [
+			makeTemplate({ id: 'a', domain: 'Transportation', title: 'Bike lanes' }),
+			makeTemplate({ id: 'b', domain: 'Transportation', title: 'Freeway removal' }),
+			makeTemplate({ id: 'c', domain: 'Healthcare', title: 'Clinic hours' })
+		];
+		const { container } = render(RelationGraph, {
+			props: { templates, onSelect: vi.fn() }
+		});
+		// The admissible set is computed from the same pure source the component uses.
+		const admissible = familyEdges(templates);
+		expect(fieldEdges(container).length).toBe(admissible.length);
+		// And it is exactly one tie (the two transportation templates), no more.
+		expect(fieldEdges(container).length).toBe(1);
+	});
+
+	it('renders a measured twin edge passed in, scaling its weight by score', () => {
+		const templates = [
+			makeTemplate({ id: 'a', domain: 'Justice', title: 'Drug treatment' }),
+			makeTemplate({ id: 'b', domain: 'Housing', title: 'Zoning reform' })
+		];
+		// A cross-domain pair: no family edge, only the measured twin we pass in.
+		const edges: RelationEdge[] = [{ a: 'a', b: 'b', kind: 'twin', score: 0.9 }];
+		const { container } = render(RelationGraph, {
+			props: { templates, edges, onSelect: vi.fn() }
+		});
+		const drawn = fieldEdges(container);
+		expect(drawn.length).toBe(1);
+		const twin = drawn[0] as SVGPathElement;
+		expect(twin.getAttribute('data-edge-kind')).toBe('twin');
+		// The twin's stroke-width is set inline from the score (not the CSS default).
+		const width = parseFloat(twin.style.strokeWidth);
+		expect(width).toBeGreaterThan(2.2); // a high score sits above the base weight
+	});
+
+	it('distinguishes twin (solid) from family (dashed): different kinds, different encodings', () => {
+		const templates = [
+			// A same-family pair (Transportation) → a family edge.
+			makeTemplate({ id: 'a', domain: 'Transportation', title: 'Bike lanes' }),
+			makeTemplate({ id: 'b', domain: 'Transportation', title: 'Freeway removal' }),
+			// A cross-domain pair we relate by a measured twin → a twin edge.
+			makeTemplate({ id: 'c', domain: 'Justice', title: 'Drug treatment' }),
+			makeTemplate({ id: 'd', domain: 'Education', title: 'Preschool' })
+		];
+		const edges: RelationEdge[] = [{ a: 'c', b: 'd', kind: 'twin', score: 0.7 }];
+		const { container } = render(RelationGraph, {
+			props: { templates, edges, onSelect: vi.fn() }
+		});
+		const drawn = fieldEdges(container);
+		const kinds = drawn.map((e) => e.getAttribute('data-edge-kind'));
+		expect(kinds).toContain('twin');
+		expect(kinds).toContain('family');
+		// The two kinds carry distinct classes (the renderer's distinct encodings).
+		expect(container.querySelector('.relation-edge--twin')).toBeTruthy();
+		expect(container.querySelector('.relation-edge--family')).toBeTruthy();
+	});
+
+	it('renders no-kin templates as visibly isolated, with no edge of their own', () => {
+		const templates = [
+			makeTemplate({ id: 'a', domain: 'Transportation', title: 'Bike lanes' }),
+			makeTemplate({ id: 'b', domain: 'Transportation', title: 'Freeway removal' }),
+			// Lone families: no twin, no same-family kin → honestly isolated.
+			makeTemplate({ id: 'c', domain: 'Healthcare', title: 'Veterans health' }),
+			makeTemplate({ id: 'd', domain: 'Labor', title: 'Retail wages' })
+		];
+		const { container } = render(RelationGraph, {
+			props: { templates, onSelect: vi.fn() }
+		});
+		const isolated = isolatedNodes(container);
+		const isolatedIds = isolated.map((n) => n.getAttribute('data-template-id'));
+		expect(isolatedIds).toContain('c');
+		expect(isolatedIds).toContain('d');
+		// The connected transportation pair is NOT isolated.
+		expect(isolatedIds).not.toContain('a');
+		expect(isolatedIds).not.toContain('b');
+		// Each isolated node is marked structurally so the surface can hold it alone.
+		for (const n of isolated) {
+			expect(n.getAttribute('data-isolated')).toBe('true');
+		}
+	});
+
+	it('names the relation kinds in a plain-English legend', () => {
+		const templates = [
+			makeTemplate({ id: 'a', domain: 'Transportation' }),
+			makeTemplate({ id: 'b', domain: 'Transportation' })
+		];
+		const { container, getByText } = render(RelationGraph, {
+			props: { templates, onSelect: vi.fn() }
+		});
+		const legend = container.querySelector('.relation-graph__legend');
+		expect(legend).toBeTruthy();
+		// Plain English, naming both honest edge kinds.
+		expect(getByText(/measured semantic twin/i)).toBeTruthy();
+		expect(getByText(/shared civic family/i)).toBeTruthy();
+	});
+
+	it('shows the title copy in the approved-mock voice', () => {
+		const { getByText } = render(RelationGraph, {
+			props: { templates: [makeTemplate({ id: 'a' })], onSelect: vi.fn() }
+		});
+		expect(getByText(/The commons, by relation/i)).toBeTruthy();
+	});
+
+	it('reports a node activation up (click and keyboard)', async () => {
+		const onSelect = vi.fn();
+		const templates = [makeTemplate({ id: 'a', domain: 'Healthcare' })];
+		const { container } = render(RelationGraph, {
+			props: { templates, onSelect }
+		});
+		const node = container.querySelector('[data-template-id="a"]') as HTMLElement;
+		await fireEvent.click(node);
+		expect(onSelect).toHaveBeenCalledWith('a');
+		await fireEvent.keyDown(node, { key: 'Enter' });
+		expect(onSelect).toHaveBeenCalledTimes(2);
+	});
+
+	it('reports hover up so a caller can light the neighbourhood / preload', async () => {
+		const onHover = vi.fn();
+		const templates = [makeTemplate({ id: 'a', domain: 'Healthcare' })];
+		const { container } = render(RelationGraph, {
+			props: { templates, onSelect: vi.fn(), onHover }
+		});
+		const node = container.querySelector('[data-template-id="a"]') as HTMLElement;
+		await fireEvent.mouseEnter(node);
+		expect(onHover).toHaveBeenCalledWith('a', true);
+		await fireEvent.mouseLeave(node);
+		expect(onHover).toHaveBeenCalledWith('a', false);
+	});
+
+	it('does not draw a family edge across domains (cross-domain pairs have no kin)', () => {
+		const templates = [
+			makeTemplate({ id: 'a', domain: 'Healthcare' }),
+			makeTemplate({ id: 'b', domain: 'Housing' })
+		];
+		const { container } = render(RelationGraph, {
+			props: { templates, onSelect: vi.fn() }
+		});
+		// No measured twin passed, different domains → no admissible edge at all.
+		expect(fieldEdges(container).length).toBe(0);
+		// Both stand alone.
+		expect(isolatedNodes(container).length).toBe(2);
+	});
+
+	it('renders an honest empty state when there are no templates', () => {
+		const { container, getByText } = render(RelationGraph, {
+			props: { templates: [], onSelect: vi.fn() }
+		});
+		expect(nodes(container).length).toBe(0);
+		expect(fieldEdges(container).length).toBe(0);
+		expect(getByText('No templates yet.')).toBeTruthy();
+	});
+
+	it('carries no foreign graph-library import in the source', () => {
+		const src = readFileSync(resolve(process.cwd(), COMPONENT_PATH), 'utf8');
+		expect(src).not.toMatch(/\bfrom\s+['"]d3/);
+		expect(src).not.toMatch(/\bfrom\s+['"]cytoscape/);
+		expect(src).not.toMatch(/\bfrom\s+['"]sigma/);
+		expect(src).not.toMatch(/\bfrom\s+['"]vis-/);
+		expect(src).not.toMatch(/force-graph/);
+	});
+
+	it('carries no foreign chrome — no pill, no white-box container, no oversized radius', () => {
+		const src = readFileSync(resolve(process.cwd(), COMPONENT_PATH), 'utf8');
+		// No oversized radius (max rounded-lg in this system).
+		expect(src).not.toMatch(/rounded-(xl|2xl|3xl|full)\b/);
+		// No bg-white container utility (white is for Artifacts only; the ground is cream).
+		expect(src).not.toMatch(/class="[^"]*\bbg-white\b/);
+	});
+});

--- a/tests/unit/components/RelationGraph.test.ts
+++ b/tests/unit/components/RelationGraph.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { fireEvent, render } from '@testing-library/svelte';
+import { fireEvent, render, waitFor } from '@testing-library/svelte';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import type { Template, RelationEdge } from '$lib/types/template';
@@ -430,5 +430,179 @@ describe('RelationGraph — the relatedness map', () => {
 		expect(src).not.toMatch(/rounded-(xl|2xl|3xl|full)\b/);
 		// No bg-white container utility (white is for Artifacts only; the ground is cream).
 		expect(src).not.toMatch(/class="[^"]*\bbg-white\b/);
+	});
+
+	// ─── Search-to-centre: recognition navigation ────────────────────────────
+	//
+	// Typing a fragment the viewer remembers must bring the matching node TO THEM:
+	// the field pans so the match lands at centre (a translate, never a relayout —
+	// spatial memory survives), the match's neighbourhood lights, non-matches dim.
+	// Clearing the field restores it: pan back to origin, every node at presence.
+
+	/** The pan group's translate, parsed to {x,y}. (0,0) means the field rests as laid out. */
+	function panTranslate(container: HTMLElement): { x: number; y: number } {
+		const g = container.querySelector('.relation-graph__pan');
+		const t = g?.getAttribute('transform') ?? 'translate(0 0)';
+		const m = t.match(/translate\(\s*(-?[\d.]+)[ ,]+(-?[\d.]+)\s*\)/);
+		return m ? { x: parseFloat(m[1]), y: parseFloat(m[2]) } : { x: 0, y: 0 };
+	}
+
+	function searchInput(container: HTMLElement): HTMLInputElement {
+		return container.querySelector('[data-testid="relation-search-input"]') as HTMLInputElement;
+	}
+
+	it('offers a search field reusing the template search vocabulary, with plain-English copy', () => {
+		const templates = neighbourhoodFixture();
+		const { container } = render(RelationGraph, {
+			props: { templates, onSelect: vi.fn() }
+		});
+		const input = searchInput(container);
+		expect(input).toBeTruthy();
+		// The shared search affordance: a native search field, keyboard-reachable.
+		expect(input.getAttribute('type')).toBe('search');
+		expect(input.tabIndex).toBeGreaterThanOrEqual(0);
+		// Plain-English placeholder — recognition, not a filter verb.
+		expect(input.getAttribute('placeholder')).toMatch(/find a concern/i);
+		// No feedback line until the viewer types.
+		expect(container.querySelector('[data-testid="relation-search-feedback"]')).toBeNull();
+	});
+
+	it('typing a query centres the best match (pans the field) and lights its neighbourhood; non-matches dim', async () => {
+		const templates = neighbourhoodFixture(); // a,b transportation pair + c healthcare loner
+		const { container } = render(RelationGraph, {
+			props: { templates, onSelect: vi.fn() }
+		});
+		const svg = container.querySelector('.relation-graph__svg') as SVGElement;
+		// At rest: the field sits un-panned and at full presence.
+		expect(panTranslate(container)).toEqual({ x: 0, y: 0 });
+		expect(dimmedIds(container)).toEqual([]);
+
+		// Type a fragment of node `a`'s title.
+		const input = searchInput(container);
+		await fireEvent.input(input, { target: { value: 'Bike' } });
+
+		// FOCUS is synchronous: the match `a` + its same-family neighbour `b` light, the
+		// loner `c` dims — the search engages the identical neighbourhood read as hover.
+		expect(svg.classList.contains('has-focus')).toBe(true);
+		const lit = litIds(container);
+		expect(lit).toContain('a');
+		expect(lit).toContain('b');
+		expect(dimmedIds(container)).toEqual(['c']);
+
+		// CENTRING is the spring-driven pan: it settles to a non-origin translate (the
+		// field slid so `a` reaches the canvas centre). A relayout would scramble the
+		// map; a pan keeps every node's relative place — so we assert the GROUP moved.
+		await waitFor(() => {
+			const p = panTranslate(container);
+			expect(p.x !== 0 || p.y !== 0).toBe(true);
+		});
+
+		// The plain-English feedback names where the field centred.
+		const feedback = container.querySelector('[data-testid="relation-search-feedback"]');
+		expect(feedback?.textContent).toMatch(/centred on/i);
+	});
+
+	it('clearing the search restores the field — pan returns to origin and every node lights', async () => {
+		const templates = neighbourhoodFixture();
+		const { container } = render(RelationGraph, {
+			props: { templates, onSelect: vi.fn() }
+		});
+		const svg = container.querySelector('.relation-graph__svg') as SVGElement;
+		const input = searchInput(container);
+
+		// Search, then clear via the input itself.
+		await fireEvent.input(input, { target: { value: 'Bike' } });
+		expect(svg.classList.contains('has-focus')).toBe(true);
+		await fireEvent.input(input, { target: { value: '' } });
+
+		// Focus releases synchronously: full presence, nothing dimmed, no feedback line.
+		expect(svg.classList.contains('has-focus')).toBe(false);
+		expect(dimmedIds(container)).toEqual([]);
+		expect(litIds(container).length).toBe(nodes(container).length);
+		expect(container.querySelector('[data-testid="relation-search-feedback"]')).toBeNull();
+
+		// The pan spring carries the field back to origin.
+		await waitFor(() => {
+			expect(panTranslate(container)).toEqual({ x: 0, y: 0 });
+		});
+	});
+
+	it('Escape clears the search (keyboard-accessible restore)', async () => {
+		const templates = neighbourhoodFixture();
+		const { container } = render(RelationGraph, {
+			props: { templates, onSelect: vi.fn() }
+		});
+		const svg = container.querySelector('.relation-graph__svg') as SVGElement;
+		const input = searchInput(container);
+
+		await fireEvent.input(input, { target: { value: 'Bike' } });
+		expect(svg.classList.contains('has-focus')).toBe(true);
+
+		// Escape on the field restores the map without a pointer.
+		await fireEvent.keyDown(input, { key: 'Escape' });
+		expect(input.value).toBe('');
+		expect(svg.classList.contains('has-focus')).toBe(false);
+		expect(dimmedIds(container)).toEqual([]);
+	});
+
+	it('matches client-side over the loaded nodes — by title and by civic family — with no server call', async () => {
+		const fetchSpy = vi.spyOn(globalThis, 'fetch');
+		const templates = neighbourhoodFixture();
+		const { container } = render(RelationGraph, {
+			props: { templates, onSelect: vi.fn() }
+		});
+		const svg = container.querySelector('.relation-graph__svg') as SVGElement;
+		const input = searchInput(container);
+
+		// A civic-family fragment ('Transp…') matches the transportation nodes — the
+		// match reads the loaded node set's family captions, not a remote index.
+		await fireEvent.input(input, { target: { value: 'Transp' } });
+		expect(svg.classList.contains('has-focus')).toBe(true);
+		// The focused node is one of the transportation pair (the first in order, `a`).
+		expect(litIds(container)).toContain('a');
+
+		// No network round-trip for the seed-size set.
+		expect(fetchSpy).not.toHaveBeenCalled();
+		fetchSpy.mockRestore();
+	});
+
+	it('reports no match honestly when nothing in the field carries the name', async () => {
+		const templates = neighbourhoodFixture();
+		const { container } = render(RelationGraph, {
+			props: { templates, onSelect: vi.fn() }
+		});
+		const svg = container.querySelector('.relation-graph__svg') as SVGElement;
+		const input = searchInput(container);
+
+		await fireEvent.input(input, { target: { value: 'zzzz-nothing' } });
+		// No match → no centring, no dim (the field stays whole), honest feedback.
+		expect(svg.classList.contains('has-focus')).toBe(false);
+		expect(dimmedIds(container)).toEqual([]);
+		expect(panTranslate(container)).toEqual({ x: 0, y: 0 });
+		const feedback = container.querySelector('[data-testid="relation-search-feedback"]');
+		expect(feedback?.textContent).toMatch(/nothing here by that name/i);
+	});
+
+	it('search-focus and hover-focus do not fight: hover overrides, then falls back to the search match', async () => {
+		const templates = neighbourhoodFixture();
+		const { container } = render(RelationGraph, {
+			props: { templates, onSelect: vi.fn() }
+		});
+		const input = searchInput(container);
+
+		// Search centres `a` (lights a,b; dims c).
+		await fireEvent.input(input, { target: { value: 'Bike' } });
+		expect(dimmedIds(container)).toEqual(['c']);
+
+		// Hovering the loner `c` overrides: its neighbourhood is just itself, so a,b dim.
+		const c = container.querySelector('[data-template-id="c"]') as HTMLElement;
+		await fireEvent.mouseEnter(c);
+		expect(litIds(container)).toContain('c');
+		expect(dimmedIds(container).sort()).toEqual(['a', 'b']);
+
+		// On mouse-leave the field falls BACK to the search-focused neighbourhood, not to
+		// nothing — the two focus channels reconcile, they don't cancel.
+		await fireEvent.mouseLeave(c);
+		expect(dimmedIds(container)).toEqual(['c']);
 	});
 });

--- a/tests/unit/components/RelationGraph.test.ts
+++ b/tests/unit/components/RelationGraph.test.ts
@@ -605,4 +605,194 @@ describe('RelationGraph — the relatedness map', () => {
 		await fireEvent.mouseLeave(c);
 		expect(dimmedIds(container)).toEqual(['c']);
 	});
+
+	// ─── Mobile: the focus-centered relation view (below the breakpoint) ───────
+	//
+	// On a phone the pannable SVG dot-cloud is wrong — sub-tap glyphs, colliding
+	// labels. Below the breakpoint (or on a coarse pointer) the SAME relation data
+	// takes a focus-centered form: one concern at the centre, its kin pulled close as
+	// full-size tappable cards that NAME the tie binding them, the rest reachable as a
+	// list with the isolated held apart. The view must express RELATION (the edges),
+	// give 44px targets, and dive through the existing path — not regress to a flat list
+	// or a shrunk graph.
+
+	/** Make the component's media probe report the narrow/coarse-pointer query as a
+	 *  match, so it mounts the mobile focus-centered form. Returns a restore fn. */
+	function withNarrowViewport(): () => void {
+		const original = window.matchMedia;
+		Object.defineProperty(window, 'matchMedia', {
+			value: (query: string) => ({
+				// The component asks for `(max-width: 767px), (pointer: coarse)`; report a
+				// match for that, and no match for the reduced-motion probe.
+				matches: /max-width|pointer/.test(query),
+				media: query,
+				onchange: null,
+				addEventListener: () => {},
+				removeEventListener: () => {},
+				addListener: () => {},
+				removeListener: () => {},
+				dispatchEvent: () => false
+			}),
+			writable: true,
+			configurable: true
+		});
+		return () => {
+			Object.defineProperty(window, 'matchMedia', {
+				value: original,
+				writable: true,
+				configurable: true
+			});
+		};
+	}
+
+	it('renders the focus-centered relation view below the breakpoint, not the pannable SVG field', async () => {
+		const restore = withNarrowViewport();
+		try {
+			const templates = neighbourhoodFixture(); // a,b transportation pair + c loner
+			const { container } = render(RelationGraph, {
+				props: { templates, onSelect: vi.fn() }
+			});
+
+			// The mobile effect runs after mount; wait for the focus-centered view to appear.
+			await waitFor(() => {
+				expect(
+					container.querySelector('[data-testid="relation-focus-view"]')
+				).toBeTruthy();
+			});
+
+			// It is the focus-centered form, NOT the pannable SVG field (no field edges or
+			// panning group below the breakpoint — that is the desktop graph).
+			expect(container.querySelector('.relation-graph__svg')).toBeNull();
+			expect(container.querySelector('.relation-graph__pan')).toBeNull();
+			expect(fieldEdges(container).length).toBe(0);
+
+			// A single concern is at the centre, readable and tappable.
+			const centre = container.querySelector(
+				'[data-testid="relation-focus-centre"]'
+			) as HTMLElement;
+			expect(centre).toBeTruthy();
+			// It opens to a stable default: the first CONNECTED node in order (`a`), which
+			// has kin — so the view opens already showing a relation, not a lone node.
+			expect(centre.getAttribute('data-template-id')).toBe('a');
+		} finally {
+			restore();
+		}
+	});
+
+	it('brings the focus concern’s kin close, each NAMING the tie (relation, not a flat list)', async () => {
+		const restore = withNarrowViewport();
+		try {
+			// A measured-twin pair (c,d cross-domain) so a named tie kind shows.
+			const templates = [
+				makeTemplate({ id: 'a', domain: 'Transportation', title: 'Bike lanes' }),
+				makeTemplate({ id: 'b', domain: 'Transportation', title: 'Freeway removal' })
+			];
+			const { container } = render(RelationGraph, {
+				props: { templates, onSelect: vi.fn() }
+			});
+
+			await waitFor(() => {
+				expect(container.querySelector('[data-testid="relation-focus-view"]')).toBeTruthy();
+			});
+
+			// The focus opens on `a`; its same-family kin `b` is brought close as a kin card
+			// that names the tie — this is RELATION, not a flat list of all templates.
+			const kin = container.querySelector('[data-testid="relation-kin-b"]') as HTMLElement;
+			expect(kin).toBeTruthy();
+			expect(kin.getAttribute('data-kin-kind')).toBe('family');
+			// The tie is named in plain English (the edge kind, surfaced as words).
+			expect(kin.textContent).toMatch(/shared civic family/i);
+		} finally {
+			restore();
+		}
+	});
+
+	it('following a kin re-centres the view on it (navigates the graph, no flat-list jump-to)', async () => {
+		const restore = withNarrowViewport();
+		try {
+			const templates = neighbourhoodFixture();
+			const { container } = render(RelationGraph, {
+				props: { templates, onSelect: vi.fn() }
+			});
+			await waitFor(() => {
+				expect(container.querySelector('[data-testid="relation-focus-view"]')).toBeTruthy();
+			});
+
+			// Opens on `a`. The loner `c` is reachable in the "elsewhere" list.
+			const other = container.querySelector('[data-testid="relation-other-c"]') as HTMLElement;
+			expect(other).toBeTruthy();
+
+			// Centring on `c` makes IT the focus — the view follows the graph to its
+			// neighbourhood rather than diving straight in.
+			await fireEvent.click(other);
+			await waitFor(() => {
+				const centre = container.querySelector(
+					'[data-testid="relation-focus-centre"]'
+				) as HTMLElement;
+				expect(centre.getAttribute('data-template-id')).toBe('c');
+			});
+		} finally {
+			restore();
+		}
+	});
+
+	it('tapping the centred concern dives via the shared select path (touch dive)', async () => {
+		const restore = withNarrowViewport();
+		try {
+			const onSelect = vi.fn();
+			const templates = neighbourhoodFixture();
+			const { container } = render(RelationGraph, {
+				props: { templates, onSelect }
+			});
+			await waitFor(() => {
+				expect(container.querySelector('[data-testid="relation-focus-view"]')).toBeTruthy();
+			});
+			const centre = container.querySelector(
+				'[data-testid="relation-focus-centre"]'
+			) as HTMLElement;
+			// Tapping the centre reports the selection up — the same onSelect the page wires
+			// to its touch dive. (Kin/other cards re-centre; only the centre dives.)
+			await fireEvent.click(centre);
+			expect(onSelect).toHaveBeenCalledWith('a');
+		} finally {
+			restore();
+		}
+	});
+
+	it('holds the honestly-isolated apart in their own group (aloneness still reads on mobile)', async () => {
+		const restore = withNarrowViewport();
+		try {
+			const templates = [
+				makeTemplate({ id: 'a', domain: 'Transportation', title: 'Bike lanes' }),
+				makeTemplate({ id: 'b', domain: 'Transportation', title: 'Freeway removal' }),
+				// A lone family: no twin, no same-family kin → honestly isolated.
+				makeTemplate({ id: 'z', domain: 'Labor', title: 'Retail wages' })
+			];
+			const { container } = render(RelationGraph, {
+				props: { templates, onSelect: vi.fn() }
+			});
+			await waitFor(() => {
+				expect(container.querySelector('[data-testid="relation-focus-view"]')).toBeTruthy();
+			});
+			// The isolated concern is reachable AND marked as standing alone — not folded
+			// silently into the adjacent kin.
+			const lone = container.querySelector('[data-testid="relation-other-z"]') as HTMLElement;
+			expect(lone).toBeTruthy();
+			expect(lone.getAttribute('data-isolated')).toBe('true');
+		} finally {
+			restore();
+		}
+	});
+
+	it('keeps the desktop pannable SVG graph at/above the breakpoint (no mobile form on a fine pointer)', () => {
+		// The default matchMedia shim reports no match → the desktop graph renders.
+		const templates = neighbourhoodFixture();
+		const { container } = render(RelationGraph, {
+			props: { templates, onSelect: vi.fn() }
+		});
+		// The SVG field + its panning group are present; no focus-centered view.
+		expect(container.querySelector('.relation-graph__svg')).toBeTruthy();
+		expect(container.querySelector('.relation-graph__pan')).toBeTruthy();
+		expect(container.querySelector('[data-testid="relation-focus-view"]')).toBeNull();
+	});
 });

--- a/tests/unit/components/RelationGraph.test.ts
+++ b/tests/unit/components/RelationGraph.test.ts
@@ -253,6 +253,47 @@ describe('RelationGraph — the relatedness map', () => {
 		expect(isolatedNodes(container).length).toBe(2);
 	});
 
+	it('paints the whole map at full presence at rest, even with a node selected', async () => {
+		// The live condition the component lane never exercised: the landing's
+		// template store auto-selects the first template on hydration, so the graph
+		// is mounted with a non-null `selectedId`. The at-rest map must still paint
+		// at FULL presence — `selectedId` marks one node but must NOT engage the
+		// global dim. (Before the fix, any truthy `selectedId` lit a focus set and
+		// the whole field rendered dimmed-to-one-node at rest.)
+		const templates = [
+			makeTemplate({ id: 'a', domain: 'Transportation', title: 'Bike lanes' }),
+			makeTemplate({ id: 'b', domain: 'Transportation', title: 'Freeway removal' }),
+			makeTemplate({ id: 'c', domain: 'Healthcare', title: 'Clinic hours' })
+		];
+		const { container } = render(RelationGraph, {
+			props: { templates, selectedId: 'a', onSelect: vi.fn() }
+		});
+
+		// No hover, no graph focus → the field is not globally dimmed.
+		const svg = container.querySelector('.relation-graph__svg') as SVGElement;
+		expect(svg).toBeTruthy();
+		expect(svg.classList.contains('has-focus')).toBe(false);
+
+		// No node carries the dimmed class at rest — every node reads at presence.
+		expect(container.querySelectorAll('.relation-node--dimmed').length).toBe(0);
+		// And every node IS lit (the at-rest full-presence state).
+		expect(container.querySelectorAll('.relation-node--lit').length).toBe(nodes(container).length);
+
+		// The selected node is still marked (a quiet "this one is open" annotation),
+		// but the marker is on exactly one node and dims nothing.
+		expect(container.querySelectorAll('.relation-node--selected').length).toBe(1);
+		const selected = container.querySelector('.relation-node--selected');
+		expect(selected?.getAttribute('data-template-id')).toBe('a');
+
+		// Hover still engages the focus state — the dim is hover-driven, not store-driven.
+		const hovered = container.querySelector('[data-template-id="c"]') as HTMLElement;
+		await fireEvent.mouseEnter(hovered);
+		expect(svg.classList.contains('has-focus')).toBe(true);
+		// On leave, the field returns to full presence.
+		await fireEvent.mouseLeave(hovered);
+		expect(svg.classList.contains('has-focus')).toBe(false);
+	});
+
 	it('renders an honest empty state when there are no templates', () => {
 		const { container, getByText } = render(RelationGraph, {
 			props: { templates: [], onSelect: vi.fn() }

--- a/tests/unit/components/RelationGraph.test.ts
+++ b/tests/unit/components/RelationGraph.test.ts
@@ -294,6 +294,118 @@ describe('RelationGraph — the relatedness map', () => {
 		expect(svg.classList.contains('has-focus')).toBe(false);
 	});
 
+	// ─── Focus lights the neighbourhood (R1) ──────────────────────────────────
+	//
+	// Focusing a node — by hover OR by keyboard — must light its incident edges and
+	// adjacent nodes and dim the rest, so "what is near this one" is answerable at a
+	// glance. Clearing focus restores the full field. The dim/lit set is asserted on
+	// a fixture with one connected pair + one loner.
+
+	/** The lit (non-dimmed) node ids in the field. */
+	function litIds(container: HTMLElement): string[] {
+		return Array.from(container.querySelectorAll('.relation-node--lit')).map(
+			(n) => n.getAttribute('data-template-id') ?? ''
+		);
+	}
+	/** The dimmed (non-neighbour) node ids in the field. */
+	function dimmedIds(container: HTMLElement): string[] {
+		return Array.from(container.querySelectorAll('.relation-node--dimmed')).map(
+			(n) => n.getAttribute('data-template-id') ?? ''
+		);
+	}
+
+	/** A three-node fixture: a connected same-family pair (a,b) + a loner (c). */
+	function neighbourhoodFixture() {
+		return [
+			makeTemplate({ id: 'a', domain: 'Transportation', title: 'Bike lanes' }),
+			makeTemplate({ id: 'b', domain: 'Transportation', title: 'Freeway removal' }),
+			makeTemplate({ id: 'c', domain: 'Healthcare', title: 'Clinic hours' })
+		];
+	}
+
+	it('focusing a node by hover lights its neighbour + incident edge and dims the rest', async () => {
+		const templates = neighbourhoodFixture();
+		const { container } = render(RelationGraph, {
+			props: { templates, onSelect: vi.fn() }
+		});
+		const svg = container.querySelector('.relation-graph__svg') as SVGElement;
+		// At rest: full presence, nothing dimmed.
+		expect(svg.classList.contains('has-focus')).toBe(false);
+		expect(dimmedIds(container)).toEqual([]);
+
+		// Hover node `a` — its same-family neighbour `b` lights, the loner `c` dims.
+		const a = container.querySelector('[data-template-id="a"]') as HTMLElement;
+		await fireEvent.mouseEnter(a);
+		expect(svg.classList.contains('has-focus')).toBe(true);
+		const lit = litIds(container);
+		expect(lit).toContain('a'); // the focused node
+		expect(lit).toContain('b'); // its admissible neighbour
+		expect(lit).not.toContain('c'); // the loner is not in the neighbourhood
+		expect(dimmedIds(container)).toEqual(['c']);
+
+		// The incident edge (the a–b tie) is marked; the rest are not.
+		const incident = container.querySelectorAll('.relation-edge--incident');
+		expect(incident.length).toBe(1);
+
+		// Clearing focus restores the full field — nothing dimmed, no has-focus.
+		await fireEvent.mouseLeave(a);
+		expect(svg.classList.contains('has-focus')).toBe(false);
+		expect(dimmedIds(container)).toEqual([]);
+		expect(litIds(container).length).toBe(nodes(container).length);
+	});
+
+	it('focusing a node by KEYBOARD lights the identical neighbourhood as hover', async () => {
+		const templates = neighbourhoodFixture();
+		const { container } = render(RelationGraph, {
+			props: { templates, onSelect: vi.fn() }
+		});
+		const svg = container.querySelector('.relation-graph__svg') as SVGElement;
+		const a = container.querySelector('[data-template-id="a"]') as HTMLElement;
+
+		// Keyboard focus (the onfocus channel) engages the same neighbourhood read.
+		await fireEvent.focus(a);
+		expect(svg.classList.contains('has-focus')).toBe(true);
+		const lit = litIds(container);
+		expect(lit).toContain('a');
+		expect(lit).toContain('b');
+		expect(dimmedIds(container)).toEqual(['c']);
+
+		// Blur restores the full field — keyboard focus is transient, like hover.
+		await fireEvent.blur(a);
+		expect(svg.classList.contains('has-focus')).toBe(false);
+		expect(dimmedIds(container)).toEqual([]);
+	});
+
+	it('keeps every node keyboard-focusable in a stable order with a visible focus ring', () => {
+		const templates = neighbourhoodFixture();
+		const { container } = render(RelationGraph, {
+			props: { templates, onSelect: vi.fn() }
+		});
+		// Every node is a tab stop (tabindex 0), in the templates' own order — the
+		// same stable order the layout seeds from, so Tab walks deterministically.
+		const ordered = Array.from(container.querySelectorAll('.relation-node')).map((n) => ({
+			id: n.getAttribute('data-template-id'),
+			tabindex: n.getAttribute('tabindex')
+		}));
+		expect(ordered.map((n) => n.id)).toEqual(['a', 'b', 'c']);
+		expect(ordered.every((n) => n.tabindex === '0')).toBe(true);
+
+		// Each node carries a dedicated focus-ring element (the visible keyboard ring).
+		const rings = container.querySelectorAll('.relation-node__focus-ring');
+		expect(rings.length).toBe(templates.length);
+	});
+
+	it('drives the focus dim with a motion.ts spring, not a foreign config', () => {
+		const src = readFileSync(resolve(process.cwd(), COMPONENT_PATH), 'utf8');
+		// The focus transition rides a named motion.ts spring (imported, not inlined).
+		expect(src).toMatch(/from\s+['"]\$lib\/design\/motion['"]/);
+		expect(src).toMatch(/SPRINGS\./);
+		// And honors reduced motion (the hard-set escape hatch is present).
+		expect(src).toMatch(/prefers-reduced-motion/);
+		// No bespoke spring literal smuggled in alongside the named config.
+		expect(src).not.toMatch(/stiffness:\s*0?\.\d/);
+	});
+
 	it('renders an honest empty state when there are no templates', () => {
 		const { container, getByText } = render(RelationGraph, {
 			props: { templates: [], onSelect: vi.fn() }

--- a/tests/unit/components/RelationGraph.test.ts
+++ b/tests/unit/components/RelationGraph.test.ts
@@ -795,4 +795,126 @@ describe('RelationGraph — the relatedness map', () => {
 		expect(container.querySelector('.relation-graph__pan')).toBeTruthy();
 		expect(container.querySelector('[data-testid="relation-focus-view"]')).toBeNull();
 	});
+
+	// ─── Immediate, unjanky, SSR-safe (R9) ────────────────────────────────────
+	//
+	// The surface must paint structure-first and never lurch: the layout is computed
+	// once (memoized) and is identical on the server and the client (no clock, no
+	// randomness in the render path), the box is reserved so nothing jumps on mount,
+	// and reduced motion is honoured. These guard that contract at the component
+	// level — not just in the layout unit.
+
+	/** The drawn node positions, read off the glyph cx/cy, keyed by template id. */
+	function nodePositions(container: HTMLElement): Map<string, { x: number; y: number }> {
+		const out = new Map<string, { x: number; y: number }>();
+		for (const node of container.querySelectorAll('.relation-node')) {
+			const id = node.getAttribute('data-template-id') ?? '';
+			const glyph = node.querySelector('.relation-node__glyph') as SVGCircleElement | null;
+			if (!glyph) continue;
+			out.set(id, {
+				x: parseFloat(glyph.getAttribute('cx') ?? 'NaN'),
+				y: parseFloat(glyph.getAttribute('cy') ?? 'NaN')
+			});
+		}
+		return out;
+	}
+
+	it('renders identical node positions across two independent renders (SSR ⇄ client parity)', () => {
+		// Two renders of the same templates stand in for the server render and the
+		// client hydration. Every glyph must land at the exact same coordinate, or the
+		// map would jump when the client takes over. (The component memoizes the layout,
+		// so this also exercises the cache returning a stable arrangement.)
+		const templates = [
+			makeTemplate({ id: 'a', domain: 'Transportation', title: 'Bike lanes' }),
+			makeTemplate({ id: 'b', domain: 'Transportation', title: 'Freeway removal' }),
+			makeTemplate({ id: 'c', domain: 'Healthcare', title: 'Clinic hours' }),
+			makeTemplate({ id: 'd', domain: 'Labor', title: 'Retail wages' })
+		];
+		const first = render(RelationGraph, { props: { templates, onSelect: vi.fn() } });
+		const posA = nodePositions(first.container);
+		first.unmount();
+		const second = render(RelationGraph, { props: { templates, onSelect: vi.fn() } });
+		const posB = nodePositions(second.container);
+
+		expect([...posB.keys()].sort()).toEqual([...posA.keys()].sort());
+		for (const [id, p] of posA) {
+			const q = posB.get(id)!;
+			expect(q.x).toBe(p.x);
+			expect(q.y).toBe(p.y);
+		}
+	});
+
+	it('does not move a node when an unrelated interaction (hover) fires — no relayout on focus', async () => {
+		// Hover changes the focus/dim, never the geometry. The memoized layout must not
+		// recompute (and must not shift any node) when the viewer merely points at one.
+		const templates = neighbourhoodFixture();
+		const { container } = render(RelationGraph, { props: { templates, onSelect: vi.fn() } });
+		const before = nodePositions(container);
+		const a = container.querySelector('[data-template-id="a"]') as HTMLElement;
+		await fireEvent.mouseEnter(a);
+		const after = nodePositions(container);
+		for (const [id, p] of before) {
+			const q = after.get(id)!;
+			expect(q.x).toBe(p.x);
+			expect(q.y).toBe(p.y);
+		}
+	});
+
+	it('reserves the SVG box so there is no layout shift on mount (R9 no-CLS)', () => {
+		const src = readFileSync(resolve(process.cwd(), COMPONENT_PATH), 'utf8');
+		// The field claims its height from the first layout pass via an explicit
+		// aspect-ratio on the SVG (the viewBox's own ratio), so the box is reserved
+		// before the SVG's intrinsic size resolves — nothing below it jumps on mount.
+		expect(src).toMatch(/\.relation-graph__svg\b[\s\S]*?aspect-ratio:/);
+	});
+
+	it('reads no wall-clock or randomness anywhere in the render path (re-confirmed at the component)', () => {
+		const src = readFileSync(resolve(process.cwd(), COMPONENT_PATH), 'utf8');
+		// SSR parity breaks the instant any clock or randomness reaches a rendered
+		// value. Neither may appear in the component source.
+		expect(src).not.toMatch(/Date\.now/);
+		expect(src).not.toMatch(/Math\.random/);
+		expect(src).not.toMatch(/performance\.now/);
+		expect(src).not.toMatch(/new Date\b/);
+	});
+
+	it('honours reduced motion: the focus state changes instantly (hard-set spring, no travel)', async () => {
+		// Shim matchMedia so the reduced-motion query reports a match; the component reads
+		// it once and hard-sets the focus spring, so a hover snaps the dim in with no ease.
+		const original = window.matchMedia;
+		Object.defineProperty(window, 'matchMedia', {
+			value: (query: string) => ({
+				matches: /prefers-reduced-motion/.test(query),
+				media: query,
+				onchange: null,
+				addEventListener: () => {},
+				removeEventListener: () => {},
+				addListener: () => {},
+				removeListener: () => {},
+				dispatchEvent: () => false
+			}),
+			writable: true,
+			configurable: true
+		});
+		try {
+			const templates = neighbourhoodFixture();
+			const { container } = render(RelationGraph, { props: { templates, onSelect: vi.fn() } });
+			const svg = container.querySelector('.relation-graph__svg') as SVGElement;
+			const a = container.querySelector('[data-template-id="a"]') as HTMLElement;
+			await fireEvent.mouseEnter(a);
+			// The focus depth (the spring-driven dim value) is at its target immediately —
+			// no animated intermediate frame — because reduced motion hard-sets it.
+			const depth = parseFloat(svg.style.getPropertyValue('--focus-depth'));
+			expect(depth).toBe(1);
+			// And the dim is engaged at once (the neighbourhood read is instant).
+			expect(svg.classList.contains('has-focus')).toBe(true);
+			expect(dimmedIds(container)).toEqual(['c']);
+		} finally {
+			Object.defineProperty(window, 'matchMedia', {
+				value: original,
+				writable: true,
+				configurable: true
+			});
+		}
+	});
 });

--- a/tests/unit/components/SpectrumLandscape.test.ts
+++ b/tests/unit/components/SpectrumLandscape.test.ts
@@ -549,18 +549,16 @@ describe('SpectrumLandscape — the dive (descent into a template)', () => {
 	it('disables the scrim blur under reduced motion — only the warm dim remains', () => {
 		// The blur is the expensive, vestibular channel, so under
 		// prefers-reduced-motion the scrim must drop its backdrop-filter while the
-		// (cheap, non-vestibular) warm dim stays. This component's scoped CSS is not
-		// injected into the jsdom document (so getComputedStyle/styleSheets cannot
-		// see it); the contract is structural, so assert it against the component
-		// source: the scrim declares the blur at rest, and a reduced-motion block
-		// zeroes that blur for the scrim.
+		// (cheap, non-vestibular) warm dim stays. The descent is the ONE shared dive
+		// (DescentDive), so its scrim CSS lives there, not forked per surface. The
+		// component's scoped CSS is not injected into the jsdom document (so
+		// getComputedStyle/styleSheets cannot see it); the contract is structural, so
+		// assert it against the shared descent's source: the scrim declares the blur
+		// at rest, and a reduced-motion block zeroes that blur for the scrim.
 		// Resolved from the vitest root (process.cwd() = the repo), so it does not
 		// depend on import.meta.url being available under the test transform.
 		const src = readFileSync(
-			resolve(
-				process.cwd(),
-				'src/lib/components/template-browser/spectrum/SpectrumLandscape.svelte'
-			),
+			resolve(process.cwd(), 'src/lib/components/template-browser/DescentDive.svelte'),
 			'utf8'
 		);
 

--- a/tests/unit/relation-family-edges.test.ts
+++ b/tests/unit/relation-family-edges.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Unit Tests — civic-family kinship edges (the dashed taxonomic relation).
+ *
+ * Asserts the behavior the relatedness graph depends on: same-anchor templates
+ * link as a connected, bounded chain; cross-anchor pairs get no family edge;
+ * anchorless templates stay honestly isolated; and the function is pure /
+ * deterministic. Fixtures use real domain wordings whose anchor resolution is
+ * verified against the shipped `matchAnchor` table (Education = Public Library /
+ * Library Workforce / Universal Preschool; Housing = Housing & Zoning /
+ * Affordable Housing; Transportation = Urban Freeway Removal / Bike
+ * Infrastructure; "Drug Treatment Access" matches no anchor → isolated).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { familyEdges } from '$lib/core/topic/relation-edges';
+import type { Template, RelationEdge } from '$lib/types/template';
+
+/** Minimal node the util reads (id + domain); the rest of Template is irrelevant. */
+type FamilyNode = Pick<Template, 'id' | 'domain'>;
+
+const node = (id: string, domain: string): FamilyNode => ({ id, domain });
+
+/** Does an undirected edge connect exactly these two ids (in either order)? */
+function connects(edge: RelationEdge, x: string, y: string): boolean {
+	return (edge.a === x && edge.b === y) || (edge.a === y && edge.b === x);
+}
+
+/** All ids reachable from `start` over the edge set (connectivity probe). */
+function reachable(start: string, edges: RelationEdge[]): Set<string> {
+	const seen = new Set<string>([start]);
+	const stack = [start];
+	while (stack.length) {
+		const cur = stack.pop()!;
+		for (const e of edges) {
+			const next = e.a === cur ? e.b : e.b === cur ? e.a : null;
+			if (next && !seen.has(next)) {
+				seen.add(next);
+				stack.push(next);
+			}
+		}
+	}
+	return seen;
+}
+
+describe('familyEdges — same-anchor linkage', () => {
+	it('links two templates that share a canonical anchor', () => {
+		const edges = familyEdges([
+			node('hz', 'Housing & Zoning'),
+			node('ah', 'Affordable Housing')
+		]);
+		expect(edges).toHaveLength(1);
+		expect(connects(edges[0], 'hz', 'ah')).toBe(true);
+	});
+
+	it('tags every edge as a family relation (never twin)', () => {
+		const edges = familyEdges([
+			node('hz', 'Housing & Zoning'),
+			node('ah', 'Affordable Housing')
+		]);
+		expect(edges.every((e) => e.kind === 'family')).toBe(true);
+	});
+
+	it('omits the measured `score` on family edges (taxonomic, not measured)', () => {
+		const edges = familyEdges([
+			node('hz', 'Housing & Zoning'),
+			node('ah', 'Affordable Housing')
+		]);
+		expect(edges[0].score).toBeUndefined();
+	});
+
+	it('normalizes endpoints so the lexically-smaller id is `a`', () => {
+		const edges = familyEdges([
+			node('zebra', 'Affordable Housing'),
+			node('alpha', 'Housing & Zoning')
+		]);
+		expect(edges[0].a).toBe('alpha');
+		expect(edges[0].b).toBe('zebra');
+	});
+});
+
+describe('familyEdges — cross-anchor absence', () => {
+	it('draws no edge between templates of different anchors', () => {
+		const edges = familyEdges([
+			node('house', 'Affordable Housing'), // Housing
+			node('bike', 'Bike Infrastructure') // Transportation
+		]);
+		expect(edges).toHaveLength(0);
+	});
+
+	it('separates families: housing links to housing, transit to transit, never across', () => {
+		const edges = familyEdges([
+			node('hz', 'Housing & Zoning'),
+			node('ah', 'Affordable Housing'),
+			node('freeway', 'Urban Freeway Removal'),
+			node('bike', 'Bike Infrastructure')
+		]);
+		// Two intra-family edges, zero cross-family.
+		expect(edges).toHaveLength(2);
+		expect(edges.some((e) => connects(e, 'hz', 'ah'))).toBe(true);
+		expect(edges.some((e) => connects(e, 'freeway', 'bike'))).toBe(true);
+		expect(edges.some((e) => connects(e, 'hz', 'bike'))).toBe(false);
+		expect(edges.some((e) => connects(e, 'ah', 'freeway'))).toBe(false);
+	});
+});
+
+describe('familyEdges — honestly isolated, never forced', () => {
+	it('gives a single same-anchor template no family edge', () => {
+		expect(familyEdges([node('solo', 'Affordable Housing')])).toHaveLength(0);
+	});
+
+	it('draws no edge for a template whose domain matches no anchor', () => {
+		const edges = familyEdges([
+			node('drug', 'Drug Treatment Access'), // matches no anchor keyword
+			node('house', 'Affordable Housing')
+		]);
+		expect(edges).toHaveLength(0);
+	});
+
+	it('does NOT bucket anchorless templates into a fake shared family', () => {
+		// Two distinct un-anchored domains must not be linked to each other.
+		const edges = familyEdges([
+			node('drug', 'Drug Treatment Access'),
+			node('permits', 'Local Bake Sale Permits')
+		]);
+		expect(edges).toHaveLength(0);
+	});
+
+	it('treats a blank/whitespace domain as anchorless (no edge)', () => {
+		const edges = familyEdges([
+			node('blank', '   '),
+			node('empty', ''),
+			node('house', 'Affordable Housing')
+		]);
+		expect(edges).toHaveLength(0);
+	});
+});
+
+describe('familyEdges — bounded fan-out yet connected', () => {
+	it('links a 3-member family as a 2-edge chain, not an all-pairs triangle', () => {
+		const edges = familyEdges([
+			node('lib', 'Public Library'),
+			node('work', 'Library Workforce'),
+			node('pre', 'Universal Preschool')
+		]);
+		// All three resolve to Education. All-pairs would be 3 edges; a chain is 2.
+		expect(edges).toHaveLength(2);
+		// Every member is reachable from any other through the chain.
+		expect(reachable('lib', edges)).toEqual(new Set(['lib', 'work', 'pre']));
+	});
+
+	it('keeps a large family connected with strictly n-1 edges (no blob)', () => {
+		// Twelve same-anchor templates. All-pairs = 66 edges; chain = 11.
+		const big: FamilyNode[] = Array.from({ length: 12 }, (_, i) =>
+			node(`h${String(i).padStart(2, '0')}`, 'Affordable Housing')
+		);
+		const edges = familyEdges(big);
+		expect(edges).toHaveLength(big.length - 1);
+		// One connected component spanning all twelve.
+		expect(reachable('h00', edges).size).toBe(12);
+		// Bounded degree: a chain's interior nodes touch at most two edges —
+		// proof there is no central hub or complete graph.
+		const degree = new Map<string, number>();
+		for (const e of edges) {
+			degree.set(e.a, (degree.get(e.a) ?? 0) + 1);
+			degree.set(e.b, (degree.get(e.b) ?? 0) + 1);
+		}
+		expect(Math.max(...degree.values())).toBeLessThanOrEqual(2);
+	});
+
+	it('collapses a duplicate id within a family to one node (no self-loop)', () => {
+		const edges = familyEdges([
+			node('dup', 'Affordable Housing'),
+			node('dup', 'Housing & Zoning'),
+			node('other', 'Affordable Housing')
+		]);
+		// Two distinct nodes (dup, other) → exactly one edge, never a self-loop.
+		expect(edges).toHaveLength(1);
+		expect(edges.every((e) => e.a !== e.b)).toBe(true);
+		expect(connects(edges[0], 'dup', 'other')).toBe(true);
+	});
+});
+
+describe('familyEdges — pure & deterministic', () => {
+	const corpus: FamilyNode[] = [
+		node('lib', 'Public Library'),
+		node('work', 'Library Workforce'),
+		node('pre', 'Universal Preschool'),
+		node('hz', 'Housing & Zoning'),
+		node('ah', 'Affordable Housing'),
+		node('freeway', 'Urban Freeway Removal'),
+		node('bike', 'Bike Infrastructure'),
+		node('drug', 'Drug Treatment Access'), // anchorless → isolated
+		node('vets', 'Veterans Healthcare') // lone Healthcare → isolated
+	];
+
+	it('returns identical output across repeated runs', () => {
+		const first = familyEdges(corpus);
+		const second = familyEdges(corpus);
+		expect(second).toEqual(first);
+	});
+
+	it('is independent of input ordering', () => {
+		const shuffled = [...corpus].reverse();
+		expect(familyEdges(shuffled)).toEqual(familyEdges(corpus));
+	});
+
+	it('produces a globally sorted edge list (by a, then b)', () => {
+		const edges = familyEdges(corpus);
+		for (let i = 1; i < edges.length; i++) {
+			const prev = edges[i - 1];
+			const cur = edges[i];
+			const ordered = prev.a < cur.a || (prev.a === cur.a && prev.b <= cur.b);
+			expect(ordered).toBe(true);
+		}
+	});
+
+	it('relates only the real families in a mixed corpus, leaving loners unlinked', () => {
+		const edges = familyEdges(corpus);
+		// Education chain (2) + Housing pair (1) + Transportation pair (1) = 4.
+		expect(edges).toHaveLength(4);
+		// The two honestly-isolated templates appear in no edge.
+		const touched = new Set(edges.flatMap((e) => [e.a, e.b]));
+		expect(touched.has('drug')).toBe(false);
+		expect(touched.has('vets')).toBe(false);
+	});
+
+	it('returns an empty list for an empty corpus', () => {
+		expect(familyEdges([])).toEqual([]);
+	});
+});

--- a/tests/unit/relation-graph-layout.test.ts
+++ b/tests/unit/relation-graph-layout.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Unit Tests — the relation-graph layout engine.
+ *
+ * Asserts the contract the relatedness surface leans on:
+ *   - DETERMINISM: same (nodes, edges, size, seed) ⇒ byte-identical positions,
+ *     independent of input order — so the SSR render and the client render
+ *     agree to the pixel and the graph never lurches on hydration.
+ *   - HONESTLY ISOLATED: nodes with no edge settle toward the periphery, not
+ *     the centre — the sparsity reads as intentional, never forced inward.
+ *   - NO OVERLAP: a minimum centre-to-centre separation is enforced so two
+ *     clusters never pile on one spot.
+ *   - BOUNDED + ON-CANVAS: the layout terminates and every position lands
+ *     inside the given width/height.
+ *
+ * The fixture mirrors the live seed's measured structure: four twin pairs, one
+ * family chain, and a few honestly-isolated loners — so the invariants are
+ * checked on the shape the surface actually renders.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+	layoutRelationGraph,
+	type GraphLayoutNode,
+	type GraphLayoutEdge,
+	type Point
+} from '$lib/core/topic/graph-layout';
+
+// --- Fixture: the measured seed shape --------------------------------------
+
+const node = (id: string): GraphLayoutNode => ({ id });
+const twin = (a: string, b: string): GraphLayoutEdge => ({ a, b, kind: 'twin' });
+const family = (a: string, b: string): GraphLayoutEdge => ({ a, b, kind: 'family' });
+
+/** Connected ids (carry at least one edge below) and the honestly-isolated ones. */
+const CONNECTED_IDS = [
+	'lib',
+	'work',
+	'pre',
+	'priv',
+	'drug',
+	'house',
+	'parks',
+	'indig',
+	'freeway',
+	'bike'
+];
+const ISOLATED_IDS = ['vets', 'retail', 'green'];
+const ALL_IDS = [...CONNECTED_IDS, ...ISOLATED_IDS];
+
+const NODES: GraphLayoutNode[] = ALL_IDS.map(node);
+const EDGES: GraphLayoutEdge[] = [
+	twin('lib', 'work'),
+	twin('priv', 'pre'),
+	twin('drug', 'house'),
+	twin('parks', 'indig'),
+	twin('bike', 'freeway'),
+	family('lib', 'pre'),
+	family('pre', 'work')
+];
+
+const SIZE = { width: 1080, height: 600 } as const;
+
+// --- Helpers ----------------------------------------------------------------
+
+function dist(p: Point, q: Point): number {
+	return Math.hypot(p.x - q.x, p.y - q.y);
+}
+
+/** Distance from the canvas centre — the "how peripheral is this node" probe. */
+function radius(p: Point, width: number, height: number): number {
+	return Math.hypot(p.x - width / 2, p.y - height / 2);
+}
+
+function mean(values: number[]): number {
+	return values.reduce((s, v) => s + v, 0) / values.length;
+}
+
+/** The smallest centre-to-centre distance over every distinct pair. */
+function minPairSeparation(pos: Map<string, Point>): number {
+	const ids = [...pos.keys()];
+	let smallest = Infinity;
+	for (let i = 0; i < ids.length; i++) {
+		for (let j = i + 1; j < ids.length; j++) {
+			const d = dist(pos.get(ids[i])!, pos.get(ids[j])!);
+			if (d < smallest) smallest = d;
+		}
+	}
+	return smallest;
+}
+
+// --- Determinism ------------------------------------------------------------
+
+describe('layoutRelationGraph — determinism (SSR ⇄ client parity)', () => {
+	it('returns byte-identical positions across repeated runs', () => {
+		const first = layoutRelationGraph(NODES, EDGES, { ...SIZE, seed: 0 });
+		const second = layoutRelationGraph(NODES, EDGES, { ...SIZE, seed: 0 });
+		expect(second.size).toBe(first.size);
+		for (const [id, point] of first) {
+			expect(second.get(id)).toEqual(point);
+		}
+	});
+
+	it('is independent of node input order', () => {
+		const forward = layoutRelationGraph(NODES, EDGES, { ...SIZE, seed: 0 });
+		const reversed = layoutRelationGraph([...NODES].reverse(), EDGES, { ...SIZE, seed: 0 });
+		for (const [id, point] of forward) {
+			expect(reversed.get(id)).toEqual(point);
+		}
+	});
+
+	it('is independent of edge input order and endpoint orientation', () => {
+		const forward = layoutRelationGraph(NODES, EDGES, { ...SIZE, seed: 0 });
+		// Reverse the edge list AND flip each edge's endpoints (undirected).
+		const shuffledEdges = [...EDGES].reverse().map((e) => ({ a: e.b, b: e.a, kind: e.kind }));
+		const other = layoutRelationGraph(NODES, shuffledEdges, { ...SIZE, seed: 0 });
+		for (const [id, point] of forward) {
+			expect(other.get(id)).toEqual(point);
+		}
+	});
+
+	it('produces a different (still deterministic) arrangement for a different seed', () => {
+		const a1 = layoutRelationGraph(NODES, EDGES, { ...SIZE, seed: 42 });
+		const a2 = layoutRelationGraph(NODES, EDGES, { ...SIZE, seed: 42 });
+		const b = layoutRelationGraph(NODES, EDGES, { ...SIZE, seed: 1337 });
+		// Same seed: identical.
+		for (const [id, point] of a1) expect(a2.get(id)).toEqual(point);
+		// Different seed: at least one node moved (the seed actually re-rolls).
+		let anyMoved = false;
+		for (const [id, point] of a1) {
+			const other = b.get(id)!;
+			if (other.x !== point.x || other.y !== point.y) anyMoved = true;
+		}
+		expect(anyMoved).toBe(true);
+	});
+
+	it('defaults the seed to 0 when omitted', () => {
+		const explicit = layoutRelationGraph(NODES, EDGES, { ...SIZE, seed: 0 });
+		const implicit = layoutRelationGraph(NODES, EDGES, { ...SIZE });
+		for (const [id, point] of explicit) {
+			expect(implicit.get(id)).toEqual(point);
+		}
+	});
+});
+
+// --- Honestly isolated, never forced ---------------------------------------
+
+describe('layoutRelationGraph — isolated nodes fall to the periphery (R4)', () => {
+	it('places no-edge nodes further from centre than the connected mean', () => {
+		const pos = layoutRelationGraph(NODES, EDGES, { ...SIZE, seed: 0 });
+		const isoRadii = ISOLATED_IDS.map((id) => radius(pos.get(id)!, SIZE.width, SIZE.height));
+		const conRadii = CONNECTED_IDS.map((id) => radius(pos.get(id)!, SIZE.width, SIZE.height));
+		// The isolated cohort sits, on average, nearer the rim than the connected
+		// cohort — the loners are pushed out, not pulled inward to a fake cluster.
+		expect(mean(isoRadii)).toBeGreaterThan(mean(conRadii));
+	});
+
+	it('keeps the periphery property across several seeds (not a lucky basin)', () => {
+		for (const seed of [0, 1, 7, 42, 1337]) {
+			const pos = layoutRelationGraph(NODES, EDGES, { ...SIZE, seed });
+			const isoRadii = ISOLATED_IDS.map((id) => radius(pos.get(id)!, SIZE.width, SIZE.height));
+			const conRadii = CONNECTED_IDS.map((id) => radius(pos.get(id)!, SIZE.width, SIZE.height));
+			expect(mean(isoRadii)).toBeGreaterThan(mean(conRadii));
+		}
+	});
+
+	it('draws no edge-derived attraction for an isolated node (it has no edge)', () => {
+		// A graph of ONLY isolated nodes still lays them out — spread, not stacked.
+		const lone = ['a', 'b', 'c', 'd'].map(node);
+		const pos = layoutRelationGraph(lone, [], { ...SIZE, seed: 0 });
+		expect(pos.size).toBe(4);
+		expect(minPairSeparation(pos)).toBeGreaterThanOrEqual(132 - 1);
+	});
+});
+
+// --- No overlap (declump min separation) -----------------------------------
+
+describe('layoutRelationGraph — minimum separation (no overlapping clusters)', () => {
+	it('keeps every pair at least the default minimum apart', () => {
+		const pos = layoutRelationGraph(NODES, EDGES, { ...SIZE, seed: 0 });
+		// Allow a 1px tolerance for the final hard clamp into [0,w]×[0,h].
+		expect(minPairSeparation(pos)).toBeGreaterThanOrEqual(132 - 1);
+	});
+
+	it('honors a caller-supplied larger minimum separation', () => {
+		const pos = layoutRelationGraph(NODES, EDGES, { ...SIZE, seed: 0, minSeparation: 160 });
+		expect(minPairSeparation(pos)).toBeGreaterThanOrEqual(160 - 1);
+	});
+
+	it('still settles connected twins nearer each other than the typical loner', () => {
+		const pos = layoutRelationGraph(NODES, EDGES, { ...SIZE, seed: 0 });
+		// The measured twin pairs end up at (or near) the declump floor — far
+		// closer than an isolated node sits to anything.
+		const twinGap = mean([
+			dist(pos.get('lib')!, pos.get('work')!),
+			dist(pos.get('parks')!, pos.get('indig')!),
+			dist(pos.get('bike')!, pos.get('freeway')!)
+		]);
+		// Nearest-neighbour distance of an isolated node (to anything at all).
+		const isoNearest = mean(
+			ISOLATED_IDS.map((id) => {
+				const p = pos.get(id)!;
+				let nearest = Infinity;
+				for (const [other, q] of pos) {
+					if (other === id) continue;
+					nearest = Math.min(nearest, dist(p, q));
+				}
+				return nearest;
+			})
+		);
+		expect(twinGap).toBeLessThanOrEqual(isoNearest);
+	});
+});
+
+// --- Bounded + on-canvas ----------------------------------------------------
+
+describe('layoutRelationGraph — bounded + within canvas (R9)', () => {
+	it('places every node inside [0, width] × [0, height]', () => {
+		const pos = layoutRelationGraph(NODES, EDGES, { ...SIZE, seed: 0 });
+		for (const point of pos.values()) {
+			expect(point.x).toBeGreaterThanOrEqual(0);
+			expect(point.x).toBeLessThanOrEqual(SIZE.width);
+			expect(point.y).toBeGreaterThanOrEqual(0);
+			expect(point.y).toBeLessThanOrEqual(SIZE.height);
+		}
+	});
+
+	it('terminates and stays on-canvas at a larger corpus (blooms — R7)', () => {
+		// 60 synthetic nodes, half linked into pairs, half isolated. Same fn,
+		// no code change — exercises the bounded-iteration + clamp guarantees.
+		const grown: GraphLayoutNode[] = Array.from({ length: 60 }, (_, i) =>
+			node(`t${String(i).padStart(2, '0')}`)
+		);
+		const grownEdges: GraphLayoutEdge[] = [];
+		for (let i = 0; i + 1 < 30; i += 2) {
+			grownEdges.push(twin(`t${String(i).padStart(2, '0')}`, `t${String(i + 1).padStart(2, '0')}`));
+		}
+		const pos = layoutRelationGraph(grown, grownEdges, { width: 1440, height: 900, seed: 0 });
+		expect(pos.size).toBe(60);
+		for (const point of pos.values()) {
+			expect(point.x).toBeGreaterThanOrEqual(0);
+			expect(point.x).toBeLessThanOrEqual(1440);
+			expect(point.y).toBeGreaterThanOrEqual(0);
+			expect(point.y).toBeLessThanOrEqual(900);
+		}
+	});
+});
+
+// --- Degenerate inputs ------------------------------------------------------
+
+describe('layoutRelationGraph — degenerate inputs', () => {
+	it('returns an empty map for no nodes', () => {
+		expect(layoutRelationGraph([], [], { ...SIZE }).size).toBe(0);
+	});
+
+	it('centres a single node', () => {
+		const pos = layoutRelationGraph([node('only')], [], { ...SIZE });
+		expect(pos.get('only')).toEqual({ x: SIZE.width / 2, y: SIZE.height / 2 });
+	});
+
+	it('collapses duplicate ids to a single placed node', () => {
+		const pos = layoutRelationGraph([node('dup'), node('dup'), node('other')], [], { ...SIZE });
+		expect(pos.size).toBe(2);
+		expect(pos.has('dup')).toBe(true);
+		expect(pos.has('other')).toBe(true);
+	});
+
+	it('ignores edges referencing ids absent from the node set', () => {
+		// An edge to a ghost id must not throw, nor invent a node.
+		const pos = layoutRelationGraph([node('a'), node('b')], [twin('a', 'ghost')], { ...SIZE });
+		expect(pos.size).toBe(2);
+		expect(pos.has('ghost')).toBe(false);
+	});
+
+	it('skips blank / non-string ids without placing them', () => {
+		const pos = layoutRelationGraph(
+			[node('real'), node(''), { id: undefined } as unknown as GraphLayoutNode],
+			[],
+			{ ...SIZE }
+		);
+		expect(pos.size).toBe(1);
+		expect(pos.has('real')).toBe(true);
+	});
+});

--- a/tests/unit/relation-graph-layout.test.ts
+++ b/tests/unit/relation-graph-layout.test.ts
@@ -20,6 +20,7 @@
 import { describe, it, expect } from 'vitest';
 import {
 	layoutRelationGraph,
+	layoutRelationGraphMemo,
 	type GraphLayoutNode,
 	type GraphLayoutEdge,
 	type Point
@@ -273,6 +274,81 @@ describe('layoutRelationGraph — bounded + within canvas (R9)', () => {
 			expect(point.x).toBeLessThanOrEqual(1440);
 			expect(point.y).toBeGreaterThanOrEqual(0);
 			expect(point.y).toBeLessThanOrEqual(900);
+		}
+	});
+});
+
+// --- Memoization (one compute per distinct graph; no stale cache) -----------
+
+describe('layoutRelationGraphMemo — memoized by (nodeIds, edgeKey, size)', () => {
+	it('returns the SAME map instance for identical inputs (no recompute)', () => {
+		const first = layoutRelationGraphMemo(NODES, EDGES, { ...SIZE, seed: 0 });
+		const second = layoutRelationGraphMemo(NODES, EDGES, { ...SIZE, seed: 0 });
+		// Reference equality is the proof the layout did not run again — a hover or a
+		// keystroke that re-derives with the same graph pays nothing.
+		expect(second).toBe(first);
+	});
+
+	it('is keyed independent of node/edge order (same logical graph → same instance)', () => {
+		const forward = layoutRelationGraphMemo(NODES, EDGES, { ...SIZE, seed: 0 });
+		const shuffledNodes = [...NODES].reverse();
+		const shuffledEdges = [...EDGES].reverse().map((e) => ({ a: e.b, b: e.a, kind: e.kind }));
+		const reordered = layoutRelationGraphMemo(shuffledNodes, shuffledEdges, { ...SIZE, seed: 0 });
+		// The key canonicalizes ids + edges, so reordering hits the same cache entry.
+		expect(reordered).toBe(forward);
+	});
+
+	it('does NOT serve a stale map when the edge set genuinely changes', () => {
+		const base = layoutRelationGraphMemo(NODES, EDGES, { ...SIZE, seed: 0 });
+		// Drop one measured twin — a genuinely different graph. The memo must recompute,
+		// not hand back the prior arrangement (the R9 stale-graph risk).
+		const fewerEdges = EDGES.filter((e) => !(e.a === 'bike' && e.b === 'freeway'));
+		const next = layoutRelationGraphMemo(NODES, fewerEdges, { ...SIZE, seed: 0 });
+		expect(next).not.toBe(base);
+		// And the positions actually differ where the dropped tie mattered.
+		expect(next.get('bike')).not.toEqual(base.get('bike'));
+	});
+
+	it('recomputes for a different size or seed (size/seed are part of the key)', () => {
+		const a = layoutRelationGraphMemo(NODES, EDGES, { ...SIZE, seed: 0 });
+		const bigger = layoutRelationGraphMemo(NODES, EDGES, { width: 1440, height: 900, seed: 0 });
+		const reseeded = layoutRelationGraphMemo(NODES, EDGES, { ...SIZE, seed: 9 });
+		expect(bigger).not.toBe(a);
+		expect(reseeded).not.toBe(a);
+	});
+
+	it('agrees with the pure layout — memoization changes caching, not geometry', () => {
+		const pure = layoutRelationGraph(NODES, EDGES, { ...SIZE, seed: 0 });
+		const memoized = layoutRelationGraphMemo(NODES, EDGES, { ...SIZE, seed: 0 });
+		expect(memoized.size).toBe(pure.size);
+		for (const [id, point] of pure) {
+			expect(memoized.get(id)).toEqual(point);
+		}
+	});
+
+	it('a second render with the same graph reuses the cache — the one-time mount cost (R9)', () => {
+		// Simulate SSR then client: two calls with the same logical graph. The second
+		// is a cache hit (same instance), so the quadratic compute is paid exactly once
+		// regardless of how many times the reactive surface re-derives.
+		const ssr = layoutRelationGraphMemo(NODES, EDGES, { ...SIZE });
+		const client = layoutRelationGraphMemo(NODES, EDGES, { ...SIZE });
+		expect(client).toBe(ssr);
+	});
+});
+
+// --- SSR ⇄ client position parity (the R9 measure) --------------------------
+
+describe('layoutRelationGraph — SSR ⇄ client parity (no post-hydration jump)', () => {
+	it('the seed-shape graph lays out byte-identically on a "server" and "client" pass', () => {
+		// Two independent computes stand in for the server render and the client
+		// hydration. With no clock or randomness in the path, every coordinate must
+		// match exactly — so the painted map cannot lurch when the client takes over.
+		const server = layoutRelationGraph(NODES, EDGES, { ...SIZE });
+		const client = layoutRelationGraph(NODES, EDGES, { ...SIZE });
+		for (const [id, point] of server) {
+			const c = client.get(id)!;
+			expect(c.x).toBe(point.x);
+			expect(c.y).toBe(point.y);
 		}
 	});
 });

--- a/tests/unit/relation-graph-layout.test.ts
+++ b/tests/unit/relation-graph-layout.test.ts
@@ -163,6 +163,38 @@ describe('layoutRelationGraph — isolated nodes fall to the periphery (R4)', ()
 		}
 	});
 
+	it('seats every isolate in the rim band, past the connected mean — not intermixed', () => {
+		// Stronger than the cohort-mean comparison: EACH loner must sit out in the
+		// rim band (≥78% of the way to the canvas edge on its own axis) AND further
+		// from centre than the connected mean. This is the property the rim push
+		// guarantees and the live defect (loners landing among the connected core)
+		// violated. The elliptical band fraction is axis-normalized, so a wide
+		// canvas pushing a loner to the left/right edge counts the same as one
+		// pushed top/bottom. (Note: a connected twin-pair can be declump-clamped
+		// against an edge too, so we don't claim every isolate beats every
+		// connected node — only that no isolate reads as nestled in the core.)
+		const RIM_BAND_FLOOR = 0.78;
+		for (const seed of [0, 1, 7, 42, 1337]) {
+			const pos = layoutRelationGraph(NODES, EDGES, { ...SIZE, seed });
+			const ellipseFraction = (id: string) => {
+				const p = pos.get(id)!;
+				return Math.hypot(
+					(p.x - SIZE.width / 2) / (SIZE.width / 2),
+					(p.y - SIZE.height / 2) / (SIZE.height / 2)
+				);
+			};
+			const connectedMeanRadius = mean(
+				CONNECTED_IDS.map((id) => radius(pos.get(id)!, SIZE.width, SIZE.height))
+			);
+			for (const id of ISOLATED_IDS) {
+				expect(ellipseFraction(id)).toBeGreaterThanOrEqual(RIM_BAND_FLOOR);
+				expect(radius(pos.get(id)!, SIZE.width, SIZE.height)).toBeGreaterThan(
+					connectedMeanRadius
+				);
+			}
+		}
+	});
+
 	it('draws no edge-derived attraction for an isolated node (it has no edge)', () => {
 		// A graph of ONLY isolated nodes still lays them out — spread, not stacked.
 		const lone = ['a', 'b', 'c', 'd'].map(node);

--- a/tests/unit/topic/landing-surface.test.ts
+++ b/tests/unit/topic/landing-surface.test.ts
@@ -1,41 +1,97 @@
 import { describe, it, expect } from 'vitest';
-import { shouldShowSpectrum } from '$lib/core/topic/landing-surface';
+import { selectLandingSurface, shouldShowSpectrum } from '$lib/core/topic/landing-surface';
 
 /**
- * The landing surface chooses between two browsing worlds: the hue-ordered
- * topical landscape (the default) and the flat geographic list (the fallback
- * kept reachable without a code change). `shouldShowSpectrum` is the pure rule
- * the page derives that choice from — a function of the URL alone. These tests
- * exercise the REAL function over real URLs, so they catch any behavioural drift
- * (an inverted predicate, a moved default) rather than pinning source text.
+ * The landing chooses between three browsing worlds over the same templates: the
+ * relatedness GRAPH (reachable at `?view=graph`), the hue-ordered topical SPECTRUM
+ * (the default), and the flat geographic LIST (the fallback kept reachable without
+ * a code change). `selectLandingSurface` is the pure rule the page derives that
+ * choice from — a function of the URL alone — and `shouldShowSpectrum` is the
+ * spectrum's predicate expressed through it. These tests exercise the REAL
+ * functions over real URLs, so they catch behavioural drift (an inverted
+ * predicate, a moved default, a precedence flip) rather than pinning source text.
  */
 
-/** The selection the page makes for a given path+query, via the real util. */
+/** The surface the page renders for a given path+query, via the real util. */
+function surface(href: string) {
+	return selectLandingSurface(new URL(href, 'https://commons.email'));
+}
+
+/** Whether the spectrum shows for a given path+query, via the real util. */
 function showsSpectrum(href: string): boolean {
 	return shouldShowSpectrum(new URL(href, 'https://commons.email'));
 }
 
-describe('shouldShowSpectrum', () => {
-	it('shows the landscape by default (the bare landing path)', () => {
-		expect(showsSpectrum('/')).toBe(true);
+describe('selectLandingSurface', () => {
+	it('shows the spectrum by default (the bare landing path)', () => {
+		expect(surface('/')).toBe('spectrum');
+	});
+
+	it('opens the relatedness graph on the explicit view swap (?view=graph)', () => {
+		expect(surface('/?view=graph')).toBe('graph');
 	});
 
 	it('falls back to the list on the explicit opt-out (?spectrum=0)', () => {
-		expect(showsSpectrum('/?spectrum=0')).toBe(false);
+		expect(surface('/?spectrum=0')).toBe('list');
 	});
 
-	it('shows the landscape for ?spectrum=1', () => {
+	it('keeps the spectrum for ?spectrum=1 and any non-zero spectrum value', () => {
+		expect(surface('/?spectrum=1')).toBe('spectrum');
+		expect(surface('/?spectrum=list')).toBe('spectrum');
+		expect(surface('/?spectrum=')).toBe('spectrum');
+		expect(surface('/?spectrum=00')).toBe('spectrum');
+	});
+
+	it('lets the graph view swap win over the spectrum/list toggle', () => {
+		// The graph is the most explicit opt-in; the orthogonal spectrum opt-out
+		// must not pull the visitor off the map they asked for.
+		expect(surface('/?view=graph&spectrum=0')).toBe('graph');
+		expect(surface('/?spectrum=0&view=graph')).toBe('graph');
+	});
+
+	it('ignores an unrecognised view value (only `graph` swaps the surface)', () => {
+		expect(surface('/?view=list')).toBe('spectrum');
+		expect(surface('/?view=')).toBe('spectrum');
+		expect(surface('/?view=Graph')).toBe('spectrum'); // case-sensitive opt-in
+	});
+
+	it('keeps the spectrum for an unrelated parameter', () => {
+		expect(surface('/?template=restore-clinic-hours')).toBe('spectrum');
+	});
+
+	it('honours the list opt-out alongside unrelated parameters', () => {
+		expect(surface('/?template=restore-clinic-hours&spectrum=0')).toBe('list');
+	});
+
+	it('renders exactly one surface for every URL (the three are mutually exclusive)', () => {
+		for (const href of [
+			'/',
+			'/?view=graph',
+			'/?spectrum=0',
+			'/?spectrum=1',
+			'/?view=graph&spectrum=0',
+			'/?view=list',
+			'/?template=x'
+		]) {
+			expect(['graph', 'spectrum', 'list']).toContain(surface(href));
+		}
+	});
+});
+
+describe('shouldShowSpectrum', () => {
+	it('is true exactly when the selected surface is the spectrum', () => {
+		expect(showsSpectrum('/')).toBe(true); // default
 		expect(showsSpectrum('/?spectrum=1')).toBe(true);
 	});
 
-	it('treats any other spectrum value as the landscape (only `0` opts out)', () => {
-		expect(showsSpectrum('/?spectrum=list')).toBe(true);
-		expect(showsSpectrum('/?spectrum=')).toBe(true);
-		expect(showsSpectrum('/?spectrum=00')).toBe(true);
+	it('is false on the list opt-out (?spectrum=0)', () => {
+		expect(showsSpectrum('/?spectrum=0')).toBe(false);
 	});
 
-	it('keeps the landscape for an unrelated parameter', () => {
-		expect(showsSpectrum('/?template=restore-clinic-hours')).toBe(true);
+	it('is false when the graph view swap takes over (?view=graph)', () => {
+		// The graph is its own surface, not the spectrum — the spectrum predicate
+		// must yield so the page does not render both.
+		expect(showsSpectrum('/?view=graph')).toBe(false);
 	});
 
 	it('honours the opt-out alongside unrelated parameters', () => {

--- a/tests/unit/topic/landing-surface.test.ts
+++ b/tests/unit/topic/landing-surface.test.ts
@@ -3,13 +3,14 @@ import { selectLandingSurface, shouldShowSpectrum } from '$lib/core/topic/landin
 
 /**
  * The landing chooses between three browsing worlds over the same templates: the
- * relatedness GRAPH (reachable at `?view=graph`), the hue-ordered topical SPECTRUM
- * (the default), and the flat geographic LIST (the fallback kept reachable without
- * a code change). `selectLandingSurface` is the pure rule the page derives that
- * choice from — a function of the URL alone — and `shouldShowSpectrum` is the
- * spectrum's predicate expressed through it. These tests exercise the REAL
- * functions over real URLs, so they catch behavioural drift (an inverted
- * predicate, a moved default, a precedence flip) rather than pinning source text.
+ * relatedness GRAPH (the default front door), the hue-ordered topical SPECTRUM
+ * (an explicit opt-in at `?view=spectrum`), and the flat geographic LIST (the
+ * fallback at `?view=list` or the back-compatible `?spectrum=0`).
+ * `selectLandingSurface` is the pure rule the page derives that choice from — a
+ * function of the URL alone — and `shouldShowSpectrum` is the spectrum's predicate
+ * expressed through it. These tests exercise the REAL functions over real URLs, so
+ * they catch behavioural drift (an inverted predicate, a moved default, a
+ * precedence flip) rather than pinning source text.
  */
 
 /** The surface the page renders for a given path+query, via the real util. */
@@ -23,40 +24,42 @@ function showsSpectrum(href: string): boolean {
 }
 
 describe('selectLandingSurface', () => {
-	it('shows the spectrum by default (the bare landing path)', () => {
-		expect(surface('/')).toBe('spectrum');
+	it('shows the relatedness graph by default (the bare landing path)', () => {
+		expect(surface('/')).toBe('graph');
 	});
 
-	it('opens the relatedness graph on the explicit view swap (?view=graph)', () => {
-		expect(surface('/?view=graph')).toBe('graph');
+	it('opens the spectrum on the explicit opt-in (?view=spectrum)', () => {
+		expect(surface('/?view=spectrum')).toBe('spectrum');
 	});
 
-	it('falls back to the list on the explicit opt-out (?spectrum=0)', () => {
+	it('opens the list on either opt-out (?view=list or the back-compatible ?spectrum=0)', () => {
+		expect(surface('/?view=list')).toBe('list');
 		expect(surface('/?spectrum=0')).toBe('list');
 	});
 
-	it('keeps the spectrum for ?spectrum=1 and any non-zero spectrum value', () => {
-		expect(surface('/?spectrum=1')).toBe('spectrum');
-		expect(surface('/?spectrum=list')).toBe('spectrum');
-		expect(surface('/?spectrum=')).toBe('spectrum');
-		expect(surface('/?spectrum=00')).toBe('spectrum');
+	it('keeps the graph default for ?spectrum=1 and any non-zero spectrum value', () => {
+		expect(surface('/?spectrum=1')).toBe('graph');
+		expect(surface('/?spectrum=list')).toBe('graph');
+		expect(surface('/?spectrum=')).toBe('graph');
+		expect(surface('/?spectrum=00')).toBe('graph');
 	});
 
-	it('lets the graph view swap win over the spectrum/list toggle', () => {
-		// The graph is the most explicit opt-in; the orthogonal spectrum opt-out
-		// must not pull the visitor off the map they asked for.
-		expect(surface('/?view=graph&spectrum=0')).toBe('graph');
-		expect(surface('/?spectrum=0&view=graph')).toBe('graph');
+	it('checks the spectrum opt-in before the list opt-out', () => {
+		// `?view=spectrum` is checked first, so a co-present spectrum opt-in wins
+		// the spectrum; the bare list opt-out (no view param) still lands list.
+		expect(surface('/?spectrum=0')).toBe('list');
+		expect(surface('/?view=spectrum&spectrum=0')).toBe('spectrum');
 	});
 
-	it('ignores an unrecognised view value (only `graph` swaps the surface)', () => {
-		expect(surface('/?view=list')).toBe('spectrum');
-		expect(surface('/?view=')).toBe('spectrum');
-		expect(surface('/?view=Graph')).toBe('spectrum'); // case-sensitive opt-in
+	it('resolves an unrecognised or malformed view value to the graph default', () => {
+		expect(surface('/?view=graph')).toBe('graph'); // explicit, same as default
+		expect(surface('/?view=')).toBe('graph');
+		expect(surface('/?view=Spectrum')).toBe('graph'); // case-sensitive opt-in
+		expect(surface('/?view=nonsense')).toBe('graph');
 	});
 
-	it('keeps the spectrum for an unrelated parameter', () => {
-		expect(surface('/?template=restore-clinic-hours')).toBe('spectrum');
+	it('keeps the graph default for an unrelated parameter', () => {
+		expect(surface('/?template=restore-clinic-hours')).toBe('graph');
 	});
 
 	it('honours the list opt-out alongside unrelated parameters', () => {
@@ -66,11 +69,12 @@ describe('selectLandingSurface', () => {
 	it('renders exactly one surface for every URL (the three are mutually exclusive)', () => {
 		for (const href of [
 			'/',
-			'/?view=graph',
+			'/?view=spectrum',
+			'/?view=list',
 			'/?spectrum=0',
 			'/?spectrum=1',
-			'/?view=graph&spectrum=0',
-			'/?view=list',
+			'/?view=spectrum&spectrum=0',
+			'/?view=nonsense',
 			'/?template=x'
 		]) {
 			expect(['graph', 'spectrum', 'list']).toContain(surface(href));
@@ -79,22 +83,20 @@ describe('selectLandingSurface', () => {
 });
 
 describe('shouldShowSpectrum', () => {
-	it('is true exactly when the selected surface is the spectrum', () => {
-		expect(showsSpectrum('/')).toBe(true); // default
-		expect(showsSpectrum('/?spectrum=1')).toBe(true);
+	it('is true exactly when the spectrum is the explicitly selected surface', () => {
+		expect(showsSpectrum('/?view=spectrum')).toBe(true);
 	});
 
-	it('is false on the list opt-out (?spectrum=0)', () => {
+	it('is false on the graph default (the bare landing path)', () => {
+		expect(showsSpectrum('/')).toBe(false);
+	});
+
+	it('is false on either list opt-out (?view=list, ?spectrum=0)', () => {
+		expect(showsSpectrum('/?view=list')).toBe(false);
 		expect(showsSpectrum('/?spectrum=0')).toBe(false);
 	});
 
-	it('is false when the graph view swap takes over (?view=graph)', () => {
-		// The graph is its own surface, not the spectrum — the spectrum predicate
-		// must yield so the page does not render both.
-		expect(showsSpectrum('/?view=graph')).toBe(false);
-	});
-
-	it('honours the opt-out alongside unrelated parameters', () => {
-		expect(showsSpectrum('/?template=restore-clinic-hours&spectrum=0')).toBe(false);
+	it('is false for an unrelated parameter (the graph is the default)', () => {
+		expect(showsSpectrum('/?template=restore-clinic-hours')).toBe(false);
 	});
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -101,6 +101,7 @@ export default defineConfig({
 			'tests/unit/components/SpectrumLandscape.test.ts',
 			'tests/unit/components/SpectrumOverview.test.ts',
 			'tests/unit/components/RelationGraph.test.ts',
+			'tests/unit/components/DescentDive.test.ts',
 			// Behavioral test for the delivery-gate conversion prompt — requires
 			// the components-lane config for @testing-library/svelte rendering.
 			'tests/unit/components/DeliveryGateNotice.test.ts',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -68,7 +68,7 @@ export default defineConfig({
 	},
 	test: {
 		// File patterns
-		include: ['tests/**/*.{test,spec}.{js,ts}'],
+		include: ['tests/**/*.{test,spec}.{js,ts}', 'convex/**/*.{test,spec}.{js,ts}'],
 		exclude: [
 			// Exclude Playwright E2E tests (UI-based)
 			'tests/e2e/basic-functionality.spec.ts',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -100,6 +100,7 @@ export default defineConfig({
 			'tests/unit/components/DomainBand.test.ts',
 			'tests/unit/components/SpectrumLandscape.test.ts',
 			'tests/unit/components/SpectrumOverview.test.ts',
+			'tests/unit/components/RelationGraph.test.ts',
 			// Behavioral test for the delivery-gate conversion prompt — requires
 			// the components-lane config for @testing-library/svelte rendering.
 			'tests/unit/components/DeliveryGateNotice.test.ts',


### PR DESCRIPTION
Replaces the landing's discovery surface with a **navigate-by-meaning relatedness graph** — templates as hue nodes; edges are measured semantic twins (mean-centered cosine, leave-one-out-robust) + civic-family kin + shared tag-concept; honest loners at the rim; focal-node highlight; shared descent dive; search-to-center; a mobile focus-centered view.

**The graph is now the `/` default** (founder decision); the spectrum moves to `?view=spectrum`, the list to `?view=list` / `?spectrum=0`. A dynamic honesty caption ('N concerns · K measured kinships so far — the map fills as the commons grows', live-derived) sets expectations as the front door.

Built via a do→review hypergraph (5 gates, 14 tasks). The adversarial review caught real defects the green unit tests masked: a twin-edge threshold that emitted zero edges live, an embedding leak via public queries, a graph that painted dimmed-at-rest. All fixed in-cycle.

**Honest caveat:** the perceptual dwell (R-03) soft-vetoed making this the default at the current 10-template corpus (edge-honest + alive on interaction, but sparse at rest); the founder overrode it. The surface blooms with the corpus at zero code change; reverting the default is a one-line flip in `landing-surface.ts`.

Embeddings stay server-only; no foreign graph lib; deterministic SSR-safe layout. 20 commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added relatedness graph view to discover and explore connected templates by shared topics, tag concepts, and domains
  * Introduced automatic concept clustering from template tags
  * Added modal-based template preview overlay with focus management and keyboard navigation
  * Three distinct template discovery surfaces: graph (default), spectrum, and list views

* **Tests**
  * Comprehensive test coverage for relatedness computation, tag concept clustering, graph layout, and UI interactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->