### PR TITLE
ci: bump brutalist-mcp to 1.18.3 (routed fail-fast)

### DIFF
--- a/.github/workflows/brutalist-review.yml
+++ b/.github/workflows/brutalist-review.yml
@@ -27,7 +27,7 @@ jobs:
           node-version: '20'
       - name: Install CLI critics
         run: |
-          npm install -g @brutalist/mcp@1.18.2 \
+          npm install -g @brutalist/mcp@1.18.3 \
                          @anthropic-ai/claude-code@2.1.177 \
                          @openai/codex@0.139.0
           # NOTE: the agy installer is unpinned upstream (no published checksum) —


### PR DESCRIPTION
Bumps `@brutalist/mcp` to **1.18.3**: an over-quota routed critic (GLM) now **fails fast** at pre-flight (a tiny `/v1/messages` 429 probe) instead of retrying the 429 for ~3–4 min per chunk. A healthy GLM is unaffected (probe returns 200 → it runs).