### PR TITLE
test(crypto): de-flake BIP39 checksum typo-detection test

### DIFF
--- a/tests/unit/crypto/org-pii-encryption.test.ts
+++ b/tests/unit/crypto/org-pii-encryption.test.ts
@@ -144,10 +144,23 @@ describe('Org PII Encryption', () => {
 
 		it('BIP39 checksum detects typos', async () => {
 			const { words } = await generateRecoveryKey();
-			// Corrupt one word
-			const corrupted = [...words];
-			corrupted[0] = corrupted[0] === 'abandon' ? 'ability' : 'abandon';
-			await expect(mnemonicToRecoveryKey(corrupted)).rejects.toThrow('checksum failed');
+			const word0 = wordlist.indexOf(words[0]);
+
+			// A single-word typo fails the 8-bit checksum 255/256 of the time, so
+			// corrupting once and hoping is a 1/256 flake. Find a corruption that is
+			// actually rejected — at least one alternative word always is.
+			let rejected = false;
+			for (let off = 1; off < wordlist.length && !rejected; off++) {
+				const corrupted = [...words];
+				corrupted[0] = wordlist[(word0 + off) % wordlist.length];
+				try {
+					await mnemonicToRecoveryKey(corrupted);
+				} catch (e) {
+					expect((e as Error).message).toContain('checksum failed');
+					rejected = true;
+				}
+			}
+			expect(rejected).toBe(true);
 		});
 
 		it('wrap → unwrap round-trip', async () => {


### PR DESCRIPTION
## Problem

`tests/unit/crypto/org-pii-encryption.test.ts` corrupts one word of a **randomly generated** mnemonic and asserts the 8-bit BIP39 checksum always rejects it. A single-word swap re-derives a pseudo-random checksum that coincidentally matches the stored byte ~**1/256** of the time, so the promise resolves instead of rejecting — a ~0.4%-per-run CI flake. It hit PR #44: `test` failed there, then the identical code passed on `main`.

## Fix

Iterate candidate corruptions until one is actually rejected (2046/2047 always are), making the test deterministic while preserving its intent (a typo'd word is caught with the `checksum failed` error).

## Verification

- Full file: 23/23 pass
- Fixed test run **25× with fresh random entropy each: 25/25 pass**
- Test-only change, no production code touched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of the recovery word checksum validation test to reduce flakiness and ensure more consistent test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->