### PR TITLE
ci: bump brutalist-mcp to 1.18.2 (agy stdin-EOF fix)

### DIFF
--- a/.github/workflows/brutalist-review.yml
+++ b/.github/workflows/brutalist-review.yml
@@ -44,7 +44,9 @@ jobs:
         env:
           BRUTALIST_TIMEOUT: "900000"
           BRUTALIST_ORCHESTRATOR_TIMEOUT_MS: "2100000"
-          # Freeze agy's binary version for the run (stops self-update drift).
+          # Disable agy's in-run self-update (it self-updates from a us-central1
+          # endpoint mid-run). NOTE: this does NOT pin the installed version —
+          # install.sh above fetches the latest; this only stops drift WITHIN a run.
           AGY_CLI_DISABLE_AUTO_UPDATE: "1"
         with:
           github-token: ${{ github.token }}

--- a/.github/workflows/brutalist-review.yml
+++ b/.github/workflows/brutalist-review.yml
@@ -27,7 +27,7 @@ jobs:
           node-version: '20'
       - name: Install CLI critics
         run: |
-          npm install -g @brutalist/mcp@1.15.0 \
+          npm install -g @brutalist/mcp@1.18.2 \
                          @anthropic-ai/claude-code@2.1.177 \
                          @openai/codex@0.139.0
           # NOTE: the agy installer is unpinned upstream (no published checksum) —
@@ -44,6 +44,8 @@ jobs:
         env:
           BRUTALIST_TIMEOUT: "900000"
           BRUTALIST_ORCHESTRATOR_TIMEOUT_MS: "2100000"
+          # Freeze agy's binary version for the run (stops self-update drift).
+          AGY_CLI_DISABLE_AUTO_UPDATE: "1"
         with:
           github-token: ${{ github.token }}
           anthropic-oauth-token: ${{ secrets.ANTHROPIC_OAUTH_TOKEN }}


### PR DESCRIPTION
agy was already wired here but **timing out** — `@brutalist/mcp` <1.18.2 left agy's stdin open, and agy `--print` blocks on stdin EOF, so it hung the full timeout in CI.

- bump `@brutalist/mcp@1.15.0 → 1.18.2` (closes stdin for agy)
- `AGY_CLI_DISABLE_AUTO_UPDATE=1` to freeze agy's binary for the run
- refreshed the `AGY_OAUTH_TOKEN` secret (agy tokens rotate ~monthly)

**This PR's own brutalist review validates** the restored 3-critic panel (claude + codex + **agy**).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated review automation tool dependency to version 1.18.2
  * Disabled automatic updates during review execution to maintain stable behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->