### PR TITLE
ci: bump per-critic cap to 30min

### DIFF
--- a/.github/workflows/brutalist-review.yml
+++ b/.github/workflows/brutalist-review.yml
@@ -42,8 +42,8 @@ jobs:
         # move-tags automation) so this repo auto-updates to the latest action.
         uses: ejmockler/brutalist-mcp/packages/github-action@v1
         env:
-          BRUTALIST_TIMEOUT: "900000"
-          BRUTALIST_ORCHESTRATOR_TIMEOUT_MS: "2100000"
+          BRUTALIST_TIMEOUT: "1800000"
+          BRUTALIST_ORCHESTRATOR_TIMEOUT_MS: "2700000"
           # Disable agy's in-run self-update (it self-updates from a us-central1
           # endpoint mid-run). NOTE: this does NOT pin the installed version —
           # install.sh above fetches the latest; this only stops drift WITHIN a run.


### PR DESCRIPTION
Bumps `BRUTALIST_TIMEOUT` to **30 min** (1800000) and `BRUTALIST_ORCHESTRATOR_TIMEOUT_MS` to **45 min** so a slow routed critic (GLM) gets room on large diffs instead of hitting the cap. agy unaffected (self-caps at 6 min).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased workflow time limits to allow longer automated review runs before timing out, improving reliability for larger or slower jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->