### PR TITLE
ci(deploy): per-branch Convex backend (separate prod from staging/preview)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,15 +103,20 @@ jobs:
 
       - name: Resolve build environment
         run: |
+          # Per-branch Convex backend: production is isolated on its own deployment;
+          # staging and preview (main/*) share the non-prod deployment.
           case "${DEPLOY_BRANCH}" in
             production)
               echo "VITE_ENVIRONMENT=production" >> "$GITHUB_ENV"
+              echo "PUBLIC_CONVEX_URL=https://quirky-chinchilla-352.convex.cloud" >> "$GITHUB_ENV"
               ;;
             staging)
               echo "VITE_ENVIRONMENT=staging" >> "$GITHUB_ENV"
+              echo "PUBLIC_CONVEX_URL=https://outstanding-firefly-831.convex.cloud" >> "$GITHUB_ENV"
               ;;
             *)
               echo "VITE_ENVIRONMENT=development" >> "$GITHUB_ENV"
+              echo "PUBLIC_CONVEX_URL=https://outstanding-firefly-831.convex.cloud" >> "$GITHUB_ENV"
               ;;
           esac
 
@@ -125,6 +130,7 @@ jobs:
             VITE_ATLAS_BASE_URL: process.env.VITE_ATLAS_BASE_URL,
             EXPECTED_CELL_MAP_ROOT: process.env.EXPECTED_CELL_MAP_ROOT,
             EXPECTED_CELL_MAP_DEPTH: process.env.EXPECTED_CELL_MAP_DEPTH,
+            PUBLIC_CONVEX_URL: process.env.PUBLIC_CONVEX_URL,
           };
 
           for (const [key, value] of Object.entries(updates)) {
@@ -176,7 +182,7 @@ jobs:
       - name: Build
         run: npm run build
         env:
-          PUBLIC_CONVEX_URL: https://quirky-chinchilla-352.convex.cloud
+          PUBLIC_CONVEX_URL: ${{ env.PUBLIC_CONVEX_URL }}
           VITE_ENVIRONMENT: ${{ env.VITE_ENVIRONMENT }}
           VITE_ATLAS_BASE_URL: ${{ env.VITE_ATLAS_BASE_URL }}
           ATLAS_BASE_URL: ${{ env.ATLAS_BASE_URL }}


### PR DESCRIPTION
Un-hardcodes `PUBLIC_CONVEX_URL` (was always `quirky-chinchilla-352` for every branch) so each environment builds + runs against its own Convex backend:

| Branch → domain | Convex backend |
|---|---|
| production → commons.email | quirky-chinchilla-352 (isolated prod) |
| staging → staging.commons.email | outstanding-firefly-831 (non-prod) |
| main → main.communique-site.pages.dev | outstanding-firefly-831 (preview/dev) |

Resolved in both the build env (client inline) and the wrangler `[vars]` sync (server runtime). Both backends already have the merged functions deployed via CLI. No app code change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment environment handling so the app uses the correct backend URL for production and non-production builds.
  * Ensured the deployed configuration stays in sync with the active environment, reducing the chance of incorrect runtime settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->