### PR TITLE
fix(build): shim undici so CF Pages Functions bundling survives

### DIFF
--- a/src/lib/server/shims/undici-workerd-shim.ts
+++ b/src/lib/server/shims/undici-workerd-shim.ts
@@ -1,0 +1,22 @@
+/**
+ * undici → workerd shim (SSR bundle only).
+ *
+ * Why this exists: `@mendable/firecrawl-js` lazily `await import("undici")` as a
+ * Node-only WebSocket fallback (guarded by its own isNodeRuntime() check, so the
+ * import is dead code on Cloudflare). But Cloudflare Pages' uploader re-bundles
+ * `_worker.js` with wrangler 3.x, whose esbuild follows the dynamic import into
+ * the real undici package — and undici ≥7.x hard-references `node:sqlite`
+ * (lib/util/runtime-features.js), which wrangler 3.x's hybrid nodejs_compat
+ * cannot resolve. The build dies with `Could not resolve "node:sqlite"`.
+ *
+ * The fix: during the SSR build, `@mendable/firecrawl-js` is inlined
+ * (ssr.noExternal) with `undici` aliased to this shim, so the emitted server
+ * chunks never reference the undici package at all. workerd provides WebSocket
+ * natively; everything else firecrawl could touch on this path is unreachable
+ * there by its own runtime guard.
+ */
+
+// workerd (and Node ≥22) expose WebSocket on globalThis.
+export const WebSocket = (globalThis as { WebSocket?: unknown }).WebSocket;
+
+export default { WebSocket };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -53,6 +53,9 @@ const pinoShimPath = fileURLToPath(new URL('./src/lib/core/proof/pino-shim.ts', 
 const voterProtocolStubPath = fileURLToPath(
 	new URL('./src/lib/core/crypto/voter-protocol-stub.ts', import.meta.url)
 );
+const undiciShimPath = fileURLToPath(
+	new URL('./src/lib/server/shims/undici-workerd-shim.ts', import.meta.url)
+);
 
 export default defineConfig({
 	plugins: [
@@ -76,6 +79,22 @@ export default defineConfig({
 			resolveId(source, _importer, options) {
 				if (source === '@voter-protocol/noir-prover' && options?.ssr) {
 					return voterProtocolStubPath;
+				}
+				return null;
+			}
+		},
+		// Shim undici ONLY during SSR: firecrawl-js (inlined via ssr.noExternal)
+		// lazily imports it as a Node-only WebSocket fallback that is dead code on
+		// workerd — but Cloudflare's wrangler-3 uploader would otherwise follow the
+		// import into real undici, whose `node:sqlite` reference breaks the Pages
+		// Functions bundling. See src/lib/server/shims/undici-workerd-shim.ts.
+		{
+			name: 'undici-workerd-shim',
+			// 'pre' so this wins before vite:resolve externalizes the bare specifier.
+			enforce: 'pre',
+			resolveId(source, _importer, options) {
+				if (source === 'undici' && options?.ssr) {
+					return undiciShimPath;
 				}
 				return null;
 			}
@@ -139,7 +158,14 @@ export default defineConfig({
 	// Enable WASM support
 	assetsInclude: ['**/*.wasm'],
 
-	ssr: {},
+	ssr: {
+		// Inline firecrawl-js into the SSR bundle so its lazy `import("undici")`
+		// goes through the undici-workerd-shim plugin above. Left external, the
+		// bare specifier would survive into the server chunks and Cloudflare's
+		// wrangler-3 uploader would bundle REAL undici → `node:sqlite` → build
+		// failure ("Failed building Pages Functions").
+		noExternal: ['@mendable/firecrawl-js']
+	},
 
 	worker: {
 		format: 'es',


### PR DESCRIPTION
CF's uploader (wrangler 3.114.17) follows firecrawl-js's lazy Node-only `import("undici")` into real undici, whose `node:sqlite` reference breaks the Functions bundling (the chronic flaky production build failure — cache-hit builds dodged it). SSR now inlines firecrawl with undici aliased to a workerd-safe WebSocket shim; verified against wrangler@3.114.17's exact bundling step locally (0 errors, bundle produced). Suites green; svelte-check 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved SSR builds for Cloudflare Pages/workerd by routing a server-side `WebSocket` shim into the bundle.
  * Added support to keep certain server bundles self-contained and avoid pulling in incompatible runtime dependencies.
* **Bug Fixes**
  * Reduced SSR bundling issues caused by server-side references to Node-only packages.
  * Helped prevent runtime failures when WebSocket support is needed during server rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->