### PR TITLE
fix(landing): resolve subdivision name in templates empty-state label

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -135,8 +135,11 @@
 		if (scope.type === 'international') return 'everywhere';
 		if (scope.type === 'nationwide') return scope.displayName || countryName(scope.country);
 		// Subnational: prefer the bare place name (a city/state stands alone, never the
-		// full "City, State, Country" hierarchy), resolving ISO codes to readable names.
+		// full "City, State, Country" hierarchy). Prefer the preserved subdivisionName
+		// (e.g. "Johor") — the code → name table only covers US/CA/AU, so outside those
+		// a bare ISO 3166-2 code like "01" would otherwise leak through.
 		if (scope.locality) return scope.locality;
+		if (scope.subdivisionName) return scope.subdivisionName;
 		if (scope.subdivision) {
 			const code = scope.subdivision.split('-')[1] || scope.subdivision;
 			return getStateName(code);


### PR DESCRIPTION
## Problem

The location breadcrumb was fixed to show "Johor", but the **templates empty-state** still rendered "No templates in **01** yet."

The empty-state reads from a separate label function — `geoScopeLabel` in `src/routes/+page.svelte` — which, for subnational scopes, fell back to `getStateName(code)`. That code→name table only covers US/CA/AU, so Malaysia's ISO 3166-2 code `MY-01` leaked through as the bare `01`.

## Fix

Prefer the preserved `subdivisionName` ("Johor") before the code→name fallback — the same fix already applied to the `LocationScopeBar` breadcrumb. `subdivisionName` is populated upstream by `location-resolver.ts` from the search result / IP geo.

```js
if (scope.locality) return scope.locality;
if (scope.subdivisionName) return scope.subdivisionName;   // ← "Johor"
if (scope.subdivision) { /* US/CA/AU code lookup fallback */ }
```

## Verification

- `svelte-check`: 0 errors
- Empty state now reads "No templates in Johor yet." consistent with the breadcrumb.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how location labels are shown in the location scope bar and “no match” notice.
  * Subnational places now display a more accurate, human-readable name when available, instead of relying on a code-based fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->