### PR TITLE
fix(csp): allow Sentry ingest in connect-src

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -85,7 +85,11 @@ const config = {
 					...atlasHosts,
 					// Convex: HTTP queries + WebSocket subscriptions (dual-stack, Cycle 1)
 					'https://*.convex.cloud',
-					'wss://*.convex.cloud'
+					'wss://*.convex.cloud',
+					// Sentry error-monitoring ingest (envelope POSTs from the browser SDK).
+					// DSN host is o<org>.ingest.us.sentry.io — the wildcard matches the org
+					// subdomain. Without this the SDK's reports are CSP-blocked.
+					'https://*.ingest.us.sentry.io'
 				],
 				'worker-src': ['self', 'blob:'],
 				'object-src': ['none'],

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -87,9 +87,11 @@ const config = {
 					'https://*.convex.cloud',
 					'wss://*.convex.cloud',
 					// Sentry error-monitoring ingest (envelope POSTs from the browser SDK).
-					// DSN host is o<org>.ingest.us.sentry.io — the wildcard matches the org
-					// subdomain. Without this the SDK's reports are CSP-blocked.
-					'https://*.ingest.us.sentry.io'
+					// Pinned to OUR org's EXACT ingest host — NOT a `*.ingest.us.sentry.io`
+					// wildcard, which would let an XSS exfiltrate to any Sentry US org. The
+					// `o<org>` subdomain is stable across projects; keep in sync with
+					// PUBLIC_SENTRY_DSN's host if the Sentry org ever changes.
+					'https://o4510735138422784.ingest.us.sentry.io'
 				],
 				'worker-src': ['self', 'blob:'],
 				'object-src': ['none'],

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -13,6 +13,23 @@ const atlasHosts = configuredAtlasHost && configuredAtlasHost !== DEFAULT_ATLAS_
 	? [DEFAULT_ATLAS_HOST, configuredAtlasHost]
 	: [DEFAULT_ATLAS_HOST];
 
+// Sentry ingest host for connect-src, derived from the DSN at build time (like
+// atlasHosts above) so the CSP allows ONLY our exact org's ingest endpoint — no
+// `*.sentry.io` wildcard (which would permit exfiltration to other Sentry orgs
+// under XSS) and no drift-prone hardcoded org id in the policy. Falls back to the
+// known org host if PUBLIC_SENTRY_DSN isn't in the build env, so error monitoring
+// is never silently CSP-blocked.
+const SENTRY_INGEST_FALLBACK = 'https://o4510735138422784.ingest.us.sentry.io';
+const sentryIngestOrigin = (() => {
+	const dsn = (process.env.PUBLIC_SENTRY_DSN || '').trim();
+	if (!dsn) return SENTRY_INGEST_FALLBACK;
+	try {
+		return new URL(dsn).origin;
+	} catch {
+		return SENTRY_INGEST_FALLBACK;
+	}
+})();
+
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	preprocess: [vitePreprocess()],
@@ -86,12 +103,10 @@ const config = {
 					// Convex: HTTP queries + WebSocket subscriptions (dual-stack, Cycle 1)
 					'https://*.convex.cloud',
 					'wss://*.convex.cloud',
-					// Sentry error-monitoring ingest (envelope POSTs from the browser SDK).
-					// Pinned to OUR org's EXACT ingest host — NOT a `*.ingest.us.sentry.io`
-					// wildcard, which would let an XSS exfiltrate to any Sentry US org. The
-					// `o<org>` subdomain is stable across projects; keep in sync with
-					// PUBLIC_SENTRY_DSN's host if the Sentry org ever changes.
-					'https://o4510735138422784.ingest.us.sentry.io'
+					// Sentry error-monitoring ingest — exact org host derived from the DSN
+					// at build time (see sentryIngestOrigin above): no wildcard, no
+					// hardcoded org id in the policy.
+					sentryIngestOrigin
 				],
 				'worker-src': ['self', 'blob:'],
 				'object-src': ['none'],


### PR DESCRIPTION
Browser console showed CSP blocking the Sentry SDK's envelope POST to `o4510735138422784.ingest.us.sentry.io` — `connect-src` didn't include the ingest host, so error/trace reports never reached Sentry (error monitoring silently dead in prod).

Adds `https://*.ingest.us.sentry.io` to `connect-src` in `svelte.config.js` (the wildcard matches the `o<org>` subdomain). Config loads; no CSP test pins the directive. Takes effect on the next build/deploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application configuration to allow error reports to be properly transmitted to error tracking services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->