### PR TITLE
ci(brutalist): track @v1 moving tag (fleet auto-update)

### DIFF
--- a/.github/workflows/brutalist-review.yml
+++ b/.github/workflows/brutalist-review.yml
@@ -38,7 +38,9 @@ jobs:
           mkdir -p "$HOME/.codex"
           printf '[features]\nimage_generation = false\n' > "$HOME/.codex/config.toml"
       - name: Brutalist review
-        uses: ejmockler/brutalist-mcp/packages/github-action@93b4ec30bf6987970432d7d53662aa28d390a9b0 # v1.15.0
+        # Tracks the moving @v1 tag (repointed to each release upstream by the
+        # move-tags automation) so this repo auto-updates to the latest action.
+        uses: ejmockler/brutalist-mcp/packages/github-action@v1
         env:
           BRUTALIST_TIMEOUT: "900000"
           BRUTALIST_ORCHESTRATOR_TIMEOUT_MS: "2100000"


### PR DESCRIPTION
## What

Switch the brutalist review action pin from the immutable v1.15.0 commit SHA to the moving **`@v1`** tag, so this repo auto-updates to each new release. The upstream `move-tags` job repoints `@v1` / `@v1.MINOR` on every stable release; `@v1` currently resolves to **v1.15.1**.

## Tradeoff (deliberate)

This reverses the prior "credentialed action stays SHA-pinned" hardening — the action receives `github.token` + OAuth secrets and `@v1` is mutable. Accepted because the action, its release pipeline, and this repo share the **same owner**, so the trust root is unchanged, and fleet-wide auto-update is the goal. Re-pinning to a SHA is a one-line revert if ever needed.

No behavior change beyond auto-tracking; maxTurns stays 50 (v1.15.0+).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated code review process to use dynamic version tracking for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->