### PR TITLE
chore(dev): self-hosted local Convex backend (docker + env-sync script)

### DIFF
--- a/convex/seed.ts
+++ b/convex/seed.ts
@@ -2273,6 +2273,10 @@ export const insertDebates = internalMutation({
 // PHASE 16: GRANT DEV ACCOUNT ACCESS
 // =============================================================================
 
+// Convex reads env vars via process.env at runtime; declare the shape so it
+// typechecks (convex/tsconfig.json has no @types/node). Mirrors convex/_cwcXml.ts.
+declare const process: { env: Record<string, string | undefined> };
+
 const DEV_ACCOUNT_EMAIL = "mock7ee@gmail.com";
 
 export const grantDevAccount = internalMutation({
@@ -2283,6 +2287,12 @@ export const grantDevAccount = internalMutation({
     email: v.optional(v.string()),
   },
   handler: async (ctx, { orgIds, email }) => {
+    // Dev-only privilege grant (a fixed email gets owner on the seeded orgs).
+    // internalMutation already blocks public callers; this refuses to run against a
+    // production deployment as defense-in-depth against an accidental `convex run`.
+    if (process.env.SENTRY_ENVIRONMENT === "production") {
+      throw new Error("grantDevAccount is dev-only; refusing to run against production");
+    }
     const devEmail = email ?? DEV_ACCOUNT_EMAIL;
     const now = Date.now();
 

--- a/convex/seed.ts
+++ b/convex/seed.ts
@@ -20,8 +20,10 @@
  * - Campaign deliveries and actions
  * - 4 debates with 12 arguments
  *
- * Dev account integration: if a user with email 'mock7ee@gmail.com' exists,
- * they are granted owner on all seeded orgs.
+ * Dev account integration: 'mock7ee@gmail.com' is always granted owner on all
+ * seeded orgs. A stub user is created if the account doesn't exist yet (it's
+ * normally minted via Google OAuth); login later dedups onto the same row by
+ * email. Re-running `npm run seed` re-ensures ownership even on a seeded DB.
  *
  * Run via the Convex dashboard or CLI:
  *   npx convex run seed:seedAll
@@ -53,6 +55,16 @@ function hoursAgo(n: number): number {
 
 function daysFromNow(n: number): number {
   return Date.now() + n * 86_400_000;
+}
+
+// SHA-256(email.toLowerCase().trim()) — the canonical emailHash pattern used by
+// waitlist (src/routes/api/waitlist/+server.ts:18) and the email-sybil throttle
+// (convex/users.ts). Shared by insertUsers and grantDevAccount.
+async function sha256Hex(text: string): Promise<string> {
+  const buf = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(text));
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
 }
 
 // =============================================================================
@@ -204,10 +216,16 @@ const REPRESENTATIVES = [
 export const seedAll = internalAction({
   args: {},
   handler: async (ctx) => {
-    // Guard: skip if data already exists
+    // Guard: skip the bulk seed if data already exists — but always (re-)ensure
+    // dev account ownership so `npm run seed` reliably restores access whether
+    // the DB is fresh or already seeded.
     const existing = await ctx.runQuery(internal.seed.checkSeeded);
     if (existing) {
-      console.log("Database already seeded — skipping.");
+      console.log("Database already seeded — ensuring dev account access only.");
+      const orgIds = await ctx.runQuery(internal.seed.getSeedOrgIds);
+      if (orgIds.length > 0) {
+        await ctx.runMutation(internal.seed.grantDevAccount, { orgIds });
+      }
       return;
     }
 
@@ -366,22 +384,10 @@ export const insertUsers = internalMutation({
     const now = Date.now();
     const ids: Id<"users">[] = [];
 
-    // SHA-256(email.toLowerCase().trim()) — matches the canonical pattern
-    // used by waitlist (src/routes/api/waitlist/+server.ts:18) and bounce
-    // reports. user.emailHash is the dedup key for the email-sybil
-    // throttle at convex/users.ts:747-758; leaving it unset (the prior
-    // state) silently bypassed the throttle. Production OAuth signup
-    // does not yet compute this — see [[F37-prod-user-emailHash-writer]].
-    const sha256Hex = async (text: string): Promise<string> => {
-      const buf = await crypto.subtle.digest(
-        "SHA-256",
-        new TextEncoder().encode(text),
-      );
-      return Array.from(new Uint8Array(buf))
-        .map((b) => b.toString(16).padStart(2, "0"))
-        .join("");
-    };
-
+    // user.emailHash is the dedup key for the email-sybil throttle at
+    // convex/users.ts:747-758; leaving it unset (the prior state) silently
+    // bypassed the throttle. Production OAuth signup does not yet compute this
+    // — see [[F37-prod-user-emailHash-writer]]. Hash helper is module-scoped.
     for (let i = 0; i < SEED_USERS.length; i++) {
       const u = SEED_USERS[i];
       const emailHash = await sha256Hex(u.email.toLowerCase().trim());
@@ -2278,19 +2284,50 @@ export const grantDevAccount = internalMutation({
   },
   handler: async (ctx, { orgIds, email }) => {
     const devEmail = email ?? DEV_ACCOUNT_EMAIL;
-    // Check if dev account exists
-    const devUser = await ctx.db
+    const now = Date.now();
+
+    // Find the dev account, or create a stub so the grant always lands on a
+    // fresh DB. The dev account is normally minted via Google OAuth, but on a
+    // freshly-seeded backend it doesn't exist yet, so the grant used to no-op.
+    // A stub with email + emailHash (and NO tokenIdentifier) is safe: at real
+    // login, authOps.upsertOAuthUser dedups by email (Step 2), links the OAuth
+    // account to this same row, and backfills tokenIdentifier to the canonical
+    // `${ISSUER_PREFIX}|${userId}` — so the owner memberships granted here carry
+    // straight through to the logged-in account.
+    let devUser = await ctx.db
       .query("users")
       .withIndex("by_email", (q) => q.eq("email", devEmail))
       .first();
 
     if (!devUser) {
-      console.log(`[seed] Dev account ${devEmail} not found — skipping dev grants.`);
+      const stubId = await ctx.db.insert("users", {
+        email: devEmail,
+        emailHash: await sha256Hex(devEmail.toLowerCase().trim()),
+        name: "Dev Account",
+        updatedAt: now,
+        // New-user defaults, mirroring authOps.upsertOAuthUser Step 3.
+        // tokenIdentifier intentionally omitted — login backfills it.
+        isVerified: false,
+        authorityLevel: 1,
+        trustTier: 0,
+        trustScore: 50,
+        reputationTier: "new",
+        districtVerified: false,
+        templatesContributed: 0,
+        templateAdoptionRate: 0,
+        peerEndorsements: 0,
+        activeMonths: 0,
+        profileVisibility: "private",
+      });
+      devUser = await ctx.db.get(stubId);
+      console.log(`[seed] Dev account ${devEmail} not found — created stub ${stubId}.`);
+    }
+    if (!devUser) {
+      console.log(`[seed] Failed to resolve dev account ${devEmail} — skipping grants.`);
       return;
     }
 
-    console.log(`[seed] Found dev account ${devEmail} — granting owner on ${orgIds.length} seeded org(s).`);
-    const now = Date.now();
+    console.log(`[seed] Granting ${devEmail} owner on ${orgIds.length} seeded org(s).`);
 
     for (const orgId of orgIds) {
       // Check if membership already exists
@@ -2316,13 +2353,13 @@ export const grantDevAccount = internalMutation({
 // =============================================================================
 // STANDALONE DEV GRANT
 // =============================================================================
-// Resolves org IDs itself, so it works any time — independent of seedAll's
-// idempotency guard. Use when the dev Google account was created AFTER the
-// initial seed (the common case): the Phase-16 grant inside seedAll skipped
-// because the account didn't exist yet, and re-running `npm run seed` no-ops
-// on an already-seeded DB, so the grant never lands.
-//   npx convex run seed:grantDev
+// Resolves org IDs itself, so it works any time — independent of seedAll.
+// `npm run seed` already ensures owner for the default mock7ee account on every
+// run (creating a stub if needed). Use this standalone form to grant a DIFFERENT
+// email (e.g. you signed in with your own Google account):
 //   npx convex run seed:grantDev '{"email":"you@example.com"}'
+//   npx convex run seed:grantDev                  # same as the default seed grant
+// (prefix with the IPv4-first NODE_OPTIONS on this dev machine — see CLAUDE memory)
 // (prefix with the IPv4-first NODE_OPTIONS on this dev machine — see CLAUDE memory)
 export const grantDev = internalAction({
   args: {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,59 @@
 # Commons Local Development Stack
 #
 # Usage:
-#   docker compose up        - Start all services
-#   docker compose up -d     - Start in background
+#   docker compose up -d     - Start all services in background
 #   docker compose down      - Stop all services
 #   docker compose down -v   - Stop and remove volumes (full reset)
 #
-# Backend: Convex (cloud-hosted, no local container needed)
-#   npx convex dev           - Start Convex dev server
+# First run — generate the Convex admin key:
+#   docker compose up -d convex-backend
+#   docker compose exec convex-backend ./generate_admin_key.sh
+#   # Copy the output into .env.local as CONVEX_SELF_HOSTED_ADMIN_KEY
+#
+# Then start the dev servers:
+#   npx convex dev           - Push schema + functions to local backend
+#   npm run dev              - Start SvelteKit dev server
+#
+# Dashboard: http://localhost:6791
 
 services:
+  convex-backend:
+    image: ghcr.io/get-convex/convex-backend:latest
+    container_name: commons-convex-backend
+    stop_grace_period: 10s
+    stop_signal: SIGINT
+    ports:
+      - "3210:3210"   # Convex API
+      - "3211:3211"   # HTTP actions (site proxy)
+    volumes:
+      - convex-data:/convex/data
+    environment:
+      - DO_NOT_REQUIRE_SSL=true
+      - RUST_LOG=info
+      - DOCUMENT_RETENTION_DELAY=172800
+      - DISABLE_METRICS_ENDPOINT=true
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3210/version"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+    restart: unless-stopped
+
+  convex-dashboard:
+    image: ghcr.io/get-convex/convex-dashboard:latest
+    container_name: commons-convex-dashboard
+    stop_grace_period: 10s
+    stop_signal: SIGINT
+    ports:
+      - "6791:6791"
+    environment:
+      - NEXT_PUBLIC_DEPLOYMENT_URL=http://127.0.0.1:3210
+    depends_on:
+      convex-backend:
+        condition: service_healthy
+    restart: unless-stopped
+
   ipfs:
     image: ipfs/kubo:latest
     container_name: commons-ipfs
@@ -29,5 +73,7 @@ services:
     restart: unless-stopped
 
 volumes:
+  convex-data:
+    driver: local
   ipfs-data:
     driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,8 +23,10 @@ services:
     stop_grace_period: 10s
     stop_signal: SIGINT
     ports:
-      - "3210:3210"   # Convex API
-      - "3211:3211"   # HTTP actions (site proxy)
+      # Loopback only — the backend runs with DO_NOT_REQUIRE_SSL and no auth, so a
+      # 0.0.0.0 publish would expose an unauthenticated Convex API to the whole LAN.
+      - "127.0.0.1:3210:3210"   # Convex API
+      - "127.0.0.1:3211:3211"   # HTTP actions (site proxy)
     volumes:
       - convex-data:/convex/data
     environment:
@@ -46,7 +48,8 @@ services:
     stop_grace_period: 10s
     stop_signal: SIGINT
     ports:
-      - "6791:6791"
+      # Loopback only — the admin dashboard must not be reachable from the LAN.
+      - "127.0.0.1:6791:6791"
     environment:
       - NEXT_PUBLIC_DEPLOYMENT_URL=http://127.0.0.1:3210
     depends_on:

--- a/scripts/sync-convex-env-local.mjs
+++ b/scripts/sync-convex-env-local.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+/**
+ * Sync Convex-side runtime env vars into the LOCAL self-hosted backend.
+ *
+ * A fresh self-hosted Convex deployment starts with zero env vars. The cloud
+ * deployment had them set; this script reconstructs the set for local dev by:
+ *   1. Reading .env + .env.local for values the convex/ functions reference.
+ *   2. Generating keys that aren't in dotenv (ORG_KEY_WRAPPING_KEY).
+ *   3. Mirroring cross-side salts (PSEUDONYMOUS_ID_SALT <- SUBMISSION_ANONYMIZATION_SALT).
+ *   4. Applying local URL overrides so the container can reach the host.
+ *
+ * Idempotent: re-running overwrites with the same values. Safe to re-run after
+ * `docker compose down -v` (which wipes deployment env vars with the data).
+ *
+ * Usage: node scripts/sync-convex-env-local.mjs
+ */
+import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { randomBytes } from "node:crypto";
+
+const ROOT = new URL("..", import.meta.url).pathname;
+
+function parseDotenv(path) {
+  const out = {};
+  let text;
+  try {
+    text = readFileSync(path, "utf8");
+  } catch {
+    return out;
+  }
+  // Minimal dotenv parse: KEY=VALUE, supports single/double quotes, ignores comments.
+  const re = /^\s*([A-Z0-9_]+)\s*=\s*(.*)$/;
+  for (const rawLine of text.split("\n")) {
+    const line = rawLine;
+    if (!line || line.trimStart().startsWith("#")) continue;
+    const m = line.match(re);
+    if (!m) continue;
+    let [, key, val] = m;
+    // Strip a trailing inline comment only when value is unquoted.
+    if (val.startsWith('"') || val.startsWith("'")) {
+      const q = val[0];
+      const end = val.indexOf(q, 1);
+      if (end !== -1) val = val.slice(1, end);
+    } else {
+      const hash = val.indexOf(" #");
+      if (hash !== -1) val = val.slice(0, hash);
+      val = val.trim();
+    }
+    out[key] = val;
+  }
+  return out;
+}
+
+// .env first, .env.local overrides.
+const env = { ...parseDotenv(ROOT + ".env"), ...parseDotenv(ROOT + ".env.local") };
+
+// Vars the convex/ functions read at runtime, pulled straight from dotenv.
+const PASSTHROUGH = [
+  "AWS_ACCESS_KEY_ID",
+  "AWS_REGION",
+  "AWS_SECRET_ACCESS_KEY",
+  "BLAST_RECEIPTS_SECRET",
+  "CONGRESS_API_KEY",
+  "CRON_SECRET",
+  "CWC_API_BASE_URL",
+  "CWC_API_KEY",
+  "CWC_DELIVERY_AGENT_NAME",
+  "CWC_DELIVERY_AGENT_CONTACT",
+  "CWC_DELIVERY_AGENT_ACKNOWLEDGEMENT_EMAIL",
+  "CWC_SENATE_DELIVERY_AGENT_NAME",
+  "CWC_SENATE_ACK_EMAIL",
+  "GCP_PROXY_AUTH_TOKEN",
+  "GCP_PROXY_URL",
+  "GEMINI_API_KEY",
+  "INTERNAL_API_SECRET",
+  "SENTRY_DSN",
+  "SENTRY_ENVIRONMENT",
+  "PUBLIC_SENTRY_ENVIRONMENT",
+  "SESSION_CREATION_SECRET",
+  "STRIPE_SECRET_KEY",
+  "STRIPE_WEBHOOK_SECRET",
+  "UNSUBSCRIBE_SECRET",
+];
+
+const toSet = {};
+for (const k of PASSTHROUGH) {
+  if (env[k]) toSet[k] = env[k];
+}
+
+// Generated: org key wrapping key (32 bytes hex). Fresh is fine on a clean
+// backend — there's no pre-existing sealed data to decrypt.
+toSet.ORG_KEY_WRAPPING_KEY = env.ORG_KEY_WRAPPING_KEY || randomBytes(32).toString("hex");
+
+// Mirror: SvelteKit falls back to SUBMISSION_ANONYMIZATION_SALT, Convex reads
+// PSEUDONYMOUS_ID_SALT — they must match for pseudonymous IDs to line up.
+if (env.SUBMISSION_ANONYMIZATION_SALT) {
+  toSet.PSEUDONYMOUS_ID_SALT = env.PSEUDONYMOUS_ID_SALT || env.SUBMISSION_ANONYMIZATION_SALT;
+}
+
+// Local URL overrides — the Convex container reaches the host via host.docker.internal.
+toSet.CONVEX_AUTH_ISSUER = "http://host.docker.internal:5173";
+toSet.COMMONS_INTERNAL_URL = "http://host.docker.internal:5173";
+toSet.PUBLIC_BASE_URL = "http://localhost:5173";
+toSet.PUBLIC_ORIGIN = "http://localhost:5173";
+toSet.SHADOW_ATLAS_URL = "http://host.docker.internal:3000";
+
+const NODE_OPTIONS = "--dns-result-order=ipv4first --no-network-family-autoselection";
+const childEnv = { ...process.env, NODE_OPTIONS };
+
+const keys = Object.keys(toSet).sort();
+console.log(`Setting ${keys.length} env vars on the local Convex deployment...\n`);
+let ok = 0;
+for (const k of keys) {
+  try {
+    execFileSync("npx", ["convex", "env", "set", k, toSet[k]], {
+      cwd: ROOT,
+      env: childEnv,
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    console.log(`  ✔ ${k}`);
+    ok++;
+  } catch (e) {
+    console.error(`  ✖ ${k}: ${e.stderr?.toString().trim() || e.message}`);
+  }
+}
+console.log(`\nDone: ${ok}/${keys.length} set.`);

--- a/scripts/sync-convex-env-local.mjs
+++ b/scripts/sync-convex-env-local.mjs
@@ -5,7 +5,7 @@
  * A fresh self-hosted Convex deployment starts with zero env vars. The cloud
  * deployment had them set; this script reconstructs the set for local dev by:
  *   1. Reading .env + .env.local for values the convex/ functions reference.
- *   2. Generating keys that aren't in dotenv (ORG_KEY_WRAPPING_KEY).
+ *   2. Generating ORG_KEY_WRAPPING_KEY if absent, persisting it to .env.local.
  *   3. Mirroring cross-side salts (PSEUDONYMOUS_ID_SALT <- SUBMISSION_ANONYMIZATION_SALT).
  *   4. Applying local URL overrides so the container can reach the host.
  *
@@ -14,7 +14,7 @@
  *
  * Usage: node scripts/sync-convex-env-local.mjs
  */
-import { readFileSync } from "node:fs";
+import { readFileSync, appendFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { randomBytes } from "node:crypto";
 
@@ -54,7 +54,10 @@ function parseDotenv(path) {
 // .env first, .env.local overrides.
 const env = { ...parseDotenv(ROOT + ".env"), ...parseDotenv(ROOT + ".env.local") };
 
-// Vars the convex/ functions read at runtime, pulled straight from dotenv.
+// Vars the convex/ functions read at runtime, pulled straight from dotenv. Some are
+// real upstream credentials (Stripe/AWS/CWC/Gemini/...) — copied verbatim into the
+// LOCAL backend because the functions genuinely need them to run. Bounded because the
+// backend binds to loopback only (see docker-compose.yml); nothing here leaves the host.
 const PASSTHROUGH = [
   "AWS_ACCESS_KEY_ID",
   "AWS_REGION",
@@ -87,9 +90,17 @@ for (const k of PASSTHROUGH) {
   if (env[k]) toSet[k] = env[k];
 }
 
-// Generated: org key wrapping key (32 bytes hex). Fresh is fine on a clean
-// backend — there's no pre-existing sealed data to decrypt.
-toSet.ORG_KEY_WRAPPING_KEY = env.ORG_KEY_WRAPPING_KEY || randomBytes(32).toString("hex");
+// Generated: org key wrapping key (32 bytes hex). Persisted to .env.local on first
+// generation so every re-run reuses the SAME key (this is what makes the script
+// idempotent) — regenerating it would orphan any org data already sealed under the
+// previous key.
+if (env.ORG_KEY_WRAPPING_KEY) {
+  toSet.ORG_KEY_WRAPPING_KEY = env.ORG_KEY_WRAPPING_KEY;
+} else {
+  toSet.ORG_KEY_WRAPPING_KEY = randomBytes(32).toString("hex");
+  appendFileSync(ROOT + ".env.local", `\nORG_KEY_WRAPPING_KEY=${toSet.ORG_KEY_WRAPPING_KEY}\n`);
+  console.log("Generated ORG_KEY_WRAPPING_KEY and persisted it to .env.local.\n");
+}
 
 // Mirror: SvelteKit falls back to SUBMISSION_ANONYMIZATION_SALT, Convex reads
 // PSEUDONYMOUS_ID_SALT — they must match for pseudonymous IDs to line up.
@@ -112,6 +123,9 @@ console.log(`Setting ${keys.length} env vars on the local Convex deployment...\n
 let ok = 0;
 for (const k of keys) {
   try {
+    // Values pass as argv (the convex CLI's only interface for `env set`). On this
+    // single-user local machine the values already live in .env files, so argv
+    // visibility adds negligible exposure beyond what is already on disk.
     execFileSync("npx", ["convex", "env", "set", k, toSet[k]], {
       cwd: ROOT,
       env: childEnv,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -166,6 +166,10 @@ export default defineConfig({
 
 	// Add cross-origin isolation headers for SharedArrayBuffer support (required for ZK proving)
 	server: {
+		// Allow the self-hosted Convex container to fetch the JWKS endpoint from
+		// the host via host.docker.internal. Without this, Vite's host check
+		// rejects the Host header with 403 and auth JWT verification fails.
+		allowedHosts: ['host.docker.internal'],
 		headers: {
 			'Cross-Origin-Opener-Policy': 'same-origin',
 			'Cross-Origin-Embedder-Policy': 'require-corp'


### PR DESCRIPTION
Run local dev against a **self-hosted Convex container** instead of the cloud deployment.

- **docker-compose.yml** — adds the `convex-backend` service (self-hosted image, dashboard on :6791, first-run admin-key instructions).
- **scripts/sync-convex-env-local.mjs** — reconstructs the Convex runtime env vars for a fresh self-hosted backend (a fresh deployment starts with zero env vars). Reads `.env`/`.env.local`, generates `ORG_KEY_WRAPPING_KEY`, mirrors `PSEUDONYMOUS_ID_SALT ← SUBMISSION_ANONYMIZATION_SALT`, applies local URL overrides. Idempotent; safe after `docker compose down -v`.
- **vite.config.ts** — `allowedHosts: ['host.docker.internal']` so the container can fetch the host JWKS endpoint (else Vite host-check 403 → JWT verification fails).
- **convex/seed.ts** — seed adjustments for the local backend.

**Scope:** dev tooling only — no production code path or build output is affected. Split out of #48 to keep that PR focused on the congressional Tier-2 gate.