### PR TITLE
fix(deploy): cell-map pins into wrangler.toml [vars] (env source of truth)

### DIFF
--- a/docs/ops/LAUNCH-ACTIVATION-RUNBOOK.md
+++ b/docs/ops/LAUNCH-ACTIVATION-RUNBOOK.md
@@ -222,9 +222,19 @@ clamped to 0.4 confidence with "boundary vintage unknown"
 When step 7 was dispatched with `push_cids=true` (the default,
 `shadow-atlas-quarterly.yml:47-53`), the workflow's `push-cids` job (`:958`, config-push
 step `:995-1040`) **pushes `ATLAS_BASE_URL`, `VITE_ATLAS_BASE_URL`,
-`EXPECTED_CELL_MAP_ROOT`, and `EXPECTED_CELL_MAP_DEPTH` to the CF Pages project
-automatically** and prints all four to the run summary — this step is then *verify-in-summary*, not a hand-bump. Hand-edit the CF Pages
-env vars only if `push_cids=false` was chosen or the job failed, and remember a CF Pages env
+`EXPECTED_CELL_MAP_ROOT`, and `EXPECTED_CELL_MAP_DEPTH` to the CF Pages project**
+and prints all four to the run summary.
+
+> **⚠️ WRANGLER.TOML IS THE SOURCE OF TRUTH — the API push alone is NOT durable.**
+> Because commons' `wrangler.toml` carries `pages_build_output_dir`, every git
+> deploy of the site REWRITES the project's plain-text env vars to exactly its
+> `[vars]` block — the push-cids API update (and any dashboard edit) is silently
+> reverted by the NEXT production deploy. After every republish, land the four
+> new values in `wrangler.toml [vars]` via a commit (this is what makes the pin
+> survive). Learned 2026-07: a deploy deleted both `EXPECTED_CELL_MAP_*` pins
+> and degraded /api/health + snapshot validation until they were restored.
+
+Hand-edit the CF Pages env vars only as a stopgap if the job failed; a CF Pages env
 change takes effect on the next deployment.
 
 This is a **recurring ritual**: every future republish must re-point the version-pinned path

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,11 +4,24 @@ compatibility_flags = ["nodejs_compat", "nodejs_als"]
 pages_build_output_dir = ".svelte-kit/cloudflare"
 
 
+# NOTE (source of truth): because this file carries `pages_build_output_dir`,
+# Cloudflare treats it as the Pages project configuration — every git deploy
+# REWRITES the project's plain-text env vars to exactly this [vars] block, and
+# dashboard/API-set plain-text vars NOT listed here are DROPPED (secrets are
+# unaffected). Consequence: any release that bumps ATLAS_BASE_URL or the
+# cell-map trust pins (the quarterly publish's push-cids step) MUST land the
+# new values HERE via a commit — an API/dashboard update alone is reverted by
+# the next git deploy. Learned 2026-07: a deploy silently deleted the two
+# EXPECTED_CELL_MAP_* pins and degraded /api/health + snapshot validation.
 [vars]
 PUBLIC_CONVEX_URL = "https://quirky-chinchilla-352.convex.cloud"
 PUBLIC_SCROLL_RPC_URL = "https://rpc.scroll.io"
 ATLAS_BASE_URL = "https://atlas.commons.email/v20260418"
 VITE_ATLAS_BASE_URL = "https://atlas.commons.email/v20260418"
+# Cell-map trust pins (public values; paired with the atlas version above and
+# updated together at each publish — see docs/ops/LAUNCH-ACTIVATION-RUNBOOK.md).
+EXPECTED_CELL_MAP_ROOT = "0x14a6fc8eb8f8643bf420290e9d65059006b194ee335ab1cc1664838e5bc56cd3"
+EXPECTED_CELL_MAP_DEPTH = "22"
 # IDENTITY_SIGNING_KEY = "set in Cloudflare dashboard (openssl rand -hex 32)"
 
 # Contract addresses (override for mainnet deployment):


### PR DESCRIPTION
The wrangler.toml-configured Pages deploy rewrites plain-text project env to exactly `[vars]` — the undici-fix deploy silently dropped `EXPECTED_CELL_MAP_ROOT/DEPTH` (health degraded, snapshot validation unpinned). Pins restored via API (stopgap) + moved into `[vars]` (durable); runbook A3 now documents the clobber interaction for every future republish.