### PR TITLE
fix(congressional): align client gate to the Tier-2 API delivery floor (gov-ID = badge, not bar)

### DIFF
--- a/convex/_policy.ts
+++ b/convex/_policy.ts
@@ -1,0 +1,19 @@
+/**
+ * Cross-boundary delivery policy — the single source of truth shared by all three
+ * enforcement points, so a security/access-control tier can never drift across them:
+ *
+ *   - the Convex action       `convex/submissions.ts`            (`./_policy`)
+ *   - the SvelteKit endpoint  `src/routes/api/submissions/create` (`$convex/_policy`)
+ *   - the client gate         `TemplateModal.svelte`             (`$convex/_policy`)
+ *
+ * Lives in `convex/` because `convex/` cannot import from `src/`, but `src/` resolves
+ * `convex/` via the `$convex` alias (svelte.config.js) — so this is the only location
+ * reachable from every side. Underscore-prefixed so Convex treats it as a helper
+ * module, not a function module.
+ *
+ * REQUIRED_CONGRESSIONAL_PROOF_TIER — the floor for API-relayed (CWC / congressional)
+ * delivery. Tier 2 (district-confirmed via the address-first flow) DELIVERS; gov-ID
+ * (tier 4) raises the assurance BADGE on the proof, it is NOT the bar. Email/mailto
+ * delivery is open (no gate) — the channel sets the requirement, not the recipient.
+ */
+export const REQUIRED_CONGRESSIONAL_PROOF_TIER = 2;

--- a/convex/submissions.ts
+++ b/convex/submissions.ts
@@ -13,6 +13,7 @@ import { requireAuth } from './_authHelpers';
 import { requireInternalSecret } from './_internalAuth';
 import { CWCXmlGenerator } from './_cwcXml';
 import { selectActiveCredentialForUser } from './_credentialSelect';
+import { REQUIRED_CONGRESSIONAL_PROOF_TIER } from './_policy';
 
 // =============================================================================
 // SUBMISSIONS — ZK proof creation + congressional delivery
@@ -321,7 +322,9 @@ export const create = action({
 		// resolver (`+server.ts`), NOT here — on the direct Convex path the domain
 		// in publicInputs is still self-referential. See follow-up note in the
 		// security review; closing it means moving the rebind into this action.
-		const REQUIRED_CONGRESSIONAL_PROOF_TIER = 2;
+		//
+		// REQUIRED_CONGRESSIONAL_PROOF_TIER is imported from `convex/_policy` — the
+		// single source of truth shared with the SvelteKit handler + client gate.
 		if (credentialStatus.trustTier < REQUIRED_CONGRESSIONAL_PROOF_TIER) {
 			throw new Error('INSUFFICIENT_AUTHORITY');
 		}

--- a/src/lib/components/template/TemplateModal.svelte
+++ b/src/lib/components/template/TemplateModal.svelte
@@ -62,6 +62,7 @@
 	import type { ComponentTemplate } from '$lib/types/component-props';
 	import type { Representative } from '$lib/types/any-replacements';
 	import type { Representative as ProviderRepresentative } from '$lib/core/legislative/types';
+	import { REQUIRED_CONGRESSIONAL_PROOF_TIER } from '$convex/_policy';
 
 	let {
 		template,
@@ -865,7 +866,7 @@
 		}
 
 		const credential = await getUsableProofCredential(user.id);
-		if (!credential || !credentialMeetsMinimumTier(credential, 4)) {
+		if (!credential || !credentialMeetsMinimumTier(credential, REQUIRED_CONGRESSIONAL_PROOF_TIER)) {
 			showVerificationGate = true;
 			return;
 		}
@@ -2022,21 +2023,14 @@
 
 <!-- Verification Gate Modal -->
 {#if user?.id}
-	<!--
-		minimumTier=2: Tier 2 (district-confirmed via the address-first flow) is the
-		DELIVERY bar for API-relayed sends — it mirrors REQUIRED_CONGRESSIONAL_PROOF_TIER
-		in BOTH submission endpoints (convex/submissions.ts + api/submissions/create).
-		Gov-ID (tier 4) raises the assurance BADGE on the proof, it is not the gate; the
-		ladder surfaces it as the optional "counts more" upgrade. The client was
-		over-gating at 4 — this aligns it to the server's actual bar so a verified
-		constituent can send through the CWC API today (no mDL dependency).
-	-->
+	<!-- API-delivery floor; see REQUIRED_CONGRESSIONAL_PROOF_TIER above. gov-ID is the
+	     optional "counts more" upgrade the ladder surfaces, not the gate. -->
 	<VerificationGate
 		bind:this={verificationGateRef}
 		userId={user.id}
 		templateSlug={template.slug}
 		cellId={verifiedCellId}
-		minimumTier={2}
+		minimumTier={REQUIRED_CONGRESSIONAL_PROOF_TIER}
 		electedTarget={template.deliveryMethod === 'cwc'}
 		userTrustTier={user.trust_tier ?? 1}
 		bind:showModal={showVerificationGate}

--- a/src/lib/components/template/TemplateModal.svelte
+++ b/src/lib/components/template/TemplateModal.svelte
@@ -2022,12 +2022,21 @@
 
 <!-- Verification Gate Modal -->
 {#if user?.id}
+	<!--
+		minimumTier=2: Tier 2 (district-confirmed via the address-first flow) is the
+		DELIVERY bar for API-relayed sends — it mirrors REQUIRED_CONGRESSIONAL_PROOF_TIER
+		in BOTH submission endpoints (convex/submissions.ts + api/submissions/create).
+		Gov-ID (tier 4) raises the assurance BADGE on the proof, it is not the gate; the
+		ladder surfaces it as the optional "counts more" upgrade. The client was
+		over-gating at 4 — this aligns it to the server's actual bar so a verified
+		constituent can send through the CWC API today (no mDL dependency).
+	-->
 	<VerificationGate
 		bind:this={verificationGateRef}
 		userId={user.id}
 		templateSlug={template.slug}
 		cellId={verifiedCellId}
-		minimumTier={template.deliveryMethod === 'cwc' ? 4 : 2}
+		minimumTier={2}
 		electedTarget={template.deliveryMethod === 'cwc'}
 		userTrustTier={user.trust_tier ?? 1}
 		bind:showModal={showVerificationGate}

--- a/src/lib/config/features.ts
+++ b/src/lib/config/features.ts
@@ -30,7 +30,9 @@ export const FEATURES = {
 	 * CWC delivery, district officials, congressional template routing.
 	 * Code exists; this is the ENTRY launch gate: when false, CWC templates are
 	 * excluded from discovery and direct CWC template routes 404. The submission
-	 * endpoint also requires Tier 4+ proof authority before delivery can run.
+	 * endpoints additionally require Tier 2+ (district-confirmed) proof authority
+	 * before delivery runs — gov-ID (tier 4) raises the assurance badge, it is not
+	 * the bar (see REQUIRED_CONGRESSIONAL_PROOF_TIER).
 	 *
 	 * Env-driven so the entry opens from BUILD config (`VITE_CONGRESSIONAL=1`) per
 	 * environment, not by editing this constant — default OFF leaves prod unchanged

--- a/src/routes/api/submissions/create/+server.ts
+++ b/src/routes/api/submissions/create/+server.ts
@@ -4,6 +4,7 @@ import type { RequestHandler } from './$types';
 import { serverAction, serverQuery } from 'convex-sveltekit';
 import { api } from '$lib/convex';
 import type { Id } from '$convex/_generated/dataModel';
+import { REQUIRED_CONGRESSIONAL_PROOF_TIER } from '$convex/_policy';
 import {
 	isCredentialValidForAction,
 	formatValidationError,
@@ -27,8 +28,10 @@ const CURRENT_SESSION_ID = '119th-congress';
 // non-revoked district credential (the structural requirement deliverToCongress
 // enforces), so this is a policy threshold, not a security mechanic — every
 // fail-closed check (active credential, revocation, nullifier, domain binding,
-// witness expiry) is unchanged.
-const REQUIRED_CONGRESSIONAL_PROOF_TIER = 2;
+// witness expiry) is unchanged. REQUIRED_CONGRESSIONAL_PROOF_TIER is imported from
+// `$convex/_policy` — the single source of truth shared with the Convex action
+// (convex/submissions.ts) and the client gate (TemplateModal), so the floor can
+// never drift across the three enforcement points.
 
 /**
  * Submission Creation Endpoint

--- a/tests/unit/components/congressional-delivery-gate.behavior.test.ts
+++ b/tests/unit/components/congressional-delivery-gate.behavior.test.ts
@@ -1,0 +1,90 @@
+/**
+ * BEHAVIORAL coverage for the API/CWC (congressional) delivery floor — renders the
+ * VerificationGate AT the congressional floor (REQUIRED_CONGRESSIONAL_PROOF_TIER) and
+ * asserts a constituent at the floor proceeds while one below it is gated. A dead or
+ * over-gate fails this, unlike a source-text grep.
+ *
+ * Runs in the COMPONENTS lane (vitest.components.config.ts) — Svelte 5 mount() is
+ * unavailable in CI's main jsdom+MSW lane, so this file is excluded from vitest.config.ts
+ * (same as VerificationGate-auto-dismiss.test.ts). The structural single-source lock that
+ * DOES run in CI lives in congressional-delivery-tier.test.ts.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor, cleanup } from '@testing-library/svelte';
+
+import { REQUIRED_CONGRESSIONAL_PROOF_TIER } from '../../../convex/_policy';
+
+// Mock the gate's heavy dependencies so it mounts in jsdom (mirrors
+// VerificationGate-auto-dismiss.test.ts). If the gov-ID upgrade flow mounts when it
+// shouldn't, the stub's testid surfaces it.
+vi.mock('$lib/components/auth/IdentityVerificationFlow.svelte', async () => {
+	const mod = await import('../../mocks/IdentityVerificationFlowStub.svelte');
+	return { default: mod.default };
+});
+vi.mock('$lib/components/auth/IdentityRecoveryFlow.svelte', async () => {
+	const mod = await import('../../mocks/IdentityRecoveryFlowStub.svelte');
+	return { default: mod.default };
+});
+vi.mock('$lib/components/auth/AddressVerificationFlow.svelte', async () => {
+	const mod = await import('../../mocks/AddressVerificationFlowStub.svelte');
+	return { default: mod.default };
+});
+vi.mock('$lib/core/identity/recovery-detector', () => ({
+	credentialMeetsMinimumTier: vi.fn(() => true),
+	getUsableProofCredential: vi.fn(async () => null),
+	needsCredentialRecovery: vi.fn(async () => false),
+}));
+vi.mock('$lib/config/features', () => ({
+	isAnyMdlProtocolEnabled: vi.fn(() => true),
+}));
+vi.mock('$lib/core/locale/jurisdiction', () => ({
+	getJurisdictionLabels: vi.fn(() => ({ legislativeBody: 'Congress' })),
+}));
+vi.mock('$lib/stores/decryptedUser.svelte', () => ({
+	decryptedUser: { email: 'test@example.com' },
+}));
+
+import VerificationGate from '$lib/components/auth/VerificationGate.svelte';
+
+describe('API/CWC delivery floor — behavioral gate at the congressional floor', () => {
+	beforeEach(() => vi.clearAllMocks());
+	afterEach(() => cleanup());
+
+	it('a constituent AT the floor proceeds — gate auto-dismisses, no gov-ID upgrade wall', async () => {
+		const oncancel = vi.fn();
+		const onverified = vi.fn();
+		const { queryByTestId } = render(VerificationGate, {
+			props: {
+				userId: 'test-user',
+				showModal: true,
+				minimumTier: REQUIRED_CONGRESSIONAL_PROOF_TIER,
+				userTrustTier: REQUIRED_CONGRESSIONAL_PROOF_TIER,
+				oncancel,
+				onverified,
+			},
+		});
+		// At the floor the gate recognizes the constituent is already verified and
+		// dismisses (the send proceeds) — it does NOT mount the gov-ID upgrade flow.
+		await waitFor(() => expect(oncancel).toHaveBeenCalledTimes(1));
+		expect(queryByTestId('identity-verification-flow-stub')).toBeNull();
+		expect(onverified).not.toHaveBeenCalled();
+	});
+
+	it('a constituent BELOW the floor is gated — no auto-dismiss', async () => {
+		const oncancel = vi.fn();
+		const onverified = vi.fn();
+		render(VerificationGate, {
+			props: {
+				userId: 'test-user',
+				showModal: true,
+				minimumTier: REQUIRED_CONGRESSIONAL_PROOF_TIER,
+				userTrustTier: REQUIRED_CONGRESSIONAL_PROOF_TIER - 1,
+				oncancel,
+				onverified,
+			},
+		});
+		await new Promise((r) => setTimeout(r, 50));
+		expect(oncancel).not.toHaveBeenCalled();
+		expect(onverified).not.toHaveBeenCalled();
+	});
+});

--- a/tests/unit/components/congressional-delivery-tier.test.ts
+++ b/tests/unit/components/congressional-delivery-tier.test.ts
@@ -1,111 +1,32 @@
 /**
  * API/CWC (congressional) delivery floor = REQUIRED_CONGRESSIONAL_PROOF_TIER (Tier 2),
- * a SINGLE source of truth (convex/_policy) shared across the three enforcement points
- * so the floor can never drift. Two layers, addressing the brutalist review of the
- * first (green-by-construction) version of this file:
+ * a SINGLE source of truth (convex/_policy) shared across the three enforcement points.
  *
- *  1. BEHAVIORAL — render VerificationGate AT the congressional floor and assert a
- *     constituent at the floor proceeds while one below it is gated. A dead/over-gate
- *     fails this, unlike a source-text grep.
- *  2. STRUCTURAL — assert all three sites IMPORT the one constant (no local literal,
- *     no hardcoded tier-4), and that each server endpoint actually gates on it.
+ * STRUCTURAL coverage — runs in CI's main lane. Asserts the floor is declared exactly
+ * once and every site DERIVES from it: no local literal, no hardcoded tier-4 in either
+ * client gate, and each server endpoint actually gates on the constant. This is a set of
+ * structural CONTRACTS, not a single spelling check — the regression that shipped (a
+ * residual `credentialMeetsMinimumTier(credential, 4)`) fails the tier-4 assertions.
  *
- * Runs under `vitest.components.config.ts` (Svelte 5 + DOM env).
+ * The BEHAVIORAL render assertion (constituent at the floor proceeds, below is gated)
+ * lives in the components lane — congressional-delivery-gate.behavior.test.ts — because
+ * Svelte 5 mount() is unavailable in CI's main jsdom+MSW lane (see vitest.config.ts).
  */
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, waitFor, cleanup } from '@testing-library/svelte';
+import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-
-// The constant under test — imported by value (relative, no alias dependency) so the
-// behavioral floor below tracks the real policy, not a copied literal.
 import { REQUIRED_CONGRESSIONAL_PROOF_TIER } from '../../../convex/_policy';
-
-// Mock the gate's heavy dependencies so it mounts in jsdom (mirrors
-// VerificationGate-auto-dismiss.test.ts). If the gov-ID upgrade flow mounts when it
-// shouldn't, the stub's testid surfaces it.
-vi.mock('$lib/components/auth/IdentityVerificationFlow.svelte', async () => {
-	const mod = await import('../../mocks/IdentityVerificationFlowStub.svelte');
-	return { default: mod.default };
-});
-vi.mock('$lib/components/auth/IdentityRecoveryFlow.svelte', async () => {
-	const mod = await import('../../mocks/IdentityRecoveryFlowStub.svelte');
-	return { default: mod.default };
-});
-vi.mock('$lib/components/auth/AddressVerificationFlow.svelte', async () => {
-	const mod = await import('../../mocks/AddressVerificationFlowStub.svelte');
-	return { default: mod.default };
-});
-vi.mock('$lib/core/identity/recovery-detector', () => ({
-	credentialMeetsMinimumTier: vi.fn(() => true),
-	getUsableProofCredential: vi.fn(async () => null),
-	needsCredentialRecovery: vi.fn(async () => false),
-}));
-vi.mock('$lib/config/features', () => ({
-	isAnyMdlProtocolEnabled: vi.fn(() => true),
-}));
-vi.mock('$lib/core/locale/jurisdiction', () => ({
-	getJurisdictionLabels: vi.fn(() => ({ legislativeBody: 'Congress' })),
-}));
-vi.mock('$lib/stores/decryptedUser.svelte', () => ({
-	decryptedUser: { email: 'test@example.com' },
-}));
-
-import VerificationGate from '$lib/components/auth/VerificationGate.svelte';
 
 const src = (p: string) => readFileSync(resolve(process.cwd(), p), 'utf8');
 
-describe('API/CWC delivery floor — BEHAVIORAL gate at the congressional floor', () => {
-	beforeEach(() => vi.clearAllMocks());
-	afterEach(() => cleanup());
-
-	it('a constituent AT the floor proceeds — gate auto-dismisses, no gov-ID upgrade wall', async () => {
-		const oncancel = vi.fn();
-		const onverified = vi.fn();
-		const { queryByTestId } = render(VerificationGate, {
-			props: {
-				userId: 'test-user',
-				showModal: true,
-				minimumTier: REQUIRED_CONGRESSIONAL_PROOF_TIER,
-				userTrustTier: REQUIRED_CONGRESSIONAL_PROOF_TIER,
-				oncancel,
-				onverified,
-			},
-		});
-		// At the floor the gate recognizes the constituent is already verified and
-		// dismisses (the send proceeds) — it does NOT mount the gov-ID upgrade flow.
-		await waitFor(() => expect(oncancel).toHaveBeenCalledTimes(1));
-		expect(queryByTestId('identity-verification-flow-stub')).toBeNull();
-		expect(onverified).not.toHaveBeenCalled();
-	});
-
-	it('a constituent BELOW the floor is gated — no auto-dismiss', async () => {
-		const oncancel = vi.fn();
-		const onverified = vi.fn();
-		render(VerificationGate, {
-			props: {
-				userId: 'test-user',
-				showModal: true,
-				minimumTier: REQUIRED_CONGRESSIONAL_PROOF_TIER,
-				userTrustTier: REQUIRED_CONGRESSIONAL_PROOF_TIER - 1,
-				oncancel,
-				onverified,
-			},
-		});
-		await new Promise((r) => setTimeout(r, 50));
-		expect(oncancel).not.toHaveBeenCalled();
-		expect(onverified).not.toHaveBeenCalled();
-	});
-});
-
-describe('API/CWC delivery floor — STRUCTURAL single source of truth (no drift)', () => {
+describe('API/CWC delivery floor — single source of truth (no drift across the 3 sites)', () => {
 	const SITES = [
 		'convex/submissions.ts',
 		'src/routes/api/submissions/create/+server.ts',
 		'src/lib/components/template/TemplateModal.svelte',
 	];
 
-	it('the floor is Tier 2 and is declared in exactly ONE place (convex/_policy)', () => {
+	it('the floor is Tier 2 and declared in exactly ONE place (convex/_policy)', () => {
 		expect(REQUIRED_CONGRESSIONAL_PROOF_TIER).toBe(2);
 		expect(src('convex/_policy.ts')).toMatch(
 			/export const REQUIRED_CONGRESSIONAL_PROOF_TIER\s*=\s*2/

--- a/tests/unit/components/congressional-delivery-tier.test.ts
+++ b/tests/unit/components/congressional-delivery-tier.test.ts
@@ -1,0 +1,28 @@
+/**
+ * API/CWC (congressional) delivery floor = Tier 2 (verified constituent via the
+ * address-first flow). The client gate must mirror the server's
+ * REQUIRED_CONGRESSIONAL_PROOF_TIER; gov-ID (tier 4) raises the assurance BADGE on
+ * the proof, it is NOT the bar. Email/mailto delivery stays open (no gate) — the
+ * channel sets the requirement, not the recipient.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const src = (p: string) => readFileSync(resolve(process.cwd(), p), 'utf8');
+
+describe('API/CWC delivery is gated at Tier 2, client aligned to the server', () => {
+	it('the client gate (TemplateModal) requires Tier 2 — no over-gating back to gov-ID (tier 4)', () => {
+		const tm = src('src/lib/components/template/TemplateModal.svelte');
+		// minimumTier is unique to the VerificationGate prop in this file
+		expect(tm).toContain('minimumTier={2}');
+		expect(tm).not.toMatch(/minimumTier=\{[^}]*4/); // never drift back to the tier-4 gov-ID gate
+	});
+
+	it('both submission endpoints enforce the same Tier-2 floor (the server bar the client mirrors)', () => {
+		expect(src('convex/submissions.ts')).toContain('REQUIRED_CONGRESSIONAL_PROOF_TIER = 2');
+		expect(src('src/routes/api/submissions/create/+server.ts')).toContain(
+			'REQUIRED_CONGRESSIONAL_PROOF_TIER = 2'
+		);
+	});
+});

--- a/tests/unit/components/congressional-delivery-tier.test.ts
+++ b/tests/unit/components/congressional-delivery-tier.test.ts
@@ -1,28 +1,141 @@
 /**
- * API/CWC (congressional) delivery floor = Tier 2 (verified constituent via the
- * address-first flow). The client gate must mirror the server's
- * REQUIRED_CONGRESSIONAL_PROOF_TIER; gov-ID (tier 4) raises the assurance BADGE on
- * the proof, it is NOT the bar. Email/mailto delivery stays open (no gate) — the
- * channel sets the requirement, not the recipient.
+ * API/CWC (congressional) delivery floor = REQUIRED_CONGRESSIONAL_PROOF_TIER (Tier 2),
+ * a SINGLE source of truth (convex/_policy) shared across the three enforcement points
+ * so the floor can never drift. Two layers, addressing the brutalist review of the
+ * first (green-by-construction) version of this file:
+ *
+ *  1. BEHAVIORAL — render VerificationGate AT the congressional floor and assert a
+ *     constituent at the floor proceeds while one below it is gated. A dead/over-gate
+ *     fails this, unlike a source-text grep.
+ *  2. STRUCTURAL — assert all three sites IMPORT the one constant (no local literal,
+ *     no hardcoded tier-4), and that each server endpoint actually gates on it.
+ *
+ * Runs under `vitest.components.config.ts` (Svelte 5 + DOM env).
  */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor, cleanup } from '@testing-library/svelte';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { describe, expect, it } from 'vitest';
+
+// The constant under test — imported by value (relative, no alias dependency) so the
+// behavioral floor below tracks the real policy, not a copied literal.
+import { REQUIRED_CONGRESSIONAL_PROOF_TIER } from '../../../convex/_policy';
+
+// Mock the gate's heavy dependencies so it mounts in jsdom (mirrors
+// VerificationGate-auto-dismiss.test.ts). If the gov-ID upgrade flow mounts when it
+// shouldn't, the stub's testid surfaces it.
+vi.mock('$lib/components/auth/IdentityVerificationFlow.svelte', async () => {
+	const mod = await import('../../mocks/IdentityVerificationFlowStub.svelte');
+	return { default: mod.default };
+});
+vi.mock('$lib/components/auth/IdentityRecoveryFlow.svelte', async () => {
+	const mod = await import('../../mocks/IdentityRecoveryFlowStub.svelte');
+	return { default: mod.default };
+});
+vi.mock('$lib/components/auth/AddressVerificationFlow.svelte', async () => {
+	const mod = await import('../../mocks/AddressVerificationFlowStub.svelte');
+	return { default: mod.default };
+});
+vi.mock('$lib/core/identity/recovery-detector', () => ({
+	credentialMeetsMinimumTier: vi.fn(() => true),
+	getUsableProofCredential: vi.fn(async () => null),
+	needsCredentialRecovery: vi.fn(async () => false),
+}));
+vi.mock('$lib/config/features', () => ({
+	isAnyMdlProtocolEnabled: vi.fn(() => true),
+}));
+vi.mock('$lib/core/locale/jurisdiction', () => ({
+	getJurisdictionLabels: vi.fn(() => ({ legislativeBody: 'Congress' })),
+}));
+vi.mock('$lib/stores/decryptedUser.svelte', () => ({
+	decryptedUser: { email: 'test@example.com' },
+}));
+
+import VerificationGate from '$lib/components/auth/VerificationGate.svelte';
 
 const src = (p: string) => readFileSync(resolve(process.cwd(), p), 'utf8');
 
-describe('API/CWC delivery is gated at Tier 2, client aligned to the server', () => {
-	it('the client gate (TemplateModal) requires Tier 2 — no over-gating back to gov-ID (tier 4)', () => {
-		const tm = src('src/lib/components/template/TemplateModal.svelte');
-		// minimumTier is unique to the VerificationGate prop in this file
-		expect(tm).toContain('minimumTier={2}');
-		expect(tm).not.toMatch(/minimumTier=\{[^}]*4/); // never drift back to the tier-4 gov-ID gate
+describe('API/CWC delivery floor — BEHAVIORAL gate at the congressional floor', () => {
+	beforeEach(() => vi.clearAllMocks());
+	afterEach(() => cleanup());
+
+	it('a constituent AT the floor proceeds — gate auto-dismisses, no gov-ID upgrade wall', async () => {
+		const oncancel = vi.fn();
+		const onverified = vi.fn();
+		const { queryByTestId } = render(VerificationGate, {
+			props: {
+				userId: 'test-user',
+				showModal: true,
+				minimumTier: REQUIRED_CONGRESSIONAL_PROOF_TIER,
+				userTrustTier: REQUIRED_CONGRESSIONAL_PROOF_TIER,
+				oncancel,
+				onverified,
+			},
+		});
+		// At the floor the gate recognizes the constituent is already verified and
+		// dismisses (the send proceeds) — it does NOT mount the gov-ID upgrade flow.
+		await waitFor(() => expect(oncancel).toHaveBeenCalledTimes(1));
+		expect(queryByTestId('identity-verification-flow-stub')).toBeNull();
+		expect(onverified).not.toHaveBeenCalled();
 	});
 
-	it('both submission endpoints enforce the same Tier-2 floor (the server bar the client mirrors)', () => {
-		expect(src('convex/submissions.ts')).toContain('REQUIRED_CONGRESSIONAL_PROOF_TIER = 2');
-		expect(src('src/routes/api/submissions/create/+server.ts')).toContain(
-			'REQUIRED_CONGRESSIONAL_PROOF_TIER = 2'
+	it('a constituent BELOW the floor is gated — no auto-dismiss', async () => {
+		const oncancel = vi.fn();
+		const onverified = vi.fn();
+		render(VerificationGate, {
+			props: {
+				userId: 'test-user',
+				showModal: true,
+				minimumTier: REQUIRED_CONGRESSIONAL_PROOF_TIER,
+				userTrustTier: REQUIRED_CONGRESSIONAL_PROOF_TIER - 1,
+				oncancel,
+				onverified,
+			},
+		});
+		await new Promise((r) => setTimeout(r, 50));
+		expect(oncancel).not.toHaveBeenCalled();
+		expect(onverified).not.toHaveBeenCalled();
+	});
+});
+
+describe('API/CWC delivery floor — STRUCTURAL single source of truth (no drift)', () => {
+	const SITES = [
+		'convex/submissions.ts',
+		'src/routes/api/submissions/create/+server.ts',
+		'src/lib/components/template/TemplateModal.svelte',
+	];
+
+	it('the floor is Tier 2 and is declared in exactly ONE place (convex/_policy)', () => {
+		expect(REQUIRED_CONGRESSIONAL_PROOF_TIER).toBe(2);
+		expect(src('convex/_policy.ts')).toMatch(
+			/export const REQUIRED_CONGRESSIONAL_PROOF_TIER\s*=\s*2/
+		);
+	});
+
+	it('all three enforcement points IMPORT the constant — none redefines a local literal', () => {
+		for (const p of SITES) {
+			const s = src(p);
+			expect(s).toMatch(/import \{[^}]*REQUIRED_CONGRESSIONAL_PROOF_TIER[^}]*\} from '[^']*_policy'/);
+			// the drift this refactor removes: no site re-declares its own value
+			expect(s).not.toMatch(/const REQUIRED_CONGRESSIONAL_PROOF_TIER\s*=/);
+		}
+	});
+
+	it('BOTH client gates reference the constant — neither hardcodes the tier-4 gov-ID requirement', () => {
+		const tm = src('src/lib/components/template/TemplateModal.svelte');
+		expect(tm).toContain('minimumTier={REQUIRED_CONGRESSIONAL_PROOF_TIER}');
+		expect(tm).toContain(
+			'credentialMeetsMinimumTier(credential, REQUIRED_CONGRESSIONAL_PROOF_TIER)'
+		);
+		// the exact regression the review caught: a residual tier-4 gate the first fix missed
+		expect(tm).not.toMatch(/minimumTier=\{[^}]*\b4\b/);
+		expect(tm).not.toMatch(/credentialMeetsMinimumTier\([^,)]+,\s*4\)/);
+	});
+
+	it('each server endpoint actually GATES on the constant (the enforcement, not just the spelling)', () => {
+		expect(src('convex/submissions.ts')).toMatch(/trustTier < REQUIRED_CONGRESSIONAL_PROOF_TIER/);
+		expect(src('src/routes/api/submissions/create/+server.ts')).toMatch(
+			/<\s*REQUIRED_CONGRESSIONAL_PROOF_TIER/
 		);
 	});
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -105,6 +105,10 @@ export default defineConfig({
 			// Behavioral test for the delivery-gate conversion prompt — requires
 			// the components-lane config for @testing-library/svelte rendering.
 			'tests/unit/components/DeliveryGateNotice.test.ts',
+			// Behavioral render of the congressional delivery floor (VerificationGate at
+			// REQUIRED_CONGRESSIONAL_PROOF_TIER). Components-lane only; the structural
+			// single-source lock runs in CI via congressional-delivery-tier.test.ts.
+			'tests/unit/components/congressional-delivery-gate.behavior.test.ts',
 			// Post-Convex migration: these tests reference deleted source files,
 			// missing Convex URL config, or stale assertions. Need rewriting against Convex.
 			'tests/integration/analytics-aggregate.test.ts',


### PR DESCRIPTION
## What

Verification requirement keys off the **delivery channel**, not the recipient:
- **Email / mailto** → open (self-serve; verification is an *optional* credibility upgrade via the `/s/[slug]` `CredibilityLadder` nudge).
- **API-relayed delivery (CWC / congressional)** → requires a **verified sender**.

Both submission endpoints already gate API delivery at `REQUIRED_CONGRESSIONAL_PROOF_TIER = 2` (district-confirmed via the address-first flow) — *"gov-ID (tier 4) raises the assurance BADGE, it is not the bar."* But the **client `VerificationGate` was over-gating CWC at `minimumTier=4`**, which routed to the mDL "coming soon" dead-end and coupled congressional to an unshipped credential.

This aligns the client to the server's actual Tier-2 floor.

## Effect
- A **verified constituent** (district-confirmed) can send through the CWC API **today** — no mDL dependency.
- **Email stays fully open**; verification is the optional credibility layer.
- **Gov-ID** surfaces in the ladder as the **"soon" upgrade** (the "counts more" badge), not the gate.

## Changes
- `TemplateModal`: `minimumTier 4 → 2` for the gate (+ rationale comment mirroring `REQUIRED_CONGRESSIONAL_PROOF_TIER`).
- `features.ts`: fixed the stale *"Tier 4+ proof authority"* comment → Tier 2+.
- Lock-in test pinning the **client ↔ server** tier alignment.

## Safety
The server's crypto gates (active credential, revocation, nullifier) are **untouched**. The server is the real enforcement — a client that over- or under-asks can't change what delivers; this only stops the client over-asking.

svelte-check 0 · 718 gate/identity tests green · lock-in test green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Changes

* **Bug Fixes**
  * Standardized congressional delivery verification requirements to Tier 2+ across the client and server, keeping gating behavior aligned.

* **Documentation**
  * Clarified that Gov-ID is an optional “counts more” assurance upgrade, not the required gating credential.

* **Tests**
  * Added unit and behavioral coverage to ensure the verification gate enforces the same Tier 2+ threshold everywhere and auto-dismisses only when the user meets it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->