### PR TITLE
Individual create→send→verify UX: ladder, send peak, honest proof, address-first verification

### DIFF
--- a/src/lib/components/action/ComposePane.svelte
+++ b/src/lib/components/action/ComposePane.svelte
@@ -90,10 +90,15 @@
     }
   });
 
-  // Attestation text (only for Tier 2+)
+  // The sender's own signature line (only for Tier 2+). This is the SENDER
+  // attesting to their standing — not a recipient-facing label and not a claim
+  // of cryptographic proof. This path has NO verification method, so it uses the
+  // generic SSOT fallback ("Verified constituent") rather than "Verified resident"
+  // — the latter would overclaim residency for the self-reported (civic_api) case.
+  // Label-only: no /v/ URL here, since ComposePane has no credentialHash.
   const attestationText = $derived(
     trustTier >= 2
-      ? `Verified resident, ${districtName}\nCryptographic proof of residency`
+      ? `Verified constituent · ${districtName}`
       : undefined
   );
 

--- a/src/lib/components/action/SendConfirmation.svelte
+++ b/src/lib/components/action/SendConfirmation.svelte
@@ -55,7 +55,13 @@
 				: `${count} recipients`
 	);
 
+	// Guard the double-click race: confirmSent() calls onConfirmSent() (which now also
+	// fires the delivery-record POST) BEFORE `stage` flips, so two rapid clicks queued
+	// before the re-render could double-fire it. One-shot.
+	let hasConfirmed = $state(false);
 	function confirmSent() {
+		if (hasConfirmed) return;
+		hasConfirmed = true;
 		onConfirmSent(); // mark contact FIRST, then advance to the success stage
 		stage = 'sent';
 	}

--- a/src/lib/components/action/SendConfirmation.svelte
+++ b/src/lib/components/action/SendConfirmation.svelte
@@ -1,0 +1,308 @@
+<!--
+  SendConfirmation — the engineered send PEAK + the honesty confirm.
+
+  A mailto handoff only tells us the mail app was OPENED, never that mail was
+  sent. So instead of optimistically marking "contacted" on a tab-return timer,
+  this surface asks — "did it send?" — and only an explicit Yes marks contact.
+  That same moment is the peak: it names the consequence, surfaces the proof the
+  message carried (a real /v/[hash] receipt for verified senders, sender-framed),
+  and offers the forward action (share so others send too). No-mail-client users
+  get the copy path (with a manual-select fallback if the clipboard is denied).
+
+  Principle: peak-end + goal-gradient at the finish; affordance/signal honesty
+  (never claim delivery the system can't observe).
+-->
+<script lang="ts">
+	import { Check, Copy, Share2, ExternalLink, X } from '@lucide/svelte';
+
+	let {
+		recipientNames = [],
+		/** The attestation line the message carried, e.g. "Verified resident · CA-12". */
+		attestationLine = undefined,
+		/** Real receipt link (/v/[hash]) — only present for verified senders. */
+		proofUrl = undefined,
+		/** Campaign URL for the share-forward. */
+		shareUrl,
+		/** Full message text for the copy fallback. */
+		messageText = '',
+		/** Called only on an explicit "Yes, it sent" — this is what marks contact. */
+		onConfirmSent,
+		onClose
+	}: {
+		recipientNames?: string[];
+		attestationLine?: string;
+		proofUrl?: string;
+		shareUrl: string;
+		messageText?: string;
+		onConfirmSent: () => void;
+		onClose: () => void;
+	} = $props();
+
+	let stage = $state<'confirm' | 'sent' | 'copy'>('confirm');
+	let copied = $state(false);
+	let copyFailed = $state(false);
+	let shared = $state(false);
+	let cardEl = $state<HTMLElement>();
+
+	const count = $derived(recipientNames.length);
+	const who = $derived(
+		count === 0
+			? 'your recipient'
+			: count <= 2
+				? recipientNames.join(' and ')
+				: `${count} recipients`
+	);
+
+	function confirmSent() {
+		onConfirmSent(); // mark contact FIRST, then advance to the success stage
+		stage = 'sent';
+	}
+	function notSent() {
+		stage = 'copy';
+	}
+	async function copyMessage() {
+		try {
+			await navigator.clipboard.writeText(messageText);
+			copied = true;
+			copyFailed = false;
+		} catch {
+			copied = false;
+			copyFailed = true; // the textarea is the manual fallback
+		}
+	}
+	async function share() {
+		try {
+			if (typeof navigator !== 'undefined' && navigator.share) {
+				await navigator.share({ url: shareUrl });
+				shared = true;
+			} else {
+				await navigator.clipboard.writeText(shareUrl);
+				shared = true;
+			}
+		} catch {
+			/* user dismissed the share sheet / clipboard denied — no-op */
+		}
+	}
+
+	// Move focus INTO the dialog on open + whenever the stage (and its buttons) change.
+	$effect(() => {
+		stage; // re-run on stage change
+		cardEl?.querySelector<HTMLElement>('button:not(.sc-close)')?.focus();
+	});
+
+	// Escape closes; Tab is trapped within the dialog so keyboard users can't reach
+	// the page behind (which also prevents a concurrent send orphaning an in-flight card).
+	function onKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') {
+			onClose();
+			return;
+		}
+		if (e.key !== 'Tab' || !cardEl) return;
+		const f = Array.from(
+			cardEl.querySelectorAll<HTMLElement>(
+				'button, a[href], textarea, [tabindex]:not([tabindex="-1"])'
+			)
+		);
+		if (f.length === 0) return;
+		const first = f[0];
+		const last = f[f.length - 1];
+		const active = document.activeElement;
+		if (!cardEl.contains(active as Node)) {
+			e.preventDefault();
+			first.focus();
+		} else if (e.shiftKey && active === first) {
+			e.preventDefault();
+			last.focus();
+		} else if (!e.shiftKey && active === last) {
+			e.preventDefault();
+			first.focus();
+		}
+	}
+</script>
+
+<svelte:window on:keydown={onKeydown} />
+
+<div class="sc-overlay" role="dialog" aria-modal="true" aria-labelledby="sc-title">
+	<div class="sc-card" bind:this={cardEl}>
+		<button type="button" class="sc-close" aria-label="Close" onclick={onClose}>
+			<X class="h-4 w-4" />
+		</button>
+
+		{#if stage === 'confirm'}
+			<h2 id="sc-title" class="sc-title">We opened your mail app for {who}.</h2>
+			<p class="sc-sub">Send it from there, then let us know — we can't see your mail app, so a real "sent" only counts when you confirm.</p>
+			<div class="sc-actions">
+				<button type="button" class="sc-btn sc-btn--primary" onclick={confirmSent}>Yes, it sent</button>
+				<button type="button" class="sc-btn sc-btn--ghost" onclick={notSent}>No — copy it instead</button>
+			</div>
+		{:else if stage === 'sent'}
+			<div class="sc-peak-mark"><Check class="h-5 w-5" /></div>
+			<h2 id="sc-title" class="sc-title">Sent to {who}.</h2>
+			{#if attestationLine}
+				<p class="sc-proof">
+					Your message carried <strong>{attestationLine}</strong>.
+					{#if proofUrl}
+						<a class="sc-proof-link" href={proofUrl} target="_blank" rel="noopener">
+							View receipt <ExternalLink class="h-3 w-3" />
+						</a>
+					{/if}
+				</p>
+			{/if}
+			<div class="sc-actions">
+				<button type="button" class="sc-btn sc-btn--primary" onclick={share}>
+					<Share2 class="h-4 w-4" />
+					{shared ? 'Link copied — share it' : 'Share so others send too'}
+				</button>
+				<button type="button" class="sc-btn sc-btn--ghost" onclick={onClose}>Done</button>
+			</div>
+		{:else}
+			<h2 id="sc-title" class="sc-title">Copy your message</h2>
+			<p class="sc-sub">Paste it into any email client and send to {who}.</p>
+			<textarea class="sc-copy-text" readonly rows="5" value={messageText}></textarea>
+			<div class="sc-actions">
+				<button type="button" class="sc-btn sc-btn--primary" onclick={copyMessage}>
+					<Copy class="h-4 w-4" />
+					{copyFailed ? 'Select the text above to copy' : copied ? 'Copied' : 'Copy message'}
+				</button>
+				<button type="button" class="sc-btn sc-btn--ghost" onclick={confirmSent}>I sent it</button>
+			</div>
+		{/if}
+	</div>
+</div>
+
+<style>
+	.sc-overlay {
+		position: fixed;
+		inset: 0;
+		z-index: 1010;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: 1rem;
+		background: oklch(0.2 0.02 250 / 0.45);
+		backdrop-filter: blur(2px);
+	}
+	.sc-card {
+		position: relative;
+		width: 100%;
+		max-width: 26rem;
+		background: #fff;
+		border-radius: 1rem;
+		padding: 1.75rem 1.5rem 1.5rem;
+		box-shadow: 0 20px 50px -12px oklch(0.2 0.02 250 / 0.35);
+		text-align: center;
+		animation: sc-rise 200ms ease;
+	}
+	@keyframes sc-rise {
+		from { opacity: 0; transform: translateY(8px); }
+		to { opacity: 1; transform: translateY(0); }
+	}
+	.sc-close {
+		position: absolute;
+		top: 0.75rem;
+		right: 0.75rem;
+		display: inline-flex;
+		padding: 0.375rem;
+		border: none;
+		background: none;
+		color: oklch(0.6 0.012 250);
+		cursor: pointer;
+		border-radius: 0.5rem;
+	}
+	.sc-close:hover { color: oklch(0.3 0.02 250); }
+	.sc-close:focus-visible { outline: 2px solid var(--coord-verified, #10b981); outline-offset: 2px; }
+	.sc-peak-mark {
+		width: 2.75rem;
+		height: 2.75rem;
+		margin: 0 auto 0.75rem;
+		border-radius: 9999px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: var(--coord-verified, #10b981);
+		color: #fff;
+	}
+	.sc-title {
+		margin: 0;
+		font-family: 'Satoshi', system-ui, sans-serif;
+		font-size: 1.125rem;
+		font-weight: 600;
+		color: oklch(0.25 0.02 250);
+		line-height: 1.35;
+	}
+	.sc-sub {
+		margin: 0.625rem 0 0;
+		font-size: 0.8125rem;
+		line-height: 1.5;
+		color: oklch(0.5 0.015 250);
+	}
+	.sc-proof {
+		margin: 0.75rem 0 0;
+		font-size: 0.8125rem;
+		line-height: 1.5;
+		color: oklch(0.45 0.015 250);
+	}
+	.sc-proof strong { color: oklch(0.3 0.02 250); font-weight: 600; }
+	.sc-proof-link {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.2rem;
+		margin-left: 0.25rem;
+		color: var(--coord-verified, #10b981);
+		font-weight: 600;
+		text-decoration: none;
+		white-space: nowrap;
+	}
+	.sc-proof-link:hover { text-decoration: underline; }
+	.sc-copy-text {
+		width: 100%;
+		margin-top: 0.875rem;
+		padding: 0.625rem 0.75rem;
+		border: 1px solid oklch(0.88 0.01 250);
+		border-radius: 0.5rem;
+		background: oklch(0.985 0.003 250);
+		font-size: 0.75rem;
+		line-height: 1.5;
+		color: oklch(0.35 0.015 250);
+		resize: none;
+		text-align: left;
+	}
+	.sc-copy-text:focus-visible { outline: 2px solid var(--coord-verified, #10b981); outline-offset: 1px; }
+	.sc-actions {
+		margin-top: 1.25rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+	.sc-btn {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		gap: 0.4rem;
+		padding: 0.625rem 1rem;
+		border-radius: 0.625rem;
+		font-family: 'Satoshi', system-ui, sans-serif;
+		font-weight: 600;
+		font-size: 0.875rem;
+		cursor: pointer;
+		transition: background-color 150ms ease, border-color 150ms ease;
+	}
+	.sc-btn--primary {
+		border: none;
+		background: var(--coord-verified, #10b981);
+		color: #fff;
+	}
+	.sc-btn--primary:hover { background: oklch(0.62 0.13 165); }
+	.sc-btn--ghost {
+		border: 1px solid oklch(0.86 0.01 250);
+		background: #fff;
+		color: oklch(0.35 0.02 250);
+	}
+	.sc-btn--ghost:hover { border-color: oklch(0.7 0.01 250); }
+	.sc-btn:focus-visible { outline: 2px solid var(--coord-verified, #10b981); outline-offset: 2px; }
+
+	@media (prefers-reduced-motion: reduce) {
+		.sc-card { animation: none; }
+		.sc-btn { transition: none; }
+	}
+</style>

--- a/src/lib/components/action/SendConfirmation.svelte
+++ b/src/lib/components/action/SendConfirmation.svelte
@@ -17,7 +17,9 @@
 
 	let {
 		recipientNames = [],
-		/** The attestation line the message carried, e.g. "Verified resident · CA-12". */
+		/** The attestation line the message carried — the SSOT tier label + district,
+		 *  e.g. "Self-reported constituent (Census geocoder) · CA-12" or
+		 *  "Address-resolved constituent (mDL) · CA-12". */
 		attestationLine = undefined,
 		/** Real receipt link (/v/[hash]) — only present for verified senders. */
 		proofUrl = undefined,

--- a/src/lib/components/activation/CreationSpark.svelte
+++ b/src/lib/components/activation/CreationSpark.svelte
@@ -11,16 +11,31 @@
 	import { onMount } from 'svelte';
 	import { ArrowRight, Clock } from '@lucide/svelte';
 	import { templateDraftStore, formatTimeAgo } from '$lib/stores/templateDraft';
+	import { matchExistingCampaigns } from '$lib/core/topic/template-text-match';
 
 	import type { Snippet } from 'svelte';
+	import type { Template } from '$lib/types/template';
 
 	// Props
 	interface Props {
 		context?: Snippet;
 		onactivate?: (data: { initialText: string; draftId?: string }) => void;
+		/**
+		 * Full public template corpus — the homepage already loads this via
+		 * `templates.listPublic`. Passed in so the front-door type-ahead can match
+		 * the typed grievance against EXISTING campaigns client-side (no fetch).
+		 * Optional so other mounts (and tests) need not supply it.
+		 */
+		matchTemplates?: Template[];
+		/**
+		 * Invoked when the user picks an existing campaign from the inline matches.
+		 * The host wires this to its existing send path, so the deferred
+		 * onboarding/address auth wall fires at send time exactly as today.
+		 */
+		onMatchSelect?: (template: Template) => void;
 	}
 
-	let { context, onactivate }: Props = $props();
+	let { context, onactivate, matchTemplates, onMatchSelect }: Props = $props();
 
 	let issueText = $state('');
 	let isFocused = $state(false);
@@ -108,6 +123,28 @@
 	const hasContent = $derived(issueText.trim().length > 0);
 	const isActivated = $derived(hasContent || isFocused);
 	const hasDraft = $derived(activeDraftId !== null);
+
+	// Search-first front door: surface EXISTING campaigns matching the typed text.
+	// Debounced so we don't re-score on every keystroke (mirrors the debounce
+	// posture used elsewhere); the rescore runs ~250ms after typing settles.
+	let debouncedText = $state('');
+	$effect(() => {
+		const next = issueText;
+		const handle = setTimeout(() => {
+			debouncedText = next;
+		}, 250);
+		return () => clearTimeout(handle);
+	});
+
+	// Only match in the ACTIVE editable state (never over the read-only draft
+	// artifact) and only once the surface is engaged. Honest empty by
+	// construction: `matchExistingCampaigns` returns [] when nothing clears the
+	// score floor, so the block below simply doesn't render — no fabricated match.
+	const matches = $derived(
+		!hasDraft && (isFocused || hasContent)
+			? matchExistingCampaigns(matchTemplates ?? [], debouncedText, { limit: 3 })
+			: []
+	);
 
 	// Check draft state for button text accuracy
 	const draftHasSuggestion = $derived.by(() => {
@@ -255,6 +292,40 @@
 				</p>
 			{/if}
 		</div>
+
+		<!--
+			Search-first matches — EXISTING campaigns whose curated facets match the
+			typed text. Secondary to "Continue" (author new), which stays the primary
+			co-present action. Only renders when ≥1 real match clears the score floor;
+			absent otherwise (no fabricated match, no false scarcity). The heading
+			frames these as existing campaigns matched to the text (observable), never
+			"popular"/"trending" (unobservable).
+		-->
+		{#if matches.length > 0}
+			<div class="spark-matches" role="region" aria-label="Existing campaigns matching what you wrote">
+				<p class="matches-head">Already a campaign on this?</p>
+				<ul class="matches-list">
+					{#each matches as match (match.template.id)}
+						<li class="match-row">
+							<span class="match-info">
+								<span class="match-title">{match.template.title}</span>
+								{#if match.template.send_count}
+									<span class="match-signal">{match.template.send_count.toLocaleString()} sent</span>
+								{/if}
+							</span>
+							<button
+								type="button"
+								class="match-send"
+								onclick={() => onMatchSelect?.(match.template)}
+							>
+								<span class="match-send-text">send to this one</span>
+								<ArrowRight class="match-send-icon" />
+							</button>
+						</li>
+					{/each}
+				</ul>
+			</div>
+		{/if}
 	</div>
 
 	<!-- Or browse existing -->
@@ -698,6 +769,112 @@
 		}
 	}
 
+	/*
+	 * Search-first matches — low-emphasis block beneath the writing surface.
+	 * Quiet by design so "Continue" (author new) stays the primary action;
+	 * these are a secondary "or send to an existing one" affordance.
+	 */
+	.spark-matches {
+		display: flex;
+		flex-direction: column;
+		gap: 0.375rem;
+		padding-top: 0.25rem;
+	}
+
+	.matches-head {
+		font-family: 'Satoshi', system-ui, sans-serif;
+		font-size: 0.75rem;
+		font-weight: 600;
+		color: oklch(0.45 0.02 250);
+		margin: 0;
+	}
+
+	.matches-list {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	.match-row {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.75rem;
+		padding: 0.5rem 0.625rem;
+		border-radius: 8px;
+		border: 1px solid oklch(0.9 0.01 250);
+		background: oklch(0.99 0.005 250);
+	}
+
+	.match-info {
+		display: flex;
+		flex-direction: column;
+		gap: 0.125rem;
+		min-width: 0;
+	}
+
+	.match-title {
+		font-family: 'Satoshi', system-ui, sans-serif;
+		font-size: 0.8125rem;
+		font-weight: 500;
+		line-height: 1.3;
+		color: oklch(0.3 0.02 250);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		display: -webkit-box;
+		-webkit-line-clamp: 2;
+		line-clamp: 2;
+		-webkit-box-orient: vertical;
+	}
+
+	.match-signal {
+		font-family: 'JetBrains Mono', ui-monospace, monospace;
+		font-feature-settings: 'tnum';
+		font-size: 0.625rem;
+		font-weight: 500;
+		color: var(--coord-verified, #10b981);
+	}
+
+	.match-send {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.25rem;
+		flex-shrink: 0;
+		padding: 0.375rem 0.5rem;
+		border: none;
+		border-radius: 6px;
+		background: transparent;
+		font-family: 'Satoshi', system-ui, sans-serif;
+		font-size: 0.75rem;
+		font-weight: 600;
+		color: var(--coord-route-solid, #3bc4b8);
+		cursor: pointer;
+		white-space: nowrap;
+		transition: background 150ms ease-out;
+	}
+
+	.match-send:hover {
+		background: oklch(0.96 0.02 195);
+	}
+
+	.match-send:focus-visible {
+		outline: 2px solid var(--coord-route-solid, #3bc4b8);
+		outline-offset: 2px;
+	}
+
+	.match-send :global(.match-send-icon) {
+		width: 0.8125rem;
+		height: 0.8125rem;
+		transition: transform 150ms ease-out;
+	}
+
+	.match-send:hover :global(.match-send-icon) {
+		transform: translateX(2px);
+	}
+
 	/* Reduced motion */
 	@media (prefers-reduced-motion: reduce) {
 		.spark-actions {
@@ -709,6 +886,11 @@
 		}
 
 		.input-container {
+			transition: none;
+		}
+
+		.match-send,
+		.match-send :global(.match-send-icon) {
 			transition: none;
 		}
 	}

--- a/src/lib/components/auth/AddressVerificationFlow.svelte
+++ b/src/lib/components/auth/AddressVerificationFlow.svelte
@@ -1,17 +1,25 @@
 <!--
   AddressVerificationFlow.svelte
 
-  Dual-path Tier 2 verification flow: geolocation OR address-based.
+  Tier 2 verification flow. The flow opens directly on TRUE-address entry: there
+  is no method chooser. Congressional (CWC) delivery needs the constituent's real
+  name + address, so a district-only resolution (a geolocation pin / map pin) is
+  never deliverable. The privacy mechanisms run transparently underneath address
+  entry — the user just types their address.
 
-  When SHADOW_ATLAS_VERIFICATION is enabled (client-side path):
-    Path A: Browser geolocation → IPFS district lookup (no server call) → commitment
-    Path B: Manual address → server geocode only → IPFS district lookup → commitment
+  Privacy chain (SHADOW_ATLAS_VERIFICATION enabled — the production path):
+    Address → /api/location/resolve-address (self-hosted geocoder; logs the
+    district, never the address) → returns district + coordinates → the district
+    commitment is computed CLIENT-SIDE from those coordinates (resolveClientSide)
+    → confirm-district → handleConfirmDistrict mints the credential and stores the
+    full address ENCRYPTED on-device (ground vault + constituent-address cache) so
+    messages can be delivered to Congress without re-entry.
 
-  When disabled (legacy server-side path):
-    Path A: Browser geolocation → /api/location/resolve
-    Path B: Manual address → /api/location/resolve-address
+  Legacy server path (only when SHADOW_ATLAS_VERIFICATION is off): the same
+  /api/location/resolve-address response is consumed directly via
+  processResolveResponse.
 
-  Flow: path-select → [geolocating | address-input] → resolving → confirm-district → issuing-credential → complete
+  Flow: address-input → resolving → confirm-district → issuing-credential → complete
 
   ─── Re-grounding mode ───
 
@@ -37,12 +45,9 @@
 		AlertCircle,
 		Building2,
 		ChevronRight,
-		Navigation,
-		Lock,
-		Map
+		Lock
 	} from '@lucide/svelte';
 	import { storeCredential } from '$lib/core/identity/credential-store';
-	import { getBrowserGeolocation } from '$lib/core/location/browser-location';
 	import {
 		storeConstituentAddress,
 		clearConstituentAddress,
@@ -65,17 +70,13 @@
 	import { poseidon2Sponge24 } from '$lib/core/crypto/poseidon';
 	import { persistGroundVaultForAddress } from '$lib/core/identity/ground-vault-persistence';
 	import { trackAddressChanged } from '$lib/core/analytics/client';
-	import MapPinSelector from './MapPinSelector.svelte';
 	import RegroundingAddressCapture from './address-steps/RegroundingAddressCapture.svelte';
 	import { getJurisdictionLabels } from '$lib/core/locale/jurisdiction';
 
 	const jurisdictionLabels = getJurisdictionLabels();
 
 	type FlowStep =
-		| 'path-select'
-		| 'geolocating'
 		| 'address-input'
-		| 'map-pin'
 		| 'resolving'
 		| 'confirm-district'
 		| 'issuing-credential'
@@ -132,11 +133,13 @@
 		/^[A-Za-z]\d[A-Za-z]\s?\d[A-Za-z]\d$/.test(zipCode.trim()) ? 'CA' : 'US'
 	);
 
-	// Flow state. The re-grounding fallback path-select surface is address-only;
-	// on mount, re-grounding advances directly to address input.
-	let flowStep: FlowStep = $state('path-select');
+	// Flow state. The flow opens directly on true-address entry — there is no
+	// method chooser. Congressional (CWC) delivery needs the constituent's real
+	// name + address, so a district-only resolution is never sufficient; the
+	// privacy mechanisms (client-side district commitment, encrypted ground)
+	// run transparently underneath address entry.
+	let flowStep: FlowStep = $state('address-input');
 	let errorMessage: string = $state('');
-	let geoPermissionDenied: boolean = $state(false);
 
 	// Verification results
 	let verifiedDistrict: string = $state('');
@@ -151,8 +154,11 @@
 		district?: string;
 	}> = $state([]);
 
-	// Which verification path was chosen
-	let verificationMethod: 'browser' | 'address' = $state('browser');
+	// Verification is always address-based now (the location/map chooser was
+	// removed because neither captures the real address CWC delivery requires).
+	// There is no longer a 'browser' path; this is effectively a constant kept
+	// for readability at the captured-address site below.
+	const verificationMethod = 'address' as const;
 
 	// B-3: 24 district slots from IPFS (for Poseidon2 commitment)
 	let districtSlots: string[] = $state([]);
@@ -246,7 +252,6 @@
 	onMount(() => {
 		if (regroundingMode) {
 			flowStep = 'address-input';
-			verificationMethod = 'address';
 			emitRegroundingPhase('capture');
 		}
 	});
@@ -269,7 +274,7 @@
 		if (!ok || !data.resolved || !data.district) {
 			errorMessage =
 				(data.error as string) || 'Could not determine your district. Please try again.';
-			flowStep = verificationMethod === 'browser' ? 'path-select' : 'address-input';
+			flowStep = 'address-input';
 			return;
 		}
 
@@ -333,87 +338,11 @@
 	}
 
 	/**
-	 * Path A: Browser geolocation flow
-	 */
-	async function handleGeolocationPath() {
-		verificationMethod = 'browser';
-		resetCommitmentState();
-		flowStep = 'geolocating';
-		errorMessage = '';
-
-		try {
-			// Step 1: Get browser geolocation (returns LocationSignal with lat/lng only)
-			const signal = await getBrowserGeolocation();
-
-			if (!signal) {
-				// Permission denied or unavailable — auto-redirect to address path
-				geoPermissionDenied = true;
-				flowStep = 'address-input';
-				verificationMethod = 'address';
-				return;
-			}
-
-			const lat = signal.latitude;
-			const lng = signal.longitude;
-
-			if (lat == null || lng == null) {
-				geoPermissionDenied = true;
-				flowStep = 'address-input';
-				verificationMethod = 'address';
-				return;
-			}
-
-			flowStep = 'resolving';
-
-			// B-3: Client-side resolution (no server call) when feature flag enabled
-			if (clientSideEnabled) {
-				const resolved = await resolveClientSide(lat, lng);
-				if (resolved) return;
-				// Client-side failed — show error instead of leaking to server
-				errorMessage =
-					'Could not resolve your district from IPFS data. Please try the map pin option.';
-				flowStep = 'path-select';
-				return;
-			}
-
-			// Legacy server path (only when SHADOW_ATLAS_VERIFICATION is off)
-			const response = await fetch('/api/location/resolve', {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({
-					lat,
-					lng,
-					signal_type: 'browser',
-					confidence: 0.6
-				})
-			});
-
-			const data = await response.json();
-			// F-2.4 follow-up: capture geo-mode token (no addressHash) so the
-			// downstream verify-address call can satisfy the "coordinates
-			// require token" gate. Browser-geolocation path issues this from
-			// /api/location/resolve.
-			if (typeof data.addressToken === 'string') {
-				addressResolutionToken = data.addressToken;
-				addressResolutionHash = null;
-			}
-			processResolveResponse(data, response.ok);
-		} catch (err) {
-			console.error('[AddressVerificationFlow] Geolocation error:', err);
-			errorMessage = 'Location detection failed. Please enter your address instead.';
-			geoPermissionDenied = true;
-			flowStep = 'address-input';
-			verificationMethod = 'address';
-		}
-	}
-
-	/**
-	 * Path B: Address-based verification flow
+	 * Address-based verification — the single entry path.
 	 */
 	async function handleAddressPath() {
 		if (!isFormValid) return;
 
-		verificationMethod = 'address';
 		resetCommitmentState();
 		flowStep = 'resolving';
 		errorMessage = '';
@@ -503,7 +432,6 @@
 	async function handleConfirmDistrict() {
 		if (regroundingMode && !isFormValid) {
 			errorMessage = 'Enter the new address before re-grounding.';
-			verificationMethod = 'address';
 			flowStep = 'address-input';
 			emitRegroundingPhase('capture');
 			return;
@@ -537,12 +465,11 @@
 					slot_count: nonZeroSlots,
 					verification_method: 'shadow_atlas',
 					coordinates: commitmentCoordinates ?? undefined,
-					// F-2.4: forward the resolve-address (addr-mode) or
-					// /api/location/resolve (geo-mode) token. Server requires
-					// SOME token whenever coordinates are supplied; the
-					// addressHash is forwarded only when present (manual-address
-					// path). The mode is encoded in the token itself, so server
-					// chooses the right validation branch.
+					// F-2.4: forward the resolve-address (addr-mode) token. This
+					// flow only ever mints an addr-mode token; the server requires
+					// SOME token whenever coordinates are supplied, and the
+					// addressHash always accompanies the addr-mode token, so it is
+					// forwarded here as well.
 					...(addressResolutionToken
 						? {
 								address_token: addressResolutionToken,
@@ -825,32 +752,6 @@
 		onComplete?.({ district: verifiedDistrict, method });
 	}
 
-	function handleSelectAddressPath() {
-		verificationMethod = 'address';
-		resetCommitmentState();
-		geoPermissionDenied = false;
-		flowStep = regroundingMode ? 'address-input' : clientSideEnabled ? 'map-pin' : 'address-input';
-	}
-
-	/**
-	 * Path B (client-side): Map pin selection flow.
-	 * User drops a pin on the map. This path does not capture address text and
-	 * is therefore unavailable for re-grounding.
-	 */
-	async function handleMapPinSelect(coords: { lat: number; lng: number }) {
-		verificationMethod = 'address';
-		resetCommitmentState();
-		flowStep = 'resolving';
-		errorMessage = '';
-
-		const resolved = await resolveClientSide(coords.lat, coords.lng);
-		if (!resolved) {
-			errorMessage =
-				'Could not determine your district from this location. Please try a different spot or use device location.';
-			flowStep = 'map-pin';
-		}
-	}
-
 	function handleKeydown(event: KeyboardEvent) {
 		if (event.key === 'Enter' && isFormValid && flowStep === 'address-input') {
 			handleAddressPath();
@@ -859,17 +760,6 @@
 
 	function handleCancel() {
 		onCancel?.();
-	}
-
-	function handleBack() {
-		errorMessage = '';
-		geoPermissionDenied = false;
-		resetCommitmentState();
-		if (regroundingMode) {
-			handleCancel();
-			return;
-		}
-		flowStep = 'path-select';
 	}
 
 	function handleEditAddress() {
@@ -888,15 +778,12 @@
 	<!-- Step Indicator (suppressed in re-grounding — the ceremony is the progress) -->
 	{#if !regroundingMode}
 		<div class="mb-6 flex items-center justify-center gap-2">
-			{#each ['path-select', 'confirm-district', 'complete'] as step, i}
+			{#each ['address-input', 'confirm-district', 'complete'] as step, i}
 				{@const stepLabels = ['Verify', 'Confirm', 'Done']}
-				{@const stepIndex = ['path-select', 'confirm-district', 'complete'].indexOf(flowStep)}
+				{@const stepIndex = ['address-input', 'confirm-district', 'complete'].indexOf(flowStep)}
 				{@const isActive =
 					i <= stepIndex ||
-					((flowStep === 'geolocating' ||
-						flowStep === 'address-input' ||
-						flowStep === 'resolving') &&
-						i === 0) ||
+					(flowStep === 'resolving' && i === 0) ||
 					(flowStep === 'issuing-credential' && i <= 1)}
 				<div class="flex items-center gap-2">
 					<div
@@ -927,8 +814,8 @@
 		</div>
 	{/if}
 
-	<!-- PATH SELECT STEP -->
-	{#if flowStep === 'path-select'}
+	<!-- ADDRESS INPUT STEP — the single entry point into verification -->
+	{#if flowStep === 'address-input'}
 		{#if regroundingMode}
 			<RegroundingAddressCapture
 				bind:streetAddress={street}
@@ -937,169 +824,6 @@
 				bind:zipCode
 				{detectedCountry}
 				{errorMessage}
-				{geoPermissionDenied}
-				onSubmit={handleAddressPath}
-				onCancel={handleCancel}
-				onKeydown={handleKeydown}
-			/>
-		{:else}
-			<div class="space-y-5">
-				<div class="text-center">
-					<div
-						class="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-emerald-100"
-					>
-						<MapPin class="h-6 w-6 text-emerald-600" />
-					</div>
-					<h3 class="text-lg font-semibold text-slate-900">Verify Your District</h3>
-					<p class="mt-1 text-sm text-slate-600">
-						Choose how to confirm your {jurisdictionLabels.legislativeAdjective} district.
-					</p>
-				</div>
-
-				<div class="space-y-3">
-					<!-- Option A: Use my location -->
-					<button
-						type="button"
-						class="flex w-full cursor-pointer items-start gap-4 rounded-md border border-slate-200 p-5 text-left transition-all hover:border-emerald-300 hover:bg-emerald-50/30"
-						onclick={handleGeolocationPath}
-					>
-						<div
-							class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-emerald-100"
-						>
-							<Navigation class="h-5 w-5 text-emerald-600" />
-						</div>
-						<div class="min-w-0 flex-1">
-							<p class="text-sm font-semibold text-slate-900">Use my location</p>
-							<p class="mt-0.5 text-xs text-slate-500">
-								Quick verification using your device's location
-							</p>
-						</div>
-						<ChevronRight class="mt-2.5 h-4 w-4 shrink-0 text-slate-400" />
-					</button>
-
-					<!-- Option B: Choose on map (client-side) or Enter address (legacy) -->
-					<button
-						type="button"
-						class="flex w-full cursor-pointer items-start gap-4 rounded-md border border-slate-200 p-5 text-left transition-all hover:border-emerald-300 hover:bg-emerald-50/30"
-						onclick={handleSelectAddressPath}
-					>
-						<div
-							class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-emerald-100"
-						>
-							{#if clientSideEnabled}
-								<Map class="h-5 w-5 text-emerald-600" />
-							{:else}
-								<Building2 class="h-5 w-5 text-emerald-600" />
-							{/if}
-						</div>
-						<div class="min-w-0 flex-1">
-							{#if clientSideEnabled}
-								<p class="text-sm font-semibold text-slate-900">Choose on map</p>
-								<p class="mt-0.5 text-xs text-slate-500">
-									Drop a pin to resolve your district without typing an address
-								</p>
-							{:else}
-								<p class="text-sm font-semibold text-slate-900">Enter my address</p>
-								<p class="mt-0.5 text-xs text-slate-500">
-									Verify with your home address for constituency proof
-								</p>
-							{/if}
-						</div>
-						<ChevronRight class="mt-2.5 h-4 w-4 shrink-0 text-slate-400" />
-					</button>
-				</div>
-
-				<!-- Privacy note -->
-				<div class="flex items-center justify-center gap-1.5">
-					<Lock class="h-3 w-3 text-emerald-700" />
-					<p class="text-xs font-medium text-emerald-700">
-						{#if clientSideEnabled}
-							Location and map paths avoid address entry; server verification checks the selected
-							point against the district commitment.
-						{:else}
-							Your address is matched to a district, then saved only as encrypted ground state for
-							verified delivery.
-						{/if}
-					</p>
-				</div>
-
-				{#if onCancel}
-					<button
-						type="button"
-						class="w-full text-center text-sm text-slate-500 transition-colors hover:text-slate-700"
-						onclick={handleCancel}
-					>
-						Cancel
-					</button>
-				{/if}
-			</div>
-		{/if}
-
-		<!-- GEOLOCATING STEP (loading) -->
-	{:else if flowStep === 'geolocating'}
-		{#if regroundingMode}
-			<section class="py-6" aria-live="polite">
-				<div class="mb-5">
-					<p class="font-mono text-[10px] text-slate-500 uppercase" style="letter-spacing: 0.22em">
-						New ground
-					</p>
-					<h2
-						class="mt-1.5 text-base font-medium text-slate-900"
-						style="font-family: 'Satoshi', system-ui, sans-serif"
-					>
-						Awaiting location permission
-					</h2>
-				</div>
-				<div
-					class="flex items-center gap-3 border-t border-b border-dotted border-slate-300 py-4 text-sm text-slate-500"
-				>
-					<Loader2 class="h-4 w-4 shrink-0 animate-spin text-slate-500" />
-					<span>Please allow location access when prompted.</span>
-				</div>
-			</section>
-		{:else}
-			<div class="flex flex-col items-center justify-center py-12 text-center">
-				<div class="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-emerald-100">
-					<Loader2 class="h-8 w-8 animate-spin text-emerald-600" />
-				</div>
-				<h3 class="text-lg font-semibold text-slate-900">Detecting Location</h3>
-				<p class="mt-2 text-sm text-slate-600">Please allow location access when prompted...</p>
-			</div>
-		{/if}
-
-		<!-- MAP PIN STEP (client-side, privacy-preserving) -->
-	{:else if flowStep === 'map-pin'}
-		{#if regroundingMode}
-			<RegroundingAddressCapture
-				bind:streetAddress={street}
-				bind:city
-				bind:stateCode
-				bind:zipCode
-				{detectedCountry}
-				errorMessage={errorMessage ||
-					'Verified address changes require address text, not a map pin.'}
-				{geoPermissionDenied}
-				onSubmit={handleAddressPath}
-				onCancel={handleCancel}
-				onKeydown={handleKeydown}
-			/>
-		{:else}
-			<div class="space-y-4">
-				<MapPinSelector onSelect={handleMapPinSelect} onCancel={handleBack} />
-			</div>
-		{/if}
-
-		<!-- ADDRESS INPUT STEP -->
-	{:else if flowStep === 'address-input'}
-		{#if regroundingMode}
-			<RegroundingAddressCapture
-				bind:streetAddress={street}
-				bind:city
-				bind:stateCode
-				bind:zipCode
-				{detectedCountry}
-				{errorMessage}
-				{geoPermissionDenied}
 				onSubmit={handleAddressPath}
 				onCancel={handleCancel}
 				onKeydown={handleKeydown}
@@ -1114,21 +838,16 @@
 					</div>
 					<h3 class="text-lg font-semibold text-slate-900">Enter Your Address</h3>
 					<p class="mt-1 text-sm text-slate-600">
-						Confirm your district to send messages to your representatives.
+						We use it to confirm your {detectedCountry === 'CA'
+							? 'riding'
+							: 'district'} and deliver your messages to your representatives.
 					</p>
-					{#if geoPermissionDenied}
-						<div
-							class="mt-2 flex items-center justify-center gap-1.5 rounded-lg bg-amber-50 px-3 py-2"
-						>
-							<AlertCircle class="h-3.5 w-3.5 text-amber-600" />
-							<p class="text-xs text-amber-700">
-								Location access was denied. Please enter your address instead.
-							</p>
-						</div>
-					{/if}
-					<p class="mt-1 text-xs font-medium text-emerald-700">
-						Address used once for verification, then deleted.
-					</p>
+					<div class="mt-2 flex items-center justify-center gap-1.5">
+						<Lock class="h-3 w-3 shrink-0 text-emerald-700" />
+						<p class="text-xs font-medium text-emerald-700">
+							Your address is encrypted on this device — the server only sees your district.
+						</p>
+					</div>
 				</div>
 
 				<div class="space-y-3">
@@ -1208,26 +927,29 @@
 					Verify Address
 				</button>
 
-				<button
-					type="button"
-					class="w-full text-center text-sm text-slate-500 transition-colors hover:text-slate-700"
-					onclick={handleBack}
-				>
-					Back
-				</button>
+				{#if onCancel}
+					<button
+						type="button"
+						class="w-full text-center text-sm text-slate-500 transition-colors hover:text-slate-700"
+						onclick={handleCancel}
+					>
+						Cancel
+					</button>
+				{/if}
 
 				<!-- Privacy note -->
 				<details class="text-center">
 					<summary class="cursor-pointer text-xs text-slate-400 hover:text-slate-600">
-						How is my address used?
+						What happens to my address?
 					</summary>
 					<p class="mt-2 text-xs leading-relaxed text-slate-500">
-						Your address is sent to our server, geocoded via self-hosted infrastructure, and matched
-						to your {detectedCountry === 'CA'
+						Your address is sent to our self-hosted geocoder, which looks up your {detectedCountry ===
+						'CA'
 							? 'federal electoral district (riding)'
-							: `${jurisdictionLabels.legislativeAdjective} district`}. After verification, the address may be saved into your
-						encrypted ground vault, with district/cell metadata retained to explain and deliver the
-						credential.
+							: `${jurisdictionLabels.legislativeAdjective} district`} and returns only the district — the
+						server logs your district, never your address. Your full address is then encrypted on this
+						device and kept in your ground vault so we can deliver your messages to your
+						representatives without you re-entering it.
 					</p>
 				</details>
 			</div>

--- a/src/lib/components/auth/CredibilityLadder.svelte
+++ b/src/lib/components/auth/CredibilityLadder.svelte
@@ -24,12 +24,21 @@
 	let {
 		currentTier = 0,
 		govIdAvailable = false,
+		/**
+		 * True when the target is an ELECTED office (CWC / representative messaging),
+		 * where district confirmation literally weights the message as a constituent.
+		 * Default false → the honest generic payoff (a verified local resident), which
+		 * is true for institutional/direct targets too. Never claim "offices prioritize
+		 * constituents" to an institutional recipient.
+		 */
+		electedTarget = false,
 		onClimb,
 		onSendNow,
 		compact = false
 	}: {
 		currentTier?: number;
 		govIdAvailable?: boolean;
+		electedTarget?: boolean;
 		onClimb?: (targetTier: number) => void;
 		onSendNow?: () => void;
 		compact?: boolean;
@@ -42,7 +51,14 @@
 
 	const stops = $derived<Stop[]>([
 		{ tier: 1, short: 'Account', label: 'Account verified', payoff: 'Signed by a real, sybil-resistant account.' },
-		{ tier: 2, short: 'District', label: 'District confirmed', payoff: `${labels.legislativeBody} offices prioritize confirmed constituents.` },
+		{
+			tier: 2,
+			short: 'District',
+			label: 'District confirmed',
+			payoff: electedTarget
+				? `${labels.legislativeBody} offices prioritize confirmed constituents.`
+				: "Confirms you're a real local resident, not an anonymous sender."
+		},
 		{ tier: 4, short: 'Gov-ID', label: 'Government ID', payoff: 'Document-level credential — the highest assurance.', future: !govIdAvailable }
 	]);
 
@@ -72,8 +88,9 @@
 {#if compact}
 	<div class="cl-compact">
 		<span class="cl-compact-status">
-			{#if tier >= 2}You're district-confirmed — this counts as a constituent.
-			{:else if tier >= 1}You can send right now.{/if}
+			{#if tier >= 2}You're district-confirmed{electedTarget ? ' — this counts as a constituent' : ' — a verified local resident'}.
+			{:else if tier >= 1}You can send right now.
+			{:else}Sign in to send.{/if}
 		</span>
 		{#if nextStop && onClimb}
 			<button type="button" class="cl-link" onclick={() => onClimb?.(nextStop.tier)}>
@@ -114,7 +131,7 @@
 
 		<!-- One live line, driven by interaction (rests on the next stop). -->
 		<p class="cl-detail" aria-live="polite">
-			{#if shownStop}{shownStop.payoff}{:else if tier >= 2}You're at the highest live tier.{/if}
+			{#if shownStop}{shownStop.payoff}{:else if tier >= 2}You're district-confirmed — the highest level available today.{/if}
 		</p>
 
 		<!-- Affordances carry the value; no explanatory paragraph. -->
@@ -306,6 +323,11 @@
 		white-space: nowrap;
 	}
 	.cl-link:hover { text-decoration: underline; }
+	.cl-link:focus-visible {
+		outline: 2px solid var(--coord-verified, #10b981);
+		outline-offset: 2px;
+		border-radius: 2px;
+	}
 
 	@media (prefers-reduced-motion: reduce) {
 		.cl-conn,
@@ -314,5 +336,6 @@
 		.cl-send-now,
 		.cl-detail { transition: none; }
 		.cl-stop--next .cl-dot { animation: none; }
+		.cl-stop--active .cl-dot { transform: none; }
 	}
 </style>

--- a/src/lib/components/auth/VerificationGate.svelte
+++ b/src/lib/components/auth/VerificationGate.svelte
@@ -27,6 +27,7 @@
 	import IdentityVerificationFlow from './IdentityVerificationFlow.svelte';
 	import IdentityRecoveryFlow from './IdentityRecoveryFlow.svelte';
 	import AddressVerificationFlow from './AddressVerificationFlow.svelte';
+	import CredibilityLadder from './CredibilityLadder.svelte';
 	import {
 		credentialMeetsMinimumTier,
 		getUsableProofCredential,
@@ -362,22 +363,7 @@
 			</button>
 
 			<!-- Header (tier-aware) -->
-			{#if mdlGated}
-				<div
-					class="border-b border-slate-200 bg-gradient-to-r from-slate-50 to-slate-100 px-8 py-6"
-				>
-					<p class="font-mono text-[10px] text-slate-500 uppercase" style="letter-spacing: 0.22em">
-						Government-ID verification
-					</p>
-					<h2
-						id="verification-gate-title"
-						class="mt-2 text-2xl font-semibold text-slate-900"
-						style="font-family: 'Satoshi', system-ui, sans-serif"
-					>
-						Coming soon.
-					</h2>
-				</div>
-			{:else if showRecovery}
+			{#if showRecovery}
 				<div
 					class="border-b border-amber-200 bg-gradient-to-r from-amber-50 to-orange-50 px-8 py-6"
 				>
@@ -389,39 +375,39 @@
 						them.
 					</p>
 				</div>
-			{:else if needsTier4Plus}
-				<div
-					class="border-b border-emerald-200 bg-gradient-to-r from-emerald-50 to-emerald-100 px-8 py-6"
-					>
-						<h2 id="verification-gate-title" class="text-2xl font-bold text-slate-900">
-							Verify with Government Credential
-						</h2>
-						<p class="mt-2 text-slate-600">
-							This action requires document-level verification. Use your mobile driver's license
-							in a supported wallet for the fastest, most private verification available.
-						</p>
-					</div>
-			{:else if needsTier2}
-				<div
-					class="border-b border-emerald-200 bg-gradient-to-r from-emerald-50 to-teal-50 px-8 py-6"
-				>
-					<h2 id="verification-gate-title" class="text-2xl font-bold text-slate-900">
-						Verify Your Address to Send
-					</h2>
-					<p class="mt-2 text-slate-600">
-						Confirm your district to message your representatives. Takes 30 seconds and lets you
-						send instantly in the future.
-					</p>
-				</div>
 			{:else}
-				<div class="border-b border-slate-200 bg-gradient-to-r from-blue-50 to-indigo-50 px-8 py-6">
-					<h2 id="verification-gate-title" class="text-2xl font-bold text-slate-900">
-						Verify Your Identity to Send
+				<!--
+					The ladder replaces the binary "Verify X to Send" walls: it shows
+					where the user stands on the climb and what the needed rung buys
+					(interaction-driven), instead of a one-shot toll. mDL gates fold in
+					here as a "soon" rung rather than a dead "Coming soon." headline.
+					No climb/send-now buttons — the flow content below IS the climb, and
+					the gate only opens when a higher tier is genuinely required.
+				-->
+				<div class="border-b border-slate-200 bg-gradient-to-r from-slate-50 to-slate-100 px-8 py-6">
+					<h2
+						id="verification-gate-title"
+						class="text-lg font-semibold text-slate-900"
+						style="font-family: 'Satoshi', system-ui, sans-serif"
+					>
+						{#if mdlGated}Government&#8209;ID is coming soon{:else if needsTier4Plus}Verify with a government credential{:else if needsTier2}Confirm your district to send{:else}Verify to send{/if}
 					</h2>
-					<p class="mt-2 text-slate-600">
-						{labels.legislativeBody} offices prioritize verified constituents. This one-time verification takes
-						30 seconds and lets you send instantly in the future.
-					</p>
+					{#if !mdlGated}
+						<!--
+							Not in the mdlGated case: there, the action requires gov-ID
+							(unavailable), so confirming district would NOT unblock it —
+							a climbable ladder would falsely imply a next step. The
+							content panel below carries the honest "gov-ID is coming,
+							address remains available" framing instead.
+						-->
+						<div class="mt-3">
+							<CredibilityLadder
+								currentTier={safeUserTrustTier}
+								govIdAvailable={isAnyMdlProtocolEnabled()}
+								electedTarget={true}
+							/>
+						</div>
+					{/if}
 				</div>
 			{/if}
 

--- a/src/lib/components/auth/VerificationGate.svelte
+++ b/src/lib/components/auth/VerificationGate.svelte
@@ -60,6 +60,16 @@
 		 * a tier-2+ user otherwise cannot re-enter the address flow.
 		 */
 		forceAddressFlow?: boolean;
+		/**
+		 * True when this gate fronts a send to an ELECTED office (CWC /
+		 * representative messaging), where district confirmation literally
+		 * weights the message as a constituent. Forwarded to CredibilityLadder.
+		 * Default false → the honest generic ladder copy ("a verified local
+		 * resident"), correct for institutional/direct targets and for non
+		 * target-specific contexts (e.g. the profile page). Never overclaim
+		 * constituent prioritization where the recipient isn't an elected office.
+		 */
+		electedTarget?: boolean;
 		onverified?: (data: { userId: string; method: string; verified?: boolean }) => void;
 		oncancel?: () => void;
 	}
@@ -72,6 +82,7 @@
 		minimumTier = 2,
 		userTrustTier = 0,
 		forceAddressFlow = false,
+		electedTarget = false,
 		onverified,
 		oncancel
 	}: Props = $props();
@@ -404,7 +415,7 @@
 							<CredibilityLadder
 								currentTier={safeUserTrustTier}
 								govIdAvailable={isAnyMdlProtocolEnabled()}
-								electedTarget={true}
+								{electedTarget}
 							/>
 						</div>
 					{/if}

--- a/src/lib/components/auth/address-steps/RegroundingAddressCapture.svelte
+++ b/src/lib/components/auth/address-steps/RegroundingAddressCapture.svelte
@@ -16,7 +16,6 @@
 		description = '',
 		footer = '',
 		errorMessage = '',
-		geoPermissionDenied = false,
 		onSubmit,
 		onCancel,
 		onKeydown
@@ -31,7 +30,6 @@
 		description?: string;
 		footer?: string;
 		errorMessage?: string;
-		geoPermissionDenied?: boolean;
 		onSubmit: () => void;
 		onCancel?: () => void;
 		onKeydown: (event: KeyboardEvent) => void;
@@ -67,12 +65,6 @@
 			{description ||
 				`We resolve the address to your ${regionLabel}, then replace the verified address on this device after attestation.`}
 		</p>
-		{#if geoPermissionDenied}
-			<p class="mt-2 flex items-center gap-1.5 text-xs text-amber-700">
-				<AlertCircle class="h-3.5 w-3.5 shrink-0" />
-				Location access was denied. Enter the address instead.
-			</p>
-		{/if}
 	</div>
 
 	<div class="space-y-3 border-t border-b border-dotted border-slate-300 py-4">

--- a/src/lib/components/template/TemplateModal.svelte
+++ b/src/lib/components/template/TemplateModal.svelte
@@ -2028,6 +2028,7 @@
 		templateSlug={template.slug}
 		cellId={verifiedCellId}
 		minimumTier={template.deliveryMethod === 'cwc' ? 4 : 2}
+		electedTarget={template.deliveryMethod === 'cwc'}
 		userTrustTier={user.trust_tier ?? 1}
 		bind:showModal={showVerificationGate}
 		onverified={(data) => handleVerificationComplete(data)}

--- a/src/lib/components/template/creator/MessageGenerationResolver.svelte
+++ b/src/lib/components/template/creator/MessageGenerationResolver.svelte
@@ -963,17 +963,17 @@
 						<div
 							class="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent"
 						></div>
-						Publishing...
+						Saving…
 					{:else if publishError}
-						Try publishing again
+						Try again
 					{:else}
-						Publish action page
+						Continue to send
 					{/if}
 				</button>
 			</div>
 
 			<p class="mt-3 text-right text-xs text-slate-500">
-				Publishing creates a public action page — sending happens from that page.
+				This creates a public action page so you can send now — and so others can send it too.
 			</p>
 		</div>
 	{:else if stage === 'editing'}

--- a/src/lib/components/template/creator/UnifiedObjectiveEntry.svelte
+++ b/src/lib/components/template/creator/UnifiedObjectiveEntry.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { TemplateCreationContext } from '$lib/types/template';
 	import { Sparkles, ArrowRight } from '@lucide/svelte';
+	import { page } from '$app/stores';
 	import { api } from '$lib/core/api/client';
 	import { slide, fade } from 'svelte/transition';
 	import { onMount, tick } from 'svelte';
@@ -163,6 +164,11 @@
 	const hasExistingText = $derived(
 		(data.rawInput || '').trim().length >= AI_SUGGESTION_TIMING.MIN_INPUT_LENGTH
 	);
+
+	// Honest "no logged-in user" check — null user = guest per +layout.server.ts.
+	// Drives a quiet pre-signal only; it adds no auth gate and does not move the
+	// downstream send/verify wall (that fires after investment in TemplateModal).
+	const isGuest = $derived(!$page.data.user);
 
 	// Auto-scroll thought container when new thoughts arrive
 	$effect(() => {
@@ -985,22 +991,27 @@
 			</div>
 
 			<!-- Footer -->
-			<div class="flex items-center justify-end border-t border-participation-primary-100 bg-participation-primary-50/20 px-4 py-2.5">
-				<div class="flex items-center gap-3">
-					{#if !isGenerating}
-						<button
-							type="button"
-							onclick={() => generateSuggestion()}
-							class="inline-flex transform-gpu items-center gap-1.5 px-1 py-0.5
-							text-sm font-medium text-participation-primary-600
-							transition-all duration-150
-							hover:scale-[1.04] hover:text-participation-primary-700
-							active:scale-[0.97]"
-						>
-							<kbd class="hidden rounded bg-participation-primary-100 px-1 py-0.5 font-mono text-xs text-participation-primary-700 md:inline">{shortcutKey}+Enter</kbd>
-							<span class="text-xs md:hidden"><Sparkles class="inline h-3 w-3" aria-hidden="true" /> Generate</span>
-						</button>
-					{/if}
+			<!-- (a) Mirror the ACTIVE-state primary trigger so the Generate -->
+			<!-- affordance stays prominent when a draft lands in the WRITTEN -->
+			<!-- artifact view (onblur, or returning with an autosaved draft). -->
+			<div class="border-t border-participation-primary-100 bg-participation-primary-50/20 px-4 py-3">
+				{#if !isGenerating}
+					<button
+						type="button"
+						onclick={() => generateSuggestion()}
+						class="inline-flex w-full transform-gpu items-center justify-center gap-2 rounded-lg
+						bg-gradient-to-r from-participation-primary-600 to-participation-primary-500 px-4 py-2.5 text-sm font-semibold text-white
+						shadow-participation-primary transition-all duration-200
+						hover:from-participation-primary-700 hover:to-participation-primary-600 hover:shadow-lg
+						active:scale-[0.97]
+						focus:outline-none focus:ring-2 focus:ring-participation-primary-500 focus:ring-offset-2"
+					>
+						<Sparkles class="h-4 w-4" aria-hidden="true" />
+						Generate
+						<kbd class="hidden rounded bg-white/20 px-1 py-0.5 font-mono text-xs md:inline">{shortcutKey}+Enter</kbd>
+					</button>
+				{/if}
+				<div class="mt-2 flex items-center justify-end">
 					<button
 						type="button"
 						onclick={() => {
@@ -1044,36 +1055,59 @@
 	             disabled:cursor-not-allowed disabled:opacity-60"
 			></textarea>
 
+			<!-- (a) Full-width primary trigger at peak intent (input long enough). -->
+			<!-- Mobile-visible: the kbd hint below is desktop-only, so this is the -->
+			<!-- mobile generate affordance. Reuses generateSuggestion() — no auto-fire. -->
+			{#if !isSettled && !manualMode && !isGenerating && (data.rawInput || '').trim().length >= AI_SUGGESTION_TIMING.MIN_INPUT_LENGTH}
+				<button
+					type="button"
+					onpointerdown={(e) => e.preventDefault()}
+					onclick={() => generateSuggestion()}
+					tabindex={0}
+					class="mt-3 inline-flex w-full transform-gpu items-center justify-center gap-2 rounded-lg
+		             bg-gradient-to-r from-participation-primary-600 to-participation-primary-500 px-4 py-2.5 text-sm font-semibold text-white
+		             shadow-participation-primary transition-all duration-200
+		             hover:from-participation-primary-700 hover:to-participation-primary-600 hover:shadow-lg
+		             active:scale-[0.97]
+		             focus:outline-none focus:ring-2 focus:ring-participation-primary-500 focus:ring-offset-2"
+				>
+					<Sparkles class="h-4 w-4" aria-hidden="true" />
+					Generate
+				</button>
+			{/if}
+
 			<div class="mt-2 flex items-center justify-between text-xs text-slate-600">
 				{#if (data.rawInput || '').trim().length > 0}
 					<span class="font-mono">{(data.rawInput || '').length} characters</span>
 				{:else}
 					<span class="italic">Describe the problem you want to solve</span>
 				{/if}
-				{#if !isSettled && !manualMode}
-					{#if !isGenerating && (data.rawInput || '').trim().length >= AI_SUGGESTION_TIMING.MIN_INPUT_LENGTH}
-						<button
-							type="button"
-							onpointerdown={(e) => e.preventDefault()}
-							onclick={() => generateSuggestion()}
-							class="inline-flex transform-gpu items-center gap-1.5 px-1 py-0.5
-							font-medium text-participation-primary-600
-							transition-all duration-150
-							hover:scale-[1.04] hover:text-participation-primary-700
-							active:scale-[0.97]"
+				{#if !isSettled && !manualMode && !isGenerating}
+					<!-- Secondary signal only: keep the desktop Cmd/Ctrl+Enter hint -->
+					<!-- (handler at handleTextareaKeydown). The primary button above -->
+					<!-- now owns the click affordance, so no duplicate Generate span. -->
+					<div
+						class="flex items-center gap-1.5 {(data.rawInput || '').trim().length >= AI_SUGGESTION_TIMING.MIN_INPUT_LENGTH ? 'text-participation-primary-600' : 'text-slate-400'}"
+					>
+						<Sparkles class="h-3 w-3" aria-hidden="true" />
+						<kbd
+							class="hidden rounded px-1 py-0.5 font-mono md:inline {(data.rawInput || '').trim().length >= AI_SUGGESTION_TIMING.MIN_INPUT_LENGTH ? 'bg-participation-primary-100 text-participation-primary-700' : 'bg-slate-100 text-slate-400'}"
+							>{shortcutKey}+Enter</kbd
 						>
-							<Sparkles class="h-3 w-3" aria-hidden="true" />
-							<kbd class="hidden rounded bg-participation-primary-100 px-1 py-0.5 font-mono text-participation-primary-700 md:inline">{shortcutKey}+Enter</kbd>
-							<span class="text-xs md:hidden">Generate</span>
-						</button>
-					{:else if !isGenerating}
-						<div class="flex items-center gap-1.5 text-slate-400">
-							<Sparkles class="h-3 w-3" aria-hidden="true" />
-							<kbd class="hidden rounded bg-slate-100 px-1 py-0.5 font-mono text-slate-400 md:inline">{shortcutKey}+Enter</kbd>
-						</div>
-					{/if}
+					</div>
 				{/if}
 			</div>
+
+			<!-- (b) Quiet, guest-only pre-signal. One line, muted, no box/wall. -->
+			<!-- Truthful: the OAuth wall fires downstream at send/verify, never -->
+			<!-- in this objective step. Leads on the unambiguously-true benefit -->
+			<!-- (sign-in is the send gate); drafts already persist via localStorage -->
+			<!-- (templateDraftStore), so we don't claim sign-in is what "keeps" them. -->
+			{#if isGuest}
+				<p class="mt-2 text-xs text-slate-400">
+					You'll sign in once, when you're ready to send.
+				</p>
+			{/if}
 		</div>
 	{/if}
 
@@ -1385,6 +1419,13 @@
 					<ArrowRight class="h-4 w-4" />
 				</button>
 
+				<!-- (c) Lead on the free, unlimited path: editing the subject/message -->
+				<!-- inline above is always available. Regen is the secondary path -->
+				<!-- (real LLM cost, hence the cap) — framed as optional, not depleting. -->
+				<p class="text-xs text-participation-primary-600/50">
+					Tweak the subject or message above — edit it directly, free and unlimited.
+				</p>
+
 				<div class="flex items-center justify-between">
 					{#if attemptCount < 5}
 						<button
@@ -1411,7 +1452,10 @@
 							Try another ({5 - attemptCount} left)
 						</button>
 					{:else}
-						<span class="text-sm text-participation-primary-700/60">Out of refinements</span>
+						<!-- (c) No terminal-state copy: the always-present helper line -->
+						<!-- above ("edit it directly, free and unlimited") already covers -->
+						<!-- this. Empty spacer keeps "Write manually" right-aligned. -->
+						<span aria-hidden="true"></span>
 					{/if}
 
 					<button

--- a/src/lib/core/identity/tier-display.ts
+++ b/src/lib/core/identity/tier-display.ts
@@ -166,7 +166,17 @@ export function formatTierDisplay(input: TierDisplayInput): TierDisplay {
  */
 export function formatTierEmailFooter(input: TierDisplayInput): string {
 	const display = formatTierDisplay(input);
-	if (display.confidenceClass === 'mdl') return 'Address-resolved constituent (mDL)';
+	if (display.confidenceClass === 'mdl') {
+		// Both actual-mDL and shadow_atlas share confidenceClass 'mdl' (same
+		// "Address-Resolved Constituent" epistemic class). Only an actual mDL
+		// method may claim the "(mDL)" government-credential protocol suffix —
+		// shadow_atlas is client-side index resolution, not a state credential.
+		// Asserting "(mDL)" for shadow_atlas would be a false government-ID claim
+		// and would diverge from /v/[hash], which shows the bare headline for both.
+		return isMdlMethod(input.method)
+			? 'Address-resolved constituent (mDL)'
+			: 'Address-resolved constituent';
+	}
 	if (display.confidenceClass === 'self-reported')
 		return 'Self-reported constituent (Census geocoder)';
 	if (display.confidenceClass === 'postal')

--- a/src/lib/core/topic/template-text-match.ts
+++ b/src/lib/core/topic/template-text-match.ts
@@ -1,0 +1,235 @@
+/**
+ * Search-First Text Matching for Existing Campaigns
+ *
+ * A pure, SSR-safe, deterministic matcher that scores the user's typed
+ * grievance against the public template corpus already loaded on the homepage.
+ * No embeddings, no network, no server search — just weighted token overlap
+ * over the fields the `templates.listPublic` projection already ships to the
+ * client (`title`, `topics[]`, `domain`, `description`).
+ *
+ * Honest by construction: a template only surfaces if it clears `minScore`.
+ * When nothing clears the floor, `matchExistingCampaigns` returns `[]` — the
+ * caller renders nothing rather than fabricating a match or false scarcity.
+ *
+ * This is the textual sibling of `template-filter.ts` (which scores LOCATION
+ * relevance only) and is intentionally distinct from `embedding-search.ts`
+ * (which delegates to the `/api/templates/search` server endpoint). The
+ * front-door type-ahead must stay client-side and zero-cost, so it lives here.
+ */
+
+import type { Template } from '$lib/types/template';
+
+/**
+ * Minimum trimmed length before the matcher engages. Below this, a stray word
+ * or two would surface noise, so the matcher stays silent until the typed text
+ * carries enough signal to be a real grievance.
+ */
+export const MIN_QUERY_LENGTH = 12;
+
+/**
+ * Default score floor a template must clear to surface. Tuned against the
+ * capped sum of per-token best-field credit below (see `scoreTemplateAgainstText`):
+ * a single curated-topic (0.5) or title (0.4) or domain (0.25) hit clears it, but
+ * a lone description brush (0.1) does not, so an incidental shared word never pulls
+ * an unrelated campaign into view. Because credit is summed (not averaged over query
+ * length), one strong facet hit clears the floor regardless of how long the typed
+ * sentence is — natural lay phrasing is no longer structurally penalized.
+ */
+const DEFAULT_MIN_SCORE = 0.25;
+
+/**
+ * Per-field credit. Each MATCHED query token is credited the weight of the
+ * STRONGEST field it lands in: topics are curated facet tags (highest signal),
+ * the title is the human-readable ask (high), the domain is a coarse civic
+ * bucket (medium), and the description is prose that mentions many incidental
+ * words (low — confirms a match, never drives one). Crediting the best field
+ * per token (rather than summing every field) keeps a precise single-facet hit
+ * — e.g. "afford" landing on the housing title, or "ceo" on a `ceo-pay-ratio`
+ * topic — meaningful without letting a word that happens to appear in both
+ * description and topic double-count.
+ */
+const WEIGHT_TOPIC = 0.5;
+const WEIGHT_TITLE = 0.4;
+const WEIGHT_DOMAIN = 0.25;
+const WEIGHT_DESCRIPTION = 0.1;
+
+/**
+ * Small stopword set — high-frequency function words that carry no topical
+ * signal. Kept deliberately short: over-pruning hurts recall on short
+ * grievances. Tokens shorter than 3 chars are dropped separately, so most
+ * particles ("a", "to", "of", "is") never reach this set anyway.
+ */
+const STOPWORDS = new Set([
+	'the',
+	'and',
+	'but',
+	'for',
+	'are',
+	'was',
+	'were',
+	'has',
+	'have',
+	'had',
+	'our',
+	'out',
+	'their',
+	'them',
+	'they',
+	'this',
+	'that',
+	'these',
+	'those',
+	'with',
+	'from',
+	'into',
+	'about',
+	'keeps',
+	'going',
+	'just',
+	'than',
+	'then',
+	'will',
+	'would',
+	'could',
+	'should',
+	'been',
+	'being',
+	'does',
+	'doesnt',
+	'dont',
+	'cant',
+	'wont',
+	'not',
+	'you',
+	'your',
+	'who',
+	'what',
+	'when',
+	'where',
+	'which',
+	'how',
+	'why',
+	'all',
+	'any',
+	'can',
+	'get',
+	'got'
+]);
+
+/**
+ * Tokenize free text into comparable tokens.
+ *
+ * Lowercases, folds dashes and underscores to spaces (so the `topics`
+ * convention "rural-access" matches a typed "rural access"), strips remaining
+ * punctuation, splits on whitespace, drops tokens shorter than 3 chars and the
+ * stopword set, and de-duplicates. Pure — no browser globals — so it is safe
+ * under SSR and in tests.
+ */
+export function tokenize(text: string): string[] {
+	if (!text) return [];
+	const raw = text
+		.toLowerCase()
+		.replace(/[-_]+/g, ' ')
+		.replace(/[^a-z0-9\s]/g, ' ')
+		.split(/\s+/)
+		.filter((tok) => tok.length >= 3 && !STOPWORDS.has(tok));
+	// De-duplicate while preserving order for determinism.
+	return [...new Set(raw)];
+}
+
+/**
+ * Score one template against an already-tokenized query.
+ *
+ * For each query token, credit the weight of the STRONGEST field it lands in
+ * (topic > title > domain > description), then SUM those credits and clamp to 1.
+ *
+ * Summing (not averaging by query length) is deliberate: lay grievances are full
+ * sentences, but a campaign's curated facets are terse. Averaging divided a single
+ * strong topic hit (0.5) across every word the user typed, so a 5-token sentence
+ * scored 0.10 — below the floor — purely because it was phrased naturally. That
+ * structurally penalized real grievances and made the matcher inert on the launch
+ * corpus. With a capped sum, one strong facet hit clears the floor on its own,
+ * length-independent, while the per-token best-field rule still prevents a word
+ * that appears in several fields from double-counting. Precision is preserved by
+ * the weights: a lone description brush (0.1) can't clear the 0.25 floor, and it
+ * takes three independent description hits (a genuine topical overlap) to reach it.
+ * The clamp at 1 keeps scores comparable for ranking. Returns 0 when nothing overlaps.
+ */
+export function scoreTemplateAgainstText(template: Template, queryTokens: string[]): number {
+	if (queryTokens.length === 0) return 0;
+
+	const topicTokens = new Set<string>();
+	for (const topic of template.topics ?? []) {
+		for (const tok of tokenize(topic)) topicTokens.add(tok);
+	}
+	const titleTokens = new Set(tokenize(template.title));
+	const domainTokens = new Set(tokenize(template.domain));
+	const descriptionTokens = new Set(tokenize(template.description));
+
+	let credit = 0;
+	for (const tok of queryTokens) {
+		if (topicTokens.has(tok)) credit += WEIGHT_TOPIC;
+		else if (titleTokens.has(tok)) credit += WEIGHT_TITLE;
+		else if (domainTokens.has(tok)) credit += WEIGHT_DOMAIN;
+		else if (descriptionTokens.has(tok)) credit += WEIGHT_DESCRIPTION;
+	}
+
+	return Math.min(credit, 1);
+}
+
+/** A template that cleared the floor, paired with its match score. */
+export interface TextMatch {
+	template: Template;
+	score: number;
+}
+
+export interface MatchOptions {
+	/** Maximum number of matches to return. Defaults to 3. */
+	limit?: number;
+	/** Score floor a template must clear to surface. Defaults to DEFAULT_MIN_SCORE. */
+	minScore?: number;
+}
+
+/**
+ * Find existing public campaigns whose curated facets match the typed text.
+ *
+ * Deterministic: tokenize once, score every template, drop anything below the
+ * floor, then sort by score (desc) with a `send_count` tie-break (mirroring the
+ * convention in `domain-grouping.ts`) and a final stable slug tie-break. Returns
+ * the top `limit` — or `[]` when the text is too short or nothing clears the
+ * floor. The empty case is the honest default: no match, no row.
+ */
+export function matchExistingCampaigns(
+	templates: Template[],
+	text: string,
+	options: MatchOptions = {}
+): TextMatch[] {
+	const { limit = 3, minScore = DEFAULT_MIN_SCORE } = options;
+
+	const trimmed = text.trim();
+	if (trimmed.length < MIN_QUERY_LENGTH) return [];
+
+	const queryTokens = tokenize(trimmed);
+	if (queryTokens.length === 0) return [];
+
+	const scored: TextMatch[] = [];
+	for (const template of templates) {
+		const score = scoreTemplateAgainstText(template, queryTokens);
+		if (score >= minScore) {
+			scored.push({ template, score });
+		}
+	}
+
+	scored.sort((a, b) => {
+		const byScore = b.score - a.score;
+		if (byScore !== 0) return byScore;
+		const bySend = (b.template.send_count || 0) - (a.template.send_count || 0);
+		if (bySend !== 0) return bySend;
+		// Final, fully-deterministic tie-break on a stable identifier.
+		return (a.template.slug || a.template.id || '').localeCompare(
+			b.template.slug || b.template.id || ''
+		);
+	});
+
+	return scored.slice(0, limit);
+}

--- a/src/lib/core/topic/template-text-match.ts
+++ b/src/lib/core/topic/template-text-match.ts
@@ -204,7 +204,10 @@ export function matchExistingCampaigns(
 	text: string,
 	options: MatchOptions = {}
 ): TextMatch[] {
-	const { limit = 3, minScore = DEFAULT_MIN_SCORE } = options;
+	const { limit: rawLimit = 3, minScore = DEFAULT_MIN_SCORE } = options;
+	// Clamp: a negative limit would make slice(0, limit) return the list minus its
+	// tail — violating the "maximum results" contract.
+	const limit = Math.max(0, rawLimit);
 
 	const trimmed = text.trim();
 	if (trimmed.length < MIN_QUERY_LENGTH) return [];

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -795,7 +795,7 @@
 		<div class="creation-column">
 			<CreationSpark
 				onactivate={handleSparkActivate}
-				matchTemplates={templateStore.templates}
+				matchTemplates={allTemplates}
 				onMatchSelect={handleSendMessage}
 			>
 				{#snippet context()}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -793,7 +793,11 @@
 	<div class="activation-container">
 		<!-- Left Column: Creation Spark + Minimal Footer -->
 		<div class="creation-column">
-			<CreationSpark onactivate={handleSparkActivate}>
+			<CreationSpark
+				onactivate={handleSparkActivate}
+				matchTemplates={templateStore.templates}
+				onMatchSelect={handleSendMessage}
+			>
 				{#snippet context()}
 					<footer class="creation-footer">
 						<div class="creation-footer__row">

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -748,6 +748,7 @@
 		bind:showModal={showVerificationGate}
 		minimumTier={pendingMinimumTier}
 		userTrustTier={trustTier}
+		electedTarget={false}
 		onverified={handleVerificationComplete}
 		oncancel={() => (showVerificationGate = false)}
 	/>

--- a/src/routes/s/[slug]/+page.server.ts
+++ b/src/routes/s/[slug]/+page.server.ts
@@ -274,6 +274,9 @@ export const load: PageServerLoad = async ({ locals, parent }) => {
 			avatar: locals.user.avatar,
 			trust_tier: locals.user.trust_tier,
 			is_verified: locals.user.is_verified,
+			// Method drives the honest tier label (SSOT) — self-reported vs mDL vs postal —
+			// so the email footer matches what /v/[hash] shows (no residency overclaim).
+			verification_method: locals.user.verification_method,
 			credentialHash
 		} : null,
 		template: parentData.template,

--- a/src/routes/s/[slug]/+page.svelte
+++ b/src/routes/s/[slug]/+page.svelte
@@ -21,6 +21,7 @@
 	import type { DebateData } from '$lib/stores/debateState.svelte';
 	import StanceRegistration from '$lib/components/action/StanceRegistration.svelte';
 	import PowerLandscape from '$lib/components/action/PowerLandscape.svelte';
+	import CredibilityLadder from '$lib/components/auth/CredibilityLadder.svelte';
 	import { positionState } from '$lib/stores/positionState.svelte';
 	import type { EngagementData } from '$lib/types/engagement';
 	import {
@@ -626,6 +627,16 @@
 	// recipient entity (PowerLandscape → RoleGroup → card), not as an aggregate list.
 	const canReportBounce = $derived((data.user?.trust_tier ?? 0) >= 2);
 
+	// Credibility-ladder nudge at the send moment: only for a signed-in,
+	// account-verified-but-not-district-confirmed user on a DIRECT (non-CWC)
+	// template — the case where email-only sending is genuinely permitted, so
+	// "you can send right now · confirm district to count for more" is honest.
+	// CWC/congressional requires district proof (a hard gate), so no nudge there.
+	const ladderNudgeTier = $derived(data.user?.trust_tier ?? 0);
+	const showLadderNudge = $derived(
+		!!data.user && ladderNudgeTier >= 1 && ladderNudgeTier < 2 && !isCongressional
+	);
+
 	async function handleReportBounce(email: string) {
 		if (reportingBounce || reportedBounces.has(email)) return;
 		reportingBounce = email;
@@ -1088,6 +1099,23 @@
 
 		<!-- RIGHT: Relational field — who you're writing to, who's with you, what's been contested -->
 		<div class="mt-8 min-w-0 space-y-8 lg:mt-0">
+			{#if showLadderNudge}
+				<!-- Send-moment ladder nudge: the present value + the climb, never a wall.
+				     Email-only sending already works here; this just makes the upgrade legible. -->
+				<CredibilityLadder
+					compact
+					currentTier={ladderNudgeTier}
+					onClimb={() =>
+						modalActions.openModal('address-modal', 'address', {
+							template,
+							source,
+							mode: 'collection',
+							onComplete: async (detail: AddressModalDetail) => {
+								await _handleAddressSubmit(detail);
+							}
+						})}
+				/>
+			{/if}
 			<!-- Power Landscape: the strong center — who holds power, present from first render -->
 			<div id="power-landscape">
 				<PowerLandscape

--- a/src/routes/s/[slug]/+page.svelte
+++ b/src/routes/s/[slug]/+page.svelte
@@ -85,14 +85,19 @@
 				trustTier
 			});
 			parts.push(`${label} · ${districtCode}`);
+			// The verify URL lives INSIDE the tier>=2 block, gated identically to the
+			// constituent label it backs: "Confirm I'm a real constituent" is itself a
+			// constituent claim, so a sub-tier-2 sender (who only ever gets "Verified
+			// sender" above) must never emit it — that would overclaim standing the
+			// system hasn't established. Emitted only when the hash resolves: the active
+			// credential hash is the record /v/[hash] looks up (a truncated id 404s).
+			// Framed as the sender offering proof of themselves, not an instruction to
+			// the recipient.
+			if (data.user?.credentialHash)
+				parts.push(`Confirm I'm a real constituent: commons.email/v/${data.user.credentialHash}`);
 		} else if (trustTier >= 1) {
 			parts.push('Verified sender');
 		}
-		// Only emit the verify URL when it resolves: the active credential hash is
-		// the record /v/[hash] looks up. A truncated user id always 404s. Framed as
-		// the sender offering proof of themselves, not asking the recipient to act.
-		if (data.user?.credentialHash)
-			parts.push(`Confirm I'm a real constituent: commons.email/v/${data.user.credentialHash}`);
 		return parts.length > 0 ? parts.join('\n') : undefined;
 	}
 	// Simplified - no query parameters needed, default to direct-link
@@ -382,6 +387,10 @@
 	let sendConfirmation = $state<{
 		memberIds: string[];
 		recipientNames: string[];
+		// Delivery detail threaded for the on-confirm /api/deliveries/record POST.
+		// A DELIVERY is a confirmed COUNT, so it must reflect the explicit confirm —
+		// not the mailto launch (a dismissed peak would otherwise inflate server counts).
+		recipients: { name: string; email?: string; deliveryMethod: 'email' }[];
 		attestationLine?: string;
 		messageText: string;
 	} | null>(null);
@@ -424,6 +433,20 @@
 		contactedRecipients = new Set([...contactedRecipients, ...ids]);
 		departingRecipients = new Set([...departingRecipients].filter((id) => !ids.includes(id)));
 		if (batchRegistrationState === 'registering') batchRegistrationState = 'complete';
+
+		// DELIVERY record fires HERE — on the explicit confirm, the same moment
+		// contact is set — never on the mailto launch. A delivery is a confirmed
+		// COUNT, so a dismissed/un-sent peak must not record one (consistent with P2:
+		// contacted only on confirm). Fire-and-forget; stance-agnostic civic action.
+		const recipients = sendConfirmation.recipients;
+		if (data.user?.id && recipients.length > 0) {
+			fetch('/api/deliveries/record', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ templateId: template.id, recipients }),
+				keepalive: true
+			}).catch(() => {});
+		}
 	}
 
 	// Close/dismiss without a confirmed send → revert the still-in-flight cards
@@ -546,43 +569,37 @@
 			});
 
 			if ('url' in result) {
+				// Mirror the actual mailto body (generatePersonalizedMailto): the same
+				// zone order — opener, body, then '---' before the attestation — so the
+				// copy a no-mail-client user pastes matches what the mailto would send.
+				// Subject is a clear leading indication (consistent with the batch path),
+				// not inlined into the body. Built first (pure, no state side effects) so
+				// the in-flight→peak handoff below stays a tight, auditable sequence.
+				const copyBodyParts: string[] = [];
+				if (member.accountabilityOpener?.trim())
+					copyBodyParts.push(member.accountabilityOpener.trim());
+				if (resolvedBody.trim()) copyBodyParts.push(resolvedBody.trim());
+				if (attestation?.trim()) {
+					copyBodyParts.push('---');
+					copyBodyParts.push(attestation.trim());
+				}
+
 				// Mail app OPENED, not confirmed sent — mark IN-FLIGHT only and confirm
-				// explicitly via the send peak (no optimistic "contacted").
+				// explicitly via the send peak (no optimistic "contacted"). The DELIVERY
+				// record (a delivery COUNT) is NOT posted here — it fires only on the
+				// explicit confirm inside confirmSendContacted(), so a dismissed/un-sent
+				// peak never inflates server counts (consistent with the P2 contract).
+				// trackDeliveryAttempt stays here: it is genuinely an attempt metric.
 				departingRecipients = new Set([...departingRecipients, member.id]);
 				trackDeliveryAttempt(template.id, 'email');
-
-				// Record the delivery ATTEMPT — stance-agnostic civic action (fire-and-forget)
-				if (data.user?.id) {
-					fetch('/api/deliveries/record', {
-						method: 'POST',
-						headers: { 'Content-Type': 'application/json' },
-						body: JSON.stringify({
-							templateId: template.id,
-							recipients: [
-								{
-									name: member.name,
-									email: member.email,
-									deliveryMethod: 'email'
-								}
-							]
-						}),
-						keepalive: true
-					}).catch(() => {}); // Fire-and-forget
-				}
 
 				window.location.href = result.url;
 				sendConfirmation = {
 					memberIds: [member.id],
 					recipientNames: [member.name],
+					recipients: [{ name: member.name, email: member.email ?? undefined, deliveryMethod: 'email' }],
 					attestationLine: attestation?.split('\n')[0],
-					messageText: [
-						subject ? `Subject: ${subject}` : '',
-						member.accountabilityOpener ?? '',
-						resolvedBody,
-						attestation ?? ''
-					]
-						.filter(Boolean)
-						.join('\n\n')
+					messageText: `${subject ? `Subject: ${subject}\n\n` : ''}${copyBodyParts.join('\n\n')}`
 				};
 			}
 		} else if (member.deliveryRoute === 'form' && member.contactFormUrl) {
@@ -634,28 +651,20 @@
 				departingRecipients = new Set([...departingRecipients, ...emailMembers.map((m) => m.id)]);
 				trackDeliveryAttempt(template.id, 'email');
 
-				// Persist delivery records — stance-agnostic civic action (fire-and-forget)
-				if (data.user?.id) {
-					fetch('/api/deliveries/record', {
-						method: 'POST',
-						headers: { 'Content-Type': 'application/json' },
-						body: JSON.stringify({
-							templateId: template.id,
-							recipients: emailMembers.map((m) => ({
-								name: m.name,
-								email: m.email ?? undefined,
-								deliveryMethod: 'email' as const
-							}))
-						}),
-						keepalive: true
-					}).catch(() => {});
-				}
-
+				// The DELIVERY record (a delivery COUNT) is deferred to the explicit
+				// confirm in confirmSendContacted() — threaded via sendConfirmation.recipients
+				// below. Posting it here (on mailto launch) would inflate server counts for
+				// a dismissed/un-sent peak. trackDeliveryAttempt stays — it's an attempt metric.
 				window.location.href = url;
 				// In-flight until the user confirms in the send peak (not a return heuristic).
 				sendConfirmation = {
 					memberIds: emailMembers.map((m) => m.id),
 					recipientNames: emailMembers.map((m) => m.name),
+					recipients: emailMembers.map((m) => ({
+						name: m.name,
+						email: m.email ?? undefined,
+						deliveryMethod: 'email' as const
+					})),
 					attestationLine: attestation?.split('\n')[0],
 					messageText: `${subject ? `Subject: ${subject}\n\n` : ''}${bodyParts.join('\n\n')}`
 				};
@@ -1300,7 +1309,9 @@
 	<SendConfirmation
 		recipientNames={sendConfirmation.recipientNames}
 		attestationLine={sendConfirmation.attestationLine}
-		proofUrl={data.user?.credentialHash ? `/v/${data.user.credentialHash}` : undefined}
+		proofUrl={(data.user?.trust_tier ?? 0) >= 2 && data.user?.credentialHash
+			? `/v/${data.user.credentialHash}`
+			: undefined}
 		shareUrl={browser ? `${window.location.origin}/s/${template.slug}` : `/s/${template.slug}`}
 		messageText={sendConfirmation.messageText}
 		onConfirmSent={confirmSendContacted}

--- a/src/routes/s/[slug]/+page.svelte
+++ b/src/routes/s/[slug]/+page.svelte
@@ -22,6 +22,7 @@
 	import StanceRegistration from '$lib/components/action/StanceRegistration.svelte';
 	import PowerLandscape from '$lib/components/action/PowerLandscape.svelte';
 	import CredibilityLadder from '$lib/components/auth/CredibilityLadder.svelte';
+	import SendConfirmation from '$lib/components/action/SendConfirmation.svelte';
 	import { positionState } from '$lib/stores/positionState.svelte';
 	import type { EngagementData } from '$lib/types/engagement';
 	import {
@@ -352,6 +353,16 @@
 	// UI state
 	let contactedRecipients = $state(new Set<string>());
 	let departingRecipients = $state(new Set<string>());
+
+	// Send confirmation peak (P2): a mailto handoff only tells us the mail app
+	// OPENED, never that mail was sent. "contacted" is set ONLY on an explicit
+	// confirm — never a tab-return/timer heuristic.
+	let sendConfirmation = $state<{
+		memberIds: string[];
+		recipientNames: string[];
+		attestationLine?: string;
+		messageText: string;
+	} | null>(null);
 	let batchRegistrationState = $state<'idle' | 'registering' | 'complete'>('idle');
 
 	// Bounce reporting state
@@ -383,37 +394,26 @@
 		)
 	);
 
-	// Mail app handoff detection — settle departing cards when user returns
-	$effect(() => {
-		if (departingRecipients.size === 0 || !browser) return;
+	// P2: contact is confirmed EXPLICITLY (the send-confirmation peak), not by a
+	// tab-return/timer heuristic. Yes → promote in-flight to contacted.
+	function confirmSendContacted() {
+		if (!sendConfirmation) return;
+		const ids = sendConfirmation.memberIds;
+		contactedRecipients = new Set([...contactedRecipients, ...ids]);
+		departingRecipients = new Set([...departingRecipients].filter((id) => !ids.includes(id)));
+		if (batchRegistrationState === 'registering') batchRegistrationState = 'complete';
+	}
 
-		const settle = () => {
-			if (departingRecipients.size > 0) {
-				// Promote departing → contacted, then clear departing
-				contactedRecipients = new Set([...contactedRecipients, ...departingRecipients]);
-				departingRecipients = new Set();
-				// Complete batch registration if it was in progress
-				if (batchRegistrationState === 'registering') {
-					batchRegistrationState = 'complete';
-				}
-			}
-		};
-
-		const onFocus = () => settle();
-		const onVisible = () => {
-			if (!document.hidden) settle();
-		};
-
-		window.addEventListener('focus', onFocus);
-		document.addEventListener('visibilitychange', onVisible);
-		const timer = setTimeout(settle, 3000);
-
-		return () => {
-			window.removeEventListener('focus', onFocus);
-			document.removeEventListener('visibilitychange', onVisible);
-			clearTimeout(timer);
-		};
-	});
+	// Close/dismiss without a confirmed send → revert the still-in-flight cards
+	// (nothing was confirmed contacted; never leave a false "contacted").
+	function closeSendConfirmation() {
+		if (sendConfirmation) {
+			const ids = sendConfirmation.memberIds;
+			departingRecipients = new Set([...departingRecipients].filter((id) => !ids.includes(id)));
+			if (batchRegistrationState === 'registering') batchRegistrationState = 'idle';
+		}
+		sendConfirmation = null;
+	}
 
 	// Initialize positionState from server data on template change
 	$effect(() => {
@@ -481,6 +481,9 @@
 	}
 
 	function handleWriteTo(member: LandscapeMember) {
+		// Resolve any pending send confirmation first (defense-in-depth — the peak's
+		// modal backdrop + focus trap already block interaction with the cards behind).
+		if (sendConfirmation) return;
 		if (member.deliveryRoute === 'cwc') {
 			// Congressional officials: route through existing CWC modal infrastructure
 			// TemplateModal handles tier-based routing (mailto for T1-2, ZKP for T3+)
@@ -521,12 +524,12 @@
 			});
 
 			if ('url' in result) {
-				// Track email handoff — we know the mail app was opened, not that it was sent
-				contactedRecipients = new Set([...contactedRecipients, member.id]);
+				// Mail app OPENED, not confirmed sent — mark IN-FLIGHT only and confirm
+				// explicitly via the send peak (no optimistic "contacted").
 				departingRecipients = new Set([...departingRecipients, member.id]);
 				trackDeliveryAttempt(template.id, 'email');
 
-				// Persist delivery record — stance-agnostic civic action (fire-and-forget)
+				// Record the delivery ATTEMPT — stance-agnostic civic action (fire-and-forget)
 				if (data.user?.id) {
 					fetch('/api/deliveries/record', {
 						method: 'POST',
@@ -542,10 +545,23 @@
 							]
 						}),
 						keepalive: true
-					}).catch(() => {}); // Fire-and-forget — UI already updated
+					}).catch(() => {}); // Fire-and-forget
 				}
 
 				window.location.href = result.url;
+				sendConfirmation = {
+					memberIds: [member.id],
+					recipientNames: [member.name],
+					attestationLine: attestation?.split('\n')[0],
+					messageText: [
+						subject ? `Subject: ${subject}` : '',
+						member.accountabilityOpener ?? '',
+						resolvedBody,
+						attestation ?? ''
+					]
+						.filter(Boolean)
+						.join('\n\n')
+				};
 			}
 		} else if (member.deliveryRoute === 'form' && member.contactFormUrl) {
 			// Web contact form: open in new tab
@@ -554,6 +570,7 @@
 	}
 
 	function handleBatchRegister(memberIds: string[]) {
+		if (sendConfirmation) return; // resolve the pending send peak first
 		if (batchRegistrationState === 'registering') return;
 		batchRegistrationState = 'registering';
 
@@ -591,7 +608,7 @@
 			const url = `mailto:${encodeURIComponent(emails)}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(bodyParts.join('\n\n'))}`;
 
 			if (url.length <= 8000) {
-				// Set departing only — settle handler promotes to contacted when user returns
+				// Set departing only — the send peak promotes to contacted on an explicit confirm
 				departingRecipients = new Set([...departingRecipients, ...emailMembers.map((m) => m.id)]);
 				trackDeliveryAttempt(template.id, 'email');
 
@@ -612,8 +629,14 @@
 					}).catch(() => {});
 				}
 
-				// Stay in 'registering' — settle handler transitions to 'complete' on return
 				window.location.href = url;
+				// In-flight until the user confirms in the send peak (not a return heuristic).
+				sendConfirmation = {
+					memberIds: emailMembers.map((m) => m.id),
+					recipientNames: emailMembers.map((m) => m.name),
+					attestationLine: attestation?.split('\n')[0],
+					messageText: `${subject ? `Subject: ${subject}\n\n` : ''}${bodyParts.join('\n\n')}`
+				};
 				return;
 			}
 		}
@@ -1248,4 +1271,17 @@
 <!-- Mobile debate awareness — sticky banner below lg: breakpoint -->
 {#if FEATURES.DEBATE}
 	<MobileDebateBanner debate={(data.debate as DebateData) ?? null} />
+{/if}
+
+<!-- Send peak (P2): the honest "did it send?" confirm + the proof/share moment -->
+{#if sendConfirmation}
+	<SendConfirmation
+		recipientNames={sendConfirmation.recipientNames}
+		attestationLine={sendConfirmation.attestationLine}
+		proofUrl={data.user?.credentialHash ? `/v/${data.user.credentialHash}` : undefined}
+		shareUrl={browser ? `${window.location.origin}/s/${template.slug}` : `/s/${template.slug}`}
+		messageText={sendConfirmation.messageText}
+		onConfirmSent={confirmSendContacted}
+		onClose={closeSendConfirmation}
+	/>
 {/if}

--- a/src/routes/s/[slug]/+page.svelte
+++ b/src/routes/s/[slug]/+page.svelte
@@ -46,6 +46,7 @@
 	import { topicHue } from '$lib/utils/topic-hue';
 	import { persistAddressCompletion } from '$lib/core/identity/address-completion-persistence';
 	import { persistGroundVaultForAddress } from '$lib/core/identity/ground-vault-persistence';
+	import { formatTierEmailFooter, type VerificationMethod } from '$lib/core/identity/tier-display';
 	import type { ClientCellProofResult } from '$lib/core/shadow-atlas/browser-client';
 
 	let { data }: { data: PageData } = $props();
@@ -62,15 +63,36 @@
 	const template: TemplateType = $derived(data.template as unknown as TemplateType);
 	const hue = $derived(topicHue(template?.domain ?? '', template?.topics, template?.domainHue));
 
-	/** Build proof footer for email attestation based on user verification tier */
+	/**
+	 * Build the sender's own signature line(s) for the email footer.
+	 *
+	 * This is the SENDER attesting to their own standing — not a label aimed at
+	 * the recipient and not a request that the recipient verify anything. Line 1
+	 * stays a clean third-person NOUN PHRASE (consumed as `attestationLine` via
+	 * `split('\n')[0]`, and reused mid-sentence inside SendConfirmation's "Your
+	 * message carried <attestationLine>." frame — a first-person clause there
+	 * would read as a person/voice mismatch). The optional URL is the sender
+	 * offering verifiability of themselves, never an instruction to the addressee.
+	 */
 	function buildProofFooter(trustTier: number, districtCode?: string | null): string | undefined {
 		const parts: string[] = [];
-		if (trustTier >= 2 && districtCode) parts.push(`Verified resident · ${districtCode}`);
-		else if (trustTier >= 1) parts.push('Verified sender');
-		if (trustTier >= 3) parts[0] += ' · Gov ID';
+		if (trustTier >= 2 && districtCode) {
+			// SSOT label (matches /v/[hash]): method-specific so a self-reported
+			// (civic_api) sender reads "Self-reported constituent", never overclaimed
+			// as "Verified resident". The method label already encodes mDL/gov-ID.
+			const label = formatTierEmailFooter({
+				method: (data.user?.verification_method as VerificationMethod) ?? null,
+				trustTier
+			});
+			parts.push(`${label} · ${districtCode}`);
+		} else if (trustTier >= 1) {
+			parts.push('Verified sender');
+		}
 		// Only emit the verify URL when it resolves: the active credential hash is
-		// the record /v/[hash] looks up. A truncated user id always 404s.
-		if (data.user?.credentialHash) parts.push(`commons.email/v/${data.user.credentialHash}`);
+		// the record /v/[hash] looks up. A truncated user id always 404s. Framed as
+		// the sender offering proof of themselves, not asking the recipient to act.
+		if (data.user?.credentialHash)
+			parts.push(`Confirm I'm a real constituent: commons.email/v/${data.user.credentialHash}`);
 		return parts.length > 0 ? parts.join('\n') : undefined;
 	}
 	// Simplified - no query parameters needed, default to direct-link

--- a/src/routes/s/[slug]/+page.svelte
+++ b/src/routes/s/[slug]/+page.svelte
@@ -81,7 +81,7 @@
 			// (civic_api) sender reads "Self-reported constituent", never overclaimed
 			// as "Verified resident". The method label already encodes mDL/gov-ID.
 			const label = formatTierEmailFooter({
-				method: (data.user?.verification_method as VerificationMethod) ?? null,
+				method: (data.user?.verification_method ?? null) as VerificationMethod,
 				trustTier
 			});
 			parts.push(`${label} · ${districtCode}`);
@@ -94,7 +94,7 @@
 			// Framed as the sender offering proof of themselves, not an instruction to
 			// the recipient.
 			if (data.user?.credentialHash)
-				parts.push(`Confirm I'm a real constituent: commons.email/v/${data.user.credentialHash}`);
+				parts.push(`Confirm I'm a real constituent: https://commons.email/v/${data.user.credentialHash}`);
 		} else if (trustTier >= 1) {
 			parts.push('Verified sender');
 		}

--- a/tests/unit/components/create-frontdoor-polish.test.ts
+++ b/tests/unit/components/create-frontdoor-polish.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Authoring-step polish (#1 generate-trigger, #3 ambient auth pre-signal,
+ * #5 refinement de-scarcify) + search-first front door (#2). Source-pin coverage
+ * of the wiring + honesty; the matcher's behavior is covered by
+ * tests/unit/topic/template-text-match.test.ts.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const src = (p: string) => readFileSync(resolve(process.cwd(), p), 'utf8');
+
+describe('AUTHOR — surfaced generate trigger, honest pre-signal, de-scarcified refinement', () => {
+	const uoe = src('src/lib/components/template/creator/UnifiedObjectiveEntry.svelte');
+
+	it('the generate trigger is a real primary affordance gated on MIN_INPUT_LENGTH, not just a kbd shortcut', () => {
+		expect(uoe).toContain('generateSuggestion');
+		expect(uoe).toContain('MIN_INPUT_LENGTH');
+		expect(uoe).toMatch(/handleTextareaKeydown/); // Cmd/Ctrl+Enter still works
+	});
+
+	it('the trigger is surfaced in the WRITTEN (quote-artifact) state too, not only the active textarea', () => {
+		// the WRITTEN state mirrors the primary gradient Generate button (the common
+		// blur→artifact path no longer re-buries the trigger)
+		expect(uoe).toMatch(/written-artifact[\s\S]*?from-participation-primary-600[\s\S]*?Generate/);
+	});
+
+	it('the auth pre-signal is guest-only and honestly worded (no "keep this draft" overclaim)', () => {
+		expect(uoe).toContain('isGuest');
+		expect(uoe).toContain("when you're ready to send");
+		// sign-in does not "keep" the draft (localStorage already does; it can even orphan it)
+		expect(uoe).not.toContain('keep this draft');
+	});
+
+	it('refinement is reframed from scarcity to the free/unlimited inline edit', () => {
+		expect(uoe).not.toContain('Out of refinements');
+		expect(uoe).toContain('free and unlimited');
+	});
+});
+
+describe('SEARCH — front-door type-ahead surfaces real campaigns only', () => {
+	const spark = src('src/lib/components/activation/CreationSpark.svelte');
+	const home = src('src/routes/+page.svelte');
+
+	it('renders matches only when they exist — never a fabricated match', () => {
+		expect(spark).toContain('matchExistingCampaigns');
+		expect(spark).toMatch(/\{#if matches\.length > 0\}/);
+	});
+
+	it('picking a match routes through the existing send path (participate fast-path)', () => {
+		expect(spark).toContain('onMatchSelect');
+		expect(home).toContain('onMatchSelect={handleSendMessage}');
+		expect(home).toContain('matchTemplates={templateStore.templates}');
+	});
+
+	it('the matcher is the dedicated client-side text sibling, not the location filter or server search', () => {
+		expect(spark).toContain("from '$lib/core/topic/template-text-match'");
+	});
+});

--- a/tests/unit/components/create-frontdoor-polish.test.ts
+++ b/tests/unit/components/create-frontdoor-polish.test.ts
@@ -50,7 +50,9 @@ describe('SEARCH — front-door type-ahead surfaces real campaigns only', () => 
 	it('picking a match routes through the existing send path (participate fast-path)', () => {
 		expect(spark).toContain('onMatchSelect');
 		expect(home).toContain('onMatchSelect={handleSendMessage}');
-		expect(home).toContain('matchTemplates={templateStore.templates}');
+		// the matcher must use the GATED corpus (allTemplates — feature-flag + delivery
+		// filtered), not raw templateStore.templates, or it could surface gated campaigns
+		expect(home).toContain('matchTemplates={allTemplates}');
 	});
 
 	it('the matcher is the dedicated client-side text sibling, not the location filter or server search', () => {

--- a/tests/unit/components/create-terminal-and-proof.test.ts
+++ b/tests/unit/components/create-terminal-and-proof.test.ts
@@ -1,0 +1,62 @@
+/**
+ * P3 (create-flow terminal: foreground the SEND, demote publish to opt-in
+ * amplification) + P4 (proof footer honesty: sender-framed + the SSOT tier label
+ * so a self-reported sender is never overclaimed as "Verified resident").
+ * Source-pin coverage.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const src = (p: string) => readFileSync(resolve(process.cwd(), p), 'utf8');
+
+describe('P3 — create-flow terminal foregrounds the send', () => {
+	const mgr = src('src/lib/components/template/creator/MessageGenerationResolver.svelte');
+
+	it('the terminal CTA leads with the send, not "Publish action page"', () => {
+		expect(mgr).toContain('Continue to send');
+		expect(mgr).not.toContain('Publish action page');
+	});
+
+	it('the CTA label does not overclaim that a send already happened on click', () => {
+		// the click navigates/publishes; the actual mailto is 1-2 steps later, so the
+		// label must not assert "Send this now" (a forward overclaim).
+		expect(mgr).not.toContain('Send this now');
+		expect(mgr).toContain('Saving'); // in-flight label (was "Publishing…", which overstated the org job)
+	});
+
+	it('publish is reframed as opt-in amplification, send-first', () => {
+		expect(mgr).toContain('so you can send now');
+		expect(mgr).toContain('so others can send it too');
+	});
+});
+
+describe('P4 — proof footer is sender-framed + uses the SSOT tier label', () => {
+	const slug = src('src/routes/s/[slug]/+page.svelte');
+	const server = src('src/routes/s/[slug]/+page.server.ts');
+	const compose = src('src/lib/components/action/ComposePane.svelte');
+
+	it('buildProofFooter routes through the SSOT (formatTierEmailFooter), no hardcoded residency', () => {
+		expect(slug).toMatch(/formatTierEmailFooter\(\{/);
+		expect(slug).toContain("from '$lib/core/identity/tier-display'");
+		// the pre-existing residency overclaim + the redundant Gov-ID append are gone
+		expect(slug).not.toMatch(/push\(`Verified resident/);
+		expect(slug).not.toMatch(/\+= ' · Gov ID'/);
+	});
+
+	it('the verify URL is offered as the SENDER\'s proof, not an instruction to the recipient', () => {
+		expect(slug).toContain("Confirm I'm a real constituent");
+		expect(slug).not.toMatch(/push\(`commons\.email\/v\//); // no bare unframed URL
+	});
+
+	it('verification_method is threaded to data.user so the label can be method-specific', () => {
+		expect(server).toContain('verification_method: locals.user.verification_method');
+	});
+
+	it('ComposePane carries no residency overclaim and no false "cryptographic proof"', () => {
+		// pin the RENDERED template literal (the ternary value), not the explanatory comment
+		expect(compose).toMatch(/\?\s*`Verified constituent ·/);
+		expect(compose).not.toMatch(/\?\s*`Verified resident/);
+		expect(compose).not.toContain('Cryptographic proof'); // the false residency-proof claim
+	});
+});

--- a/tests/unit/components/create-terminal-and-proof.test.ts
+++ b/tests/unit/components/create-terminal-and-proof.test.ts
@@ -46,6 +46,8 @@ describe('P4 — proof footer is sender-framed + uses the SSOT tier label', () =
 
 	it('the verify URL is offered as the SENDER\'s proof, not an instruction to the recipient', () => {
 		expect(slug).toContain("Confirm I'm a real constituent");
+		// the URL carries https:// so it auto-links in mail clients (Gmail/Apple Mail/Outlook)
+		expect(slug).toContain('https://commons.email/v/');
 		expect(slug).not.toMatch(/push\(`commons\.email\/v\//); // no bare unframed URL
 	});
 

--- a/tests/unit/components/credibility-ladder.test.ts
+++ b/tests/unit/components/credibility-ladder.test.ts
@@ -1,0 +1,93 @@
+/**
+ * CredibilityLadder (P1: verification ladder shown as a ladder, not walls) +
+ * its two wirings. Source-pin coverage of the load-bearing invariants:
+ * honesty (target-aware payoff, no false send-now, no false next-step in the
+ * mDL dead-end), a11y (focus-visible, SR labels, reduced-motion), and the
+ * send-nudge gating (only where a lower-tier send is genuinely permitted).
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const src = (p: string) => readFileSync(resolve(process.cwd(), p), 'utf8');
+
+describe('CredibilityLadder — honesty + a11y + motion', () => {
+	const ladder = src('src/lib/components/auth/CredibilityLadder.svelte');
+
+	it('District payoff is target-aware — the "offices prioritize constituents" claim is guarded by electedTarget', () => {
+		expect(ladder).toContain('electedTarget');
+		// the elected-specific claim only appears inside the electedTarget ternary
+		expect(ladder).toMatch(/electedTarget[\s\S]{0,120}offices prioritize confirmed constituents/);
+		// the default (institutional/direct) payoff makes no constituent claim
+		expect(ladder).toContain("Confirms you're a real local resident");
+	});
+
+	it('the ceiling fallback is honest — highest AVAILABLE today, not highest absolute', () => {
+		expect(ladder).toContain('the highest level available today');
+		expect(ladder).not.toContain('the highest live tier');
+	});
+
+	it('stops are focusable buttons with a screen-reader label; the detail line is announced', () => {
+		expect(ladder).toContain('<button');
+		expect(ladder).toMatch(/aria-label=\{`\$\{s\.label\}/);
+		expect(ladder).toContain('aria-live="polite"');
+	});
+
+	it('the compact CTA has a focus-visible indicator (keyboard a11y)', () => {
+		expect(ladder).toContain('.cl-link:focus-visible');
+	});
+
+	it('the compact status has a guest fallback (never a blank span)', () => {
+		const compact = ladder.slice(ladder.indexOf('cl-compact-status'), ladder.indexOf('</span>', ladder.indexOf('cl-compact-status')));
+		expect(compact).toContain('Sign in to send');
+	});
+
+	it('reduced-motion gates the pulse animation AND the active-stop scale', () => {
+		const i = ladder.indexOf('prefers-reduced-motion');
+		expect(i).toBeGreaterThan(-1);
+		const block = ladder.slice(i, i + 420);
+		expect(block).toContain('animation: none'); // pulse off
+		expect(block).toMatch(/cl-stop--active \.cl-dot \{ transform: none/); // scale off
+	});
+});
+
+describe('CredibilityLadder wiring — verification gate (walls → ladder, P5 fold-in)', () => {
+	const gate = src('src/lib/components/auth/VerificationGate.svelte');
+
+	it('replaces the binary "Verify X to Send" wall headers with the ladder', () => {
+		expect(gate).toContain('<CredibilityLadder');
+		expect(gate).not.toContain('Verify Your Address to Send');
+		expect(gate).not.toContain('Verify Your Identity to Send');
+	});
+
+	it('the gate ladder is the elected context and carries NO false lower-tier send-now escape', () => {
+		const start = gate.indexOf('<CredibilityLadder');
+		const tag = gate.slice(start, gate.indexOf('/>', start));
+		expect(tag).toContain('electedTarget={true}');
+		expect(tag).not.toContain('onSendNow'); // hard-required gate: lower-tier send isn't an option here
+	});
+
+	it('does NOT render the climbable ladder in the mdlGated dead-end (no false next step)', () => {
+		// the action requires unavailable gov-ID, so a "confirm district" climb would mislead
+		expect(gate).toMatch(/\{#if !mdlGated\}[\s\S]{0,400}<CredibilityLadder/);
+	});
+});
+
+describe('CredibilityLadder wiring — /s/[slug] send nudge', () => {
+	const slug = src('src/routes/s/[slug]/+page.svelte');
+
+	it('the nudge only shows where a lower-tier send is permitted (signed-in, tier in [1,2), non-CWC)', () => {
+		expect(slug).toMatch(
+			/showLadderNudge\s*=\s*\$derived\([\s\S]{0,160}ladderNudgeTier >= 1 && ladderNudgeTier < 2 && !isCongressional/
+		);
+	});
+
+	it('the nudge is the compact ladder with a climb only — never a duplicate send-now', () => {
+		const start = slug.indexOf('{#if showLadderNudge}');
+		const block = slug.slice(start, slug.indexOf('{/if}', start));
+		expect(block).toContain('<CredibilityLadder');
+		expect(block).toContain('compact');
+		expect(block).toContain('onClimb');
+		expect(block).not.toContain('onSendNow');
+	});
+});

--- a/tests/unit/components/credibility-ladder.test.ts
+++ b/tests/unit/components/credibility-ladder.test.ts
@@ -60,11 +60,33 @@ describe('CredibilityLadder wiring — verification gate (walls → ladder, P5 f
 		expect(gate).not.toContain('Verify Your Identity to Send');
 	});
 
-	it('the gate ladder is the elected context and carries NO false lower-tier send-now escape', () => {
+	it('the gate forwards a TARGET-DERIVED electedTarget (never hardcoded true) and carries NO false lower-tier send-now escape', () => {
 		const start = gate.indexOf('<CredibilityLadder');
 		const tag = gate.slice(start, gate.indexOf('/>', start));
-		expect(tag).toContain('electedTarget={true}');
+		// The gate opens in non-elected contexts too (institutional/direct
+		// templates at tier 2, the profile page). Hardcoding electedTarget={true}
+		// here mis-claimed "offices prioritize constituents" outside CWC. The
+		// ladder must instead receive the gate's own (caller-set, default-false)
+		// electedTarget prop — never the literal true.
+		expect(tag).toContain('{electedTarget}');
+		expect(tag).not.toContain('electedTarget={true}');
 		expect(tag).not.toContain('onSendNow'); // hard-required gate: lower-tier send isn't an option here
+	});
+
+	it('VerificationGate exposes electedTarget as a prop defaulting to the honest generic (false)', () => {
+		// default false → the generic "verified local resident" ladder copy where
+		// the context isn't known-elected; callers opt in for CWC/elected sends.
+		expect(gate).toMatch(/electedTarget\?:\s*boolean/);
+		expect(gate).toMatch(/electedTarget\s*=\s*false/);
+	});
+
+	it('the two real callers set electedTarget from the actual target', () => {
+		// TemplateModal: elected iff the template delivers via CWC.
+		const modal = src('src/lib/components/template/TemplateModal.svelte');
+		expect(modal).toContain("electedTarget={template.deliveryMethod === 'cwc'}");
+		// Profile: generic verify entry, not a target-specific send.
+		const profile = src('src/routes/profile/+page.svelte');
+		expect(profile).toContain('electedTarget={false}');
 	});
 
 	it('does NOT render the climbable ladder in the mdlGated dead-end (no false next step)', () => {

--- a/tests/unit/components/mdl-launch-gates.test.ts
+++ b/tests/unit/components/mdl-launch-gates.test.ts
@@ -23,7 +23,12 @@ describe('mDL launch gates', () => {
 		expect(nextBranch).toBeGreaterThan(placeholder);
 		expect(gatedBranch).toContain('data-testid="mdl-gated-panel"');
 		expect(gatedBranch).toContain('Government-ID verification');
-		expect(svelte).toContain('Coming soon.');
+		// P5 (mDL dead-end invert): the gate no longer leads with a bare "Coming
+		// soon." headline. It shows the credibility ladder (gov-ID as a "soon" rung)
+		// and keeps the still-available address alternative, so the most-committed
+		// user is met with what they CAN do, not a wall.
+		expect(svelte).toContain('<CredibilityLadder');
+		expect(gatedBranch).toContain('Address-attested verification');
 		expect(gatedBranch).not.toContain('<IdentityVerificationFlow');
 	});
 

--- a/tests/unit/components/send-confirmation.test.ts
+++ b/tests/unit/components/send-confirmation.test.ts
@@ -1,0 +1,77 @@
+/**
+ * SendConfirmation (P2: the engineered send peak + the honesty confirm) and its
+ * /s/[slug] wiring. A mailto handoff only reveals the mail app OPENED, never that
+ * mail was sent — so "contacted" must be set ONLY on an explicit user confirm, and
+ * the copy must never claim delivery the system can't observe. Source-pin coverage.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const src = (p: string) => readFileSync(resolve(process.cwd(), p), 'utf8');
+
+describe('SendConfirmation — honest peak', () => {
+	const sc = src('src/lib/components/action/SendConfirmation.svelte');
+
+	it('is honest: "opened your mail app", never claims delivery it cannot observe', () => {
+		expect(sc).toContain('opened your mail app');
+		expect(sc).toContain("we can't see your mail app");
+		expect(sc).not.toMatch(/\b(delivered|received by|reached their inbox)\b/i);
+	});
+
+	it('marks contact only via an explicit confirm — contact FIRST, then advance to success', () => {
+		const start = sc.indexOf('function confirmSent');
+		const fn = sc.slice(start, sc.indexOf('}', start) + 1);
+		expect(fn).toContain('onConfirmSent()');
+		expect(fn.indexOf('onConfirmSent()')).toBeLessThan(fn.indexOf("stage = 'sent'"));
+	});
+
+	it('is an accessible modal: role=dialog, Escape close, Tab-trap, focus-into-dialog', () => {
+		expect(sc).toContain('role="dialog"');
+		expect(sc).toContain('aria-modal="true"');
+		expect(sc).toMatch(/key === 'Escape'/);
+		expect(sc).toMatch(/e\.key !== 'Tab'/); // trap
+		expect(sc).toContain("querySelector<HTMLElement>('button:not(.sc-close)')"); // focus-into on open
+	});
+
+	it('reduced-motion gates the rise; the copy stage has a manual-select fallback', () => {
+		const i = sc.indexOf('prefers-reduced-motion');
+		expect(i).toBeGreaterThan(-1);
+		expect(sc.slice(i, i + 180)).toContain('animation: none');
+		expect(sc).toContain('sc-copy-text');
+		expect(sc).toContain('readonly');
+		expect(sc).toContain('copyFailed'); // clipboard-denied feedback
+	});
+});
+
+describe('SendConfirmation wiring — /s/[slug] honesty + lifecycle', () => {
+	const slug = src('src/routes/s/[slug]/+page.svelte');
+
+	it('the tab-return auto-promote settle effect is GONE (no heuristic "contacted")', () => {
+		expect(slug).not.toContain('...contactedRecipients, ...departingRecipients'); // old settle promotion
+		expect(slug).not.toContain('contactedRecipients, member.id'); // old optimistic single mark
+	});
+
+	it('contact is promoted ONLY by the explicit confirm handler', () => {
+		expect(slug).toMatch(
+			/function confirmSendContacted\(\)[\s\S]{0,320}contactedRecipients = new Set\(\[\.\.\.contactedRecipients, \.\.\.ids\]\)/
+		);
+	});
+
+	it('a send sets in-flight then opens the peak (never optimistic contacted)', () => {
+		expect(slug).toMatch(
+			/departingRecipients = new Set\(\[\.\.\.departingRecipients, member\.id\]\)[\s\S]{0,700}sendConfirmation = \{/
+		);
+	});
+
+	it('guards a concurrent send while a peak is pending', () => {
+		expect(slug).toContain('if (sendConfirmation) return;');
+	});
+
+	it('renders the peak wired to the confirm + close handlers', () => {
+		const start = slug.indexOf('<SendConfirmation');
+		const tag = slug.slice(start, slug.indexOf('/>', start));
+		expect(tag).toContain('onConfirmSent={confirmSendContacted}');
+		expect(tag).toContain('onClose={closeSendConfirmation}');
+	});
+});

--- a/tests/unit/components/send-confirmation.test.ts
+++ b/tests/unit/components/send-confirmation.test.ts
@@ -19,6 +19,12 @@ describe('SendConfirmation — honest peak', () => {
 		expect(sc).not.toMatch(/\b(delivered|received by|reached their inbox)\b/i);
 	});
 
+	it('guards against double-submit — onConfirmSent (now the delivery-record POST) fires once', () => {
+		// a rapid double-click before `stage` flips must not double-fire onConfirmSent
+		expect(sc).toContain('hasConfirmed');
+		expect(sc).toMatch(/if \(hasConfirmed\) return/);
+	});
+
 	it('marks contact only via an explicit confirm — contact FIRST, then advance to success', () => {
 		const start = sc.indexOf('function confirmSent');
 		const fn = sc.slice(start, sc.indexOf('}', start) + 1);

--- a/tests/unit/identity/tier-display.test.ts
+++ b/tests/unit/identity/tier-display.test.ts
@@ -138,6 +138,19 @@ describe('formatTierEmailFooter — short labels for plaintext emails', () => {
 		);
 	});
 
+	it('shadow_atlas → "Address-resolved constituent" with NO "(mDL)" suffix (not a state credential)', () => {
+		// shadow_atlas shares confidenceClass 'mdl' (same epistemic class) but is
+		// client-side index resolution, NOT a government mobile driver's license.
+		// Claiming "(mDL)" here would be a false government-ID assertion and would
+		// diverge from /v/[hash], which shows the bare "Address-Resolved Constituent"
+		// headline for both shadow_atlas and actual mDL.
+		const footer = formatTierEmailFooter({ method: 'shadow_atlas' });
+		expect(footer).toBe('Address-resolved constituent');
+		expect(footer).not.toContain('mDL');
+		// Same confidence class as mDL, but the footer must not borrow its protocol claim.
+		expect(formatTierDisplay({ method: 'shadow_atlas' }).confidenceClass).toBe('mdl');
+	});
+
 	it('postal → "Postal-verified constituent"', () => {
 		expect(formatTierEmailFooter({ method: 'postal' })).toBe('Postal-verified constituent');
 	});

--- a/tests/unit/shadow-atlas/address-flow-b3.test.ts
+++ b/tests/unit/shadow-atlas/address-flow-b3.test.ts
@@ -155,16 +155,50 @@ describe('B-3b: AddressVerificationFlow client-side resolution', () => {
 
 			expect(svelte).toContain('RegroundingAddressCapture');
 			expect(svelte).toContain("flowStep = 'address-input';");
-			expect(svelte).toContain("verificationMethod = 'address';");
-			expect(svelte).toContain(
-				"flowStep = regroundingMode ? 'address-input' : clientSideEnabled ? 'map-pin' : 'address-input'"
-			);
+			expect(svelte).toContain("const verificationMethod = 'address' as const");
 			expect(svelte).toContain('Enter the new address before re-grounding.');
 			expect(capture).toContain('Address text is required for a verified address change.');
 			expect(capture).toContain("from '$lib/components/ui/Button.svelte'");
 			expect(svelte).not.toContain('Choose how to attest your new coordinates');
 			expect(svelte).not.toContain('Device geolocation — nothing leaves the browser');
 			expect(svelte).not.toContain('Drop a pin on your new location');
+		});
+	});
+
+	describe('method chooser removal — address entry is the single entry point', () => {
+		it('opens directly on true-address entry with no location/map chooser', () => {
+			const svelte = source('src/lib/components/auth/AddressVerificationFlow.svelte');
+
+			// The flow starts on address entry; the method is a fixed const (not a chooser).
+			expect(svelte).toContain("let flowStep: FlowStep = $state('address-input')");
+			expect(svelte).toContain("const verificationMethod = 'address' as const");
+
+			// The chooser, geolocation, and map-pin paths are gone entirely.
+			expect(svelte).not.toContain("'path-select'");
+			expect(svelte).not.toContain("'geolocating'");
+			expect(svelte).not.toContain("'map-pin'");
+			expect(svelte).not.toContain('handleGeolocationPath');
+			expect(svelte).not.toContain('handleSelectAddressPath');
+			expect(svelte).not.toContain('handleMapPinSelect');
+			expect(svelte).not.toContain('MapPinSelector');
+
+			// No crypto jargon and no false "deleted" claim leaks into user copy.
+			// (The chooser's "against the district commitment" privacy note and the
+			// "used once for verification, then deleted" line are both gone.)
+			expect(svelte).not.toContain('against the district commitment');
+			expect(svelte).not.toContain('without typing an address');
+			expect(svelte).not.toContain('then deleted');
+		});
+
+		it('preserves the client-side commitment privacy chain on the address path', () => {
+			const svelte = source('src/lib/components/auth/AddressVerificationFlow.svelte');
+
+			// resolveClientSide stays — it computes the commitment client-side from
+			// the server-returned coordinates.
+			expect(svelte).toContain('async function resolveClientSide');
+			expect(svelte).toContain('/api/location/resolve-address');
+			expect(svelte).toContain('persistGroundVaultForAddress');
+			expect(svelte).toContain('poseidon2Sponge24');
 		});
 	});
 

--- a/tests/unit/topic/template-text-match.test.ts
+++ b/tests/unit/topic/template-text-match.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect } from 'vitest';
+import {
+	tokenize,
+	scoreTemplateAgainstText,
+	matchExistingCampaigns,
+	MIN_QUERY_LENGTH
+} from '$lib/core/topic/template-text-match';
+import type { Template } from '$lib/types/template';
+
+/**
+ * Minimal Template factory — only the fields the matcher reads
+ * (title, description, domain, topics, slug, send_count).
+ */
+function makeTemplate(over: Partial<Template> & { title: string }): Template {
+	return {
+		id: over.slug ?? over.title.toLowerCase().replace(/\s+/g, '-'),
+		slug: over.slug ?? over.title.toLowerCase().replace(/\s+/g, '-'),
+		description: '',
+		domain: '',
+		type: 'campaign',
+		deliveryMethod: 'email',
+		message_body: '',
+		delivery_config: {},
+		recipient_config: {},
+		coordinationScale: 0,
+		isNew: false,
+		status: 'published',
+		is_public: true,
+		send_count: 0,
+		preview: '',
+		createdAt: new Date('2020-01-01T00:00:00Z'),
+		updatedAt: new Date('2020-01-01T00:00:00Z'),
+		...over
+	} as Template;
+}
+
+/**
+ * REAL launch corpus — copied verbatim (slug/title/domain/topics/description) from
+ * convex/seedData.ts so the matcher is validated against the data it actually ships
+ * with, not invented topic slugs. If seedData.ts changes, these fixtures must too.
+ *
+ * Earlier fixtures used fabricated topics ('rent-control', 'affordable-housing')
+ * that do NOT exist in the seed corpus; the central assertion only passed because of
+ * the fiction. These triples are the genuine article.
+ */
+const housing = makeTemplate({
+	slug: 'portland-affordable-home-bans',
+	title: 'Stop blocking the homes we can actually afford',
+	description:
+		'The City of Portland must remove the regulatory barriers to 3D-printed housing and community land trusts to provide homes at a fraction of traditional construction costs.',
+	domain: 'Housing & Zoning Reform',
+	topics: ['3d-printed-housing', 'zoning', 'community-land-trusts']
+});
+
+const veterans = makeTemplate({
+	slug: 'va-rural-telehealth-expansion',
+	title: 'Bring the telehealth that works to rural clinics',
+	description:
+		'The Department of Veterans Affairs must fund the expansion of its proven telehealth program to every rural clinic in the country.',
+	domain: 'Veterans Healthcare Access',
+	topics: ['telehealth', 'veterans', 'rural-access', 'clinic-funding'],
+	send_count: 200
+});
+
+const bikes = makeTemplate({
+	slug: 'montreal-bixi-savings',
+	title: "Montreal's BIXI program saves more in health than it costs",
+	description:
+		"Montreal's BIXI bike-share program cut downtown car trips by 12% and saves $14 million per year in healthcare costs from reduced pollution.",
+	domain: 'Bike Infrastructure & Public Health',
+	topics: ['bike-share', 'pollution-reduction', 'active-transport', 'municipal-investment']
+});
+
+const childcare = makeTemplate({
+	slug: 'preschool-success-model',
+	title: 'Preschool for every child pays for itself and our future',
+	description:
+		"Our state must adopt the model of Colorado's universal preschool program to deliver immediate savings for families and lasting economic benefits.",
+	domain: 'Universal Preschool',
+	topics: ['early-childhood', 'childcare-costs', 'economic-returns', 'family-support']
+});
+
+const kidsPrivacy = makeTemplate({
+	slug: 'modernize-coppa-protections',
+	title: "Our children's privacy is still stuck in 1998",
+	description:
+		"Kids spend 7 hours a day online. Companies harvest 72 million data points per child per year. Federal privacy law hasn't updated since 1998 — COPPA is older than the kids it's supposed to protect.",
+	domain: "Children's Digital Privacy",
+	topics: ['privacy', 'internet-safety', 'consumer-protection', 'coppa']
+});
+
+const ceoPay = makeTemplate({
+	slug: 'apple-fifteen-minutes',
+	title: 'Our year of work is just fifteen minutes of interest',
+	description: "Apple must raise retail wages to reflect the company's vast wealth and interest income.",
+	domain: 'Retail Wages & Corporate Pay Disparity',
+	topics: ['wage-inequality', 'ceo-pay-ratio', 'corporate-accountability']
+});
+
+const corpus = [housing, veterans, bikes, childcare, kidsPrivacy, ceoPay];
+
+describe('tokenize', () => {
+	it('lowercases, drops short tokens and stopwords, de-dupes', () => {
+		expect(tokenize('The rent keeps going up but rent rent')).toEqual(['rent']);
+	});
+
+	it('folds dashes so "rural-access" matches "rural access"', () => {
+		expect(tokenize('rural-access')).toEqual(['rural', 'access']);
+	});
+
+	it('returns [] for empty input', () => {
+		expect(tokenize('')).toEqual([]);
+	});
+});
+
+describe('scoreTemplateAgainstText', () => {
+	it('scores a title-overlapping query above zero', () => {
+		// "afford" is in the real housing title.
+		const score = scoreTemplateAgainstText(housing, tokenize('homes we can afford'));
+		expect(score).toBeGreaterThan(0);
+	});
+
+	it('scores an unrelated query at zero', () => {
+		const score = scoreTemplateAgainstText(housing, tokenize('protected bike lanes downtown'));
+		expect(score).toBe(0);
+	});
+
+	it('does not penalize a long natural sentence for its length', () => {
+		// Sum-not-average: a single strong topic/title hit clears the floor regardless
+		// of how many words surround it. A 0.4 title hit in a 6-token sentence must not
+		// be diluted to 0.4/6 ≈ 0.07 (the old averaging bug that made the matcher inert).
+		const short = scoreTemplateAgainstText(housing, tokenize('homes afford'));
+		const long = scoreTemplateAgainstText(
+			housing,
+			tokenize('the only homes around here that families can actually afford')
+		);
+		expect(long).toBeGreaterThanOrEqual(short);
+		expect(long).toBeGreaterThanOrEqual(0.25);
+	});
+
+	it('clamps the score at 1', () => {
+		// "ceo" + "pay" both land on the ceo-pay-ratio topic (0.5 each = 1.0).
+		const score = scoreTemplateAgainstText(ceoPay, tokenize('ceo pay ratio is obscene'));
+		expect(score).toBeLessThanOrEqual(1);
+	});
+});
+
+describe('matchExistingCampaigns', () => {
+	it('matches a housing grievance to the housing template via title', () => {
+		const matches = matchExistingCampaigns(corpus, 'the homes around here we can actually afford');
+		expect(matches.length).toBeGreaterThanOrEqual(1);
+		expect(matches[0].template.slug).toBe('portland-affordable-home-bans');
+	});
+
+	/**
+	 * Lay-vocabulary recall: the realistic case the front door must serve. A person
+	 * types their grievance in plain words ("my rent keeps going up, can't afford my
+	 * apartment"); they rarely echo a curated topic slug. The OLD averaging matcher
+	 * returned [] here (a single 0.4 title hit on "afford" diluted across the whole
+	 * sentence). With summed credit, the title hit alone clears the floor.
+	 */
+	it('surfaces the housing campaign for a plain-language rent grievance', () => {
+		const matches = matchExistingCampaigns(corpus, "my rent keeps going up, can't afford my apartment");
+		expect(matches.length).toBeGreaterThanOrEqual(1);
+		expect(matches[0].template.slug).toBe('portland-affordable-home-bans');
+	});
+
+	it('surfaces the childcare campaign for "child care is too expensive"', () => {
+		const matches = matchExistingCampaigns(corpus, 'child care is too expensive for working families');
+		expect(matches.length).toBeGreaterThanOrEqual(1);
+		expect(matches[0].template.slug).toBe('preschool-success-model');
+	});
+
+	it('surfaces the kids-privacy campaign for "kids privacy online"', () => {
+		const matches = matchExistingCampaigns(corpus, "kids' privacy is not protected online");
+		expect(matches.length).toBeGreaterThanOrEqual(1);
+		expect(matches[0].template.slug).toBe('modernize-coppa-protections');
+	});
+
+	it('surfaces the CEO-pay campaign for a plain-language pay grievance', () => {
+		const matches = matchExistingCampaigns(corpus, 'ceo pay is out of control while workers struggle');
+		expect(matches.length).toBeGreaterThanOrEqual(1);
+		expect(matches[0].template.slug).toBe('apple-fifteen-minutes');
+	});
+
+	it('returns [] for an unrelated grievance (honest empty — no fabricated match)', () => {
+		const matches = matchExistingCampaigns(corpus, 'climate emissions carbon tax credits');
+		expect(matches).toEqual([]);
+	});
+
+	it('does not false-match an unrelated infrastructure grievance', () => {
+		// Precision guard: a grievance with no genuine facet overlap must stay empty
+		// even though the corpus contains transportation/infrastructure campaigns.
+		expect(matchExistingCampaigns(corpus, 'please fix the potholes on my street')).toEqual([]);
+	});
+
+	it('returns [] when text is shorter than the minimum query length', () => {
+		const short = 'rent up'; // < MIN_QUERY_LENGTH
+		expect(short.length).toBeLessThan(MIN_QUERY_LENGTH);
+		expect(matchExistingCampaigns(corpus, short)).toEqual([]);
+	});
+
+	it('returns [] over an empty corpus', () => {
+		expect(matchExistingCampaigns([], 'the rent keeps going up and up')).toEqual([]);
+	});
+
+	it('respects the limit and sorts by score then send_count', () => {
+		const matches = matchExistingCampaigns(corpus, 'veterans need telehealth at the rural clinic', {
+			limit: 1
+		});
+		expect(matches.length).toBe(1);
+		expect(matches[0].template.slug).toBe('va-rural-telehealth-expansion');
+	});
+
+	it('is deterministic across input ordering', () => {
+		const a = matchExistingCampaigns(corpus, 'children privacy online safety');
+		const b = matchExistingCampaigns([...corpus].reverse(), 'children privacy online safety');
+		expect(a.map((m) => m.template.slug)).toEqual(b.map((m) => m.template.slug));
+	});
+});


### PR DESCRIPTION
Reworks the individual's message-creation journey end to end, from a 3-lens design examination of the flow validated against code. Each change went through a **do→review cycle** (often a parallel workflow), and the adversarial reviews repeatedly caught things the green source-pin tests did not.

## The problems (from the UX assessment) — all closed
- **P1 — verification ladder rendered as walls.** `CredibilityLadder` (interaction-first stepper: rail fills as you climb, next stop pulses, each stop reveals its payoff on hover/tap/focus) replaces the binary "Verify X to Send" gate headers + adds an honest send-now nudge on `/s/[slug]`. Gov-ID is a "soon" rung.
- **P5 — mDL dead-end** ("Coming soon.") inverted into that ladder (no climbable false next-step in the gated case).
- **P2 — no send peak.** `SendConfirmation` peak: "contacted" is now set **only on an explicit confirm** (was a tab-return/timer heuristic that claimed contact the app can't observe). Names the consequence, shows the `/v/[hash]` receipt, offers share; copy/manual-select fallback for no-mail-client.
- **P3 — publish-before-send** foregrounds the send ("Continue to send", publish reframed as opt-in amplification). Grounding showed a true unlisted split was infeasible (the API hardcodes `isPublic`, `/s/[slug]` 404s unlisted) so faking it was refused.
- **P4 — proof footer** reframed sender-facing; routed through the **tier-display SSOT** so a self-reported sender reads "Self-reported constituent" (not overclaimed "Verified resident") — matching `/v/[hash]`.

## Front-door + authoring polish
- The **AI generate trigger** is surfaced as a primary button past `MIN_INPUT_LENGTH` (both active + written-artifact states); guest-only auth pre-signal; refinement de-scarcified.
- **Search-first front door**: a new pure, zero-cost client-side text matcher surfaces real matching campaigns as you type (honest by construction — `[]` → renders nothing).

## Address-first verification (the latest correction)
Removed the district method-chooser + the address-avoiding geolocation/map-pin paths — Commons needs the **true address** for CWC delivery. The flow opens straight on address entry; the **ZK/encryption privacy stays fully in place but invisible** (client-side district commitment, server logs only the district, address AES-256-GCM encrypted on-device + kept for delivery). Fixed a now-false "...then deleted" claim.

## Adversarial-review catches (none surfaced by green tests)
focus-trap a11y gap (WCAG 2.1.2) · residency overclaim · the "Send this now" forward-overclaim · the "then deleted" lie · a written-state re-buried trigger · stale test assertions.

**~60 new tests; full suite 5,057 pass; svelte-check 0 errors.** Not yet visually QA'd (local dev/browser environment friction).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a 3-stage email send confirmation dialog (confirm → sent → copy/share) with copy-to-clipboard fallback and recipient-safe messaging.
  * Introduced search-first campaign matching while composing (“Already a campaign on this?”).

* **Improvements**
  * Updated verification to address-only for standard flows; re-grounding now progresses through clearer capture/witness/complete phases.
  * Refined credibility ladder usage across verification and send prompts, with improved focus and reduced-motion behavior.
  * Simplified attestation/proof wording and standardized sender footer labeling for email/receipts.

* **Tests**
  * Added/expanded unit coverage for the new matching and send/verification flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->