### PR TITLE
ci: add GLM routed critic

### DIFF
--- a/.github/workflows/brutalist-review.yml
+++ b/.github/workflows/brutalist-review.yml
@@ -54,3 +54,13 @@ jobs:
           codex-auth: ${{ secrets.CODEX_AUTH }}
           agy-oauth-token: ${{ secrets.AGY_OAUTH_TOKEN }}
           minimum-severity: medium
+          # GLM routed critic — Anthropic-compatible gateway (public Tailscale Funnel).
+          # Additive 4th critic, hardened by default. GLM is the slowest critic
+          # (~5min healthy); down=fast preflight, over-quota 429 retries ~3-4min/chunk.
+          # Reviews are advisory, so this never gates merges.
+          custom-claude-client-id: glm
+          custom-claude-base-url: https://immersivecommons13.tail5da903.ts.net
+          custom-claude-auth-token: ${{ secrets.GLM_TOKEN }}
+          custom-claude-model: glm-5.1
+          custom-claude-small-fast-model: glm-4.5-air
+          custom-claude-context-window: 128000


### PR DESCRIPTION
Adds a **GLM** routed Claude critic (4th critic) via the public Anthropic-compatible gateway (`immersivecommons13.tail5da903.ts.net`, a public Tailscale Funnel). Additive + hardened by default (no web/MCP, no native creds).

**Validated end-to-end on the dogfood** (ejmockler/brutalist-mcp #16): GLM authenticates, routes, stays hardened (confirmed from inside CI), and produces real findings. The `GLM_TOKEN` secret is already set here.

Caveat: GLM is the **slowest critic** (~5 min even healthy); reviews are advisory, so it never gates merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded automated review coverage with an additional AI reviewer option.
  * Improved review processing capacity for larger inputs, helping handle longer submissions more reliably.
  * Added a faster fallback path to support quicker review feedback when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->