### PR TITLE
Convex authorization hardening — close the data-plane exposure (40 functions)

### DIFF
--- a/convex/analytics.ts
+++ b/convex/analytics.ts
@@ -10,6 +10,7 @@ import { mutation, internalMutation, internalQuery, internalAction } from "./_ge
 import { internal } from "./_generated/api";
 import { v } from "convex/values";
 import type { Id } from "./_generated/dataModel";
+import { requireInternalSecret } from "./_internalAuth";
 
 // =============================================================================
 // DP CONSTANTS — mirrors src/lib/types/analytics/metrics.ts PRIVACY object
@@ -111,6 +112,7 @@ type AnalyticsInternalApi = {
 // Rate limiting + validation happens in the SvelteKit endpoint; this just writes.
 export const incrementBatch = mutation({
   args: {
+    _secret: v.string(),
     increments: v.array(
       v.object({
         metric: v.string(),
@@ -123,6 +125,7 @@ export const incrementBatch = mutation({
     ),
   },
   handler: async (ctx, args) => {
+    requireInternalSecret(args._secret);
     // Defense-in-depth: validate even if SvelteKit endpoint already checked
     const batch = args.increments.slice(0, MAX_BATCH_SIZE);
     const now = Date.now();

--- a/convex/authOps.ts
+++ b/convex/authOps.ts
@@ -482,8 +482,9 @@ const MAX_SESSION_LIFETIME_MS = 90 * DAY_MS;
  * Handles session renewal (extends expiry when within 15 days of expiration).
  */
 export const validateSession = query({
-  args: { sessionId: v.string() },
-  handler: async (ctx: any, { sessionId }): Promise<ValidateSessionResult> => {
+  args: { _secret: v.string(), sessionId: v.string() },
+  handler: async (ctx: any, { _secret, sessionId }): Promise<ValidateSessionResult> => {
+    requireInternalSecret(_secret);
     const db = authOpsDb(ctx);
     const normalizedSessionId = db.normalizeId("sessions", sessionId);
     const session = normalizedSessionId ? await db.get(normalizedSessionId) : null;
@@ -527,12 +528,12 @@ export const validateSession = query({
  * but the user doc has no tokenIdentifier.
  */
 export const backfillTokenIdentifier = mutation({
-  args: { userId: v.string() },
+  args: {},
   returns: v.null(),
-  handler: async (ctx: any, args): Promise<null> => {
+  handler: async (ctx: any): Promise<null> => {
     const db = authOpsDb(ctx);
-    const userId = db.normalizeId("users", args.userId);
-    const user = userId ? await db.get(userId) : null;
+    const { userId } = await requireAuth(ctx);
+    const user = await db.get(userId);
     if (user && !user.tokenIdentifier) {
       await db.patch(user._id, {
         tokenIdentifier: `${ISSUER_PREFIX}|${user._id}`,

--- a/convex/campaigns.ts
+++ b/convex/campaigns.ts
@@ -2593,17 +2593,7 @@ export const getDeliveryMetrics = query({
 		const { userId } = await requireAuth(ctx);
 		const campaign = await ctx.db.get(campaignId);
 		if (!campaign) {
-			return {
-				sent: 0,
-				delivered: 0,
-				opened: 0,
-				clicked: 0,
-				bounced: 0,
-				deliveryRate: 0,
-				openRate: 0,
-				clickRate: 0,
-				bounceRate: 0
-			};
+			throw new Error('You are not a member of this organization');
 		}
 		await requireOrgMembership(ctx, campaign.orgId, userId);
 

--- a/convex/campaigns.ts
+++ b/convex/campaigns.ts
@@ -12,6 +12,7 @@ import type { FunctionReference } from 'convex/server';
 import { v } from 'convex/values';
 import { campaignType, campaignStatus } from './_validators';
 import { requireOrgRole, loadOrg, requireAuth, requireOrgMembership } from './_authHelpers';
+import { requireInternalSecret } from './_internalAuth';
 import type { Doc, Id } from './_generated/dataModel';
 import {
 	computeOrgScopedEmailHash,
@@ -1493,6 +1494,7 @@ export const createCampaignAction = internalMutation({
  */
 export const submitAction = action({
 	args: {
+		_secret: v.string(),
 		campaignId: v.string(),
 		email: v.string(),
 		name: v.string(),
@@ -1509,6 +1511,7 @@ export const submitAction = action({
 		atlasVersion: v.optional(v.string())
 	},
 	handler: async (ctx, args): Promise<SubmitActionResult> => {
+		requireInternalSecret(args._secret);
 		// Validate early
 		if (!args.email) throw new Error('Email is required');
 		if (!args.name) throw new Error('Name is required');
@@ -2587,6 +2590,23 @@ export const updateDeliveryStatus = internalMutation({
 export const getDeliveryMetrics = query({
 	args: { campaignId: v.id('campaigns') },
 	handler: async (ctx, { campaignId }) => {
+		const { userId } = await requireAuth(ctx);
+		const campaign = await ctx.db.get(campaignId);
+		if (!campaign) {
+			return {
+				sent: 0,
+				delivered: 0,
+				opened: 0,
+				clicked: 0,
+				bounced: 0,
+				deliveryRate: 0,
+				openRate: 0,
+				clickRate: 0,
+				bounceRate: 0
+			};
+		}
+		await requireOrgMembership(ctx, campaign.orgId, userId);
+
 		const deliveries = await ctx.db
 			.query('campaignDeliveries')
 			.withIndex('by_campaignId', (q) => q.eq('campaignId', campaignId))

--- a/convex/campaigns.ts
+++ b/convex/campaigns.ts
@@ -2869,11 +2869,19 @@ export const getPastDeliveries = query({
 export const getCampaignByDebateId = query({
 	args: { debateId: v.id('debates') },
 	handler: async (ctx, { debateId }) => {
+		const { userId } = await requireAuth(ctx);
 		const campaign = await ctx.db
 			.query('campaigns')
 			.withIndex('by_debateId', (idx) => idx.eq('debateId', debateId))
 			.first();
 		if (!campaign) return null;
+		const membership = await ctx.db
+			.query('orgMemberships')
+			.withIndex('by_userId_orgId', (q) =>
+				q.eq('userId', userId).eq('orgId', campaign.orgId),
+			)
+			.first();
+		if (!membership) return null;
 		return {
 			_id: campaign._id,
 			orgId: campaign.orgId,

--- a/convex/cutover.ts
+++ b/convex/cutover.ts
@@ -8,7 +8,7 @@
  * specs/CIRCUIT-REVISION-MIGRATION.md.
  */
 
-import { query, internalMutation } from "./_generated/server";
+import { internalQuery, internalMutation } from "./_generated/server";
 import { v } from "convex/values";
 import { internal } from "./_generated/api";
 
@@ -17,11 +17,11 @@ import { internal } from "./_generated/api";
  * one-shot cutover script to enumerate candidates.
  *
  * Scope: rows where revokedAt is undefined AND expiresAt is in the future.
- * The script runs in admin mode (CONVEX_ADMIN_KEY); the query is exposed as
- * `query` not `internalQuery` because HTTP client calls cannot target
- * internal functions directly.
+ * This is an internal query reachable only from the admin-authenticated ops
+ * script via `internal.cutover.listActiveCredentials`, keeping the verified-user
+ * roster off the public data plane.
  */
-export const listActiveCredentials = query({
+export const listActiveCredentials = internalQuery({
   args: {},
   handler: async (ctx) => {
     const now = Date.now();

--- a/convex/debates.ts
+++ b/convex/debates.ts
@@ -1132,6 +1132,12 @@ export const getCampaignForDebate = query({
 export const listAwaitingGovernance = query({
   args: {},
   handler: async (ctx) => {
+    // Deliberately community-visible (any authenticated user), NOT operator-only:
+    // this is the participatory-governance queue. Safe because the return below is
+    // an explicit allowlist projection (no userId/PII/internal fields) and
+    // participation counts (argumentCount, uniqueParticipants) are K-floored to null
+    // below 5. The debate propositions, arguments, and AI resolutions are public
+    // deliberative content by design.
     await requireAuth(ctx);
     const debates = await ctx.db
       .query("debates")

--- a/convex/debates.ts
+++ b/convex/debates.ts
@@ -27,6 +27,14 @@ declare const process: { env: Record<string, string | undefined> };
 
 const insertDebateRef = makeFunctionReference<"mutation">("debates:insertDebate") as unknown as FunctionReference<"mutation", "internal">;
 const getCallerTrustTierRef = makeFunctionReference<"query">("debates:_getCallerTrustTier") as unknown as FunctionReference<"query", "internal", { tokenIdentifier: string }, number>;
+const getCampaignEditorRoleRef = makeFunctionReference<"query">(
+  "debates:_getCampaignEditorRoleForCaller",
+) as unknown as FunctionReference<
+  "query",
+  "internal",
+  { campaignId: Id<"campaigns"> },
+  "owner" | "editor" | "member" | null
+>;
 // Re-imported here so the listPublic args validator can reference the
 // closed union — declared inline because debates.ts already manages
 // many makeFunctionReference helpers and centralizing imports keeps
@@ -1116,6 +1124,7 @@ export const getCampaignForDebate = query({
 export const listAwaitingGovernance = query({
   args: {},
   handler: async (ctx) => {
+    await requireAuth(ctx);
     const debates = await ctx.db
       .query("debates")
       .filter((q) => q.eq(q.field("status"), "awaiting_governance"))
@@ -1271,6 +1280,13 @@ export const forceSpawnDebateForCampaign = action({
     const identity = await ctx.auth.getUserIdentity();
     if (!identity) throw new Error("Not authenticated");
 
+    const memberRole = await ctx.runQuery(getCampaignEditorRoleRef, {
+      campaignId: args.campaignId,
+    });
+    if (memberRole !== "owner" && memberRole !== "editor") {
+      throw new Error("Only org editors/owners can spawn debates for a campaign");
+    }
+
     const campaign: {
       _id: Id<"campaigns">;
       title: string;
@@ -1371,6 +1387,22 @@ export const _getCampaignForSpawn = internalQuery({
       debateId: c.debateId ?? null,
       verifiedActionCount: c.verifiedActionCount ?? 0,
     };
+  },
+});
+
+export const _getCampaignEditorRoleForCaller = internalQuery({
+  args: { campaignId: v.id("campaigns") },
+  handler: async (ctx, { campaignId }) => {
+    const { userId } = await requireAuth(ctx);
+    const campaign = await ctx.db.get(campaignId);
+    if (!campaign) return null;
+    const membership = await ctx.db
+      .query("orgMemberships")
+      .withIndex("by_userId_orgId", (q) =>
+        q.eq("userId", userId).eq("orgId", campaign.orgId),
+      )
+      .first();
+    return membership?.role ?? null;
   },
 });
 

--- a/convex/debates.ts
+++ b/convex/debates.ts
@@ -607,6 +607,7 @@ export const cosign = mutation({
  */
 export const updateStatus = mutation({
   args: {
+    _secret: v.string(),
     debateId: v.id("debates"),
     status: v.string(),
     winningStance: v.optional(v.string()),
@@ -619,21 +620,28 @@ export const updateStatus = mutation({
     appealDeadline: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
-    const user = await requireAuth(ctx);
+    requireInternalSecret(args._secret);
 
     const debate = await ctx.db.get(args.debateId);
     if (!debate) throw new Error("Debate not found");
 
-    // Verify caller has org editor/owner role if debate is tied to a template with an org
+    // Defense-in-depth for org-tied debates: when the caller carries a user
+    // identity (the resolve/settle user-session routes) require org
+    // editor/owner. The operator CRON routes carry no identity and are gated
+    // by CRON_SECRET plus the internal secret above.
     if (debate.templateId) {
       const template = await ctx.db.get(debate.templateId);
       const templateOrgId = template?.orgId;
       if (templateOrgId) {
-        const membership = await ctx.db.query("orgMemberships")
-          .withIndex("by_userId_orgId", (q) => q.eq("userId", user.userId).eq("orgId", templateOrgId))
-          .unique();
-        if (!membership || (membership.role !== "owner" && membership.role !== "editor")) {
-          throw new Error("Only org editors/owners can change debate status");
+        const identity = await ctx.auth.getUserIdentity();
+        if (identity) {
+          const { userId } = await requireAuth(ctx);
+          const membership = await ctx.db.query("orgMemberships")
+            .withIndex("by_userId_orgId", (q) => q.eq("userId", userId).eq("orgId", templateOrgId))
+            .unique();
+          if (!membership || (membership.role !== "owner" && membership.role !== "editor")) {
+            throw new Error("Only org editors/owners can change debate status");
+          }
         }
       }
     }

--- a/convex/debates.ts
+++ b/convex/debates.ts
@@ -1024,6 +1024,7 @@ export const findNullifier = query({
  */
 export const updateArgumentScores = mutation({
   args: {
+    _secret: v.string(),
     debateId: v.id("debates"),
     scores: v.array(v.object({
       argumentIndex: v.number(),
@@ -1033,7 +1034,8 @@ export const updateArgumentScores = mutation({
       modelAgreement: v.float64(),
     })),
   },
-  handler: async (ctx, { debateId, scores }) => {
+  handler: async (ctx, { _secret, debateId, scores }) => {
+    requireInternalSecret(_secret);
     for (const score of scores) {
       const arg = await ctx.db
         .query("debateArguments")

--- a/convex/events.ts
+++ b/convex/events.ts
@@ -516,6 +516,7 @@ export const patchRsvpEmail = internalMutation({
  */
 export const createRsvp = action({
 	args: {
+		_secret: v.string(),
 		eventId: v.id('events'),
 		email: v.string(),
 		name: v.string(),
@@ -527,6 +528,7 @@ export const createRsvp = action({
 		supporterId: v.optional(v.id('supporters'))
 	},
 	handler: async (ctx, args): Promise<InsertRsvpResult> => {
+		requireInternalSecret(args._secret);
 		// Action-boundary length caps. The SvelteKit `/api/e/[id]/rsvp`
 		// route enforces these too, but Convex actions are directly
 		// callable from any authenticated client.
@@ -699,6 +701,7 @@ export const checkIn = mutation({
  */
 export const publicCheckIn = mutation({
 	args: {
+		_secret: v.string(),
 		eventId: v.id('events'),
 		// Optional checkin code. The mutation derives `verifiedTrust`
 		// server-side via constant-time compare against `event.checkinCode`;
@@ -721,6 +724,7 @@ export const publicCheckIn = mutation({
 		identityCommitment: v.optional(v.string())
 	},
 	handler: async (ctx, args) => {
+		requireInternalSecret(args._secret);
 		if (!args.emailHash || args.emailHash.length === 0 || args.emailHash.length > 128) {
 			throw new Error('EMAIL_HASH_INVALID');
 		}

--- a/convex/legislation.ts
+++ b/convex/legislation.ts
@@ -12,6 +12,7 @@ import { makeFunctionReference } from 'convex/server';
 import type { FunctionReference } from 'convex/server';
 import type { Doc, Id } from './_generated/dataModel';
 import { requireAuth, requireOrgRole } from './_authHelpers';
+import { requireInternalSecret } from './_internalAuth';
 import { upsertExternalId } from './_externalIds';
 
 declare const process: { env: Record<string, string | undefined> };
@@ -3017,11 +3018,12 @@ async function hashScorecardSnapshot(
 
 /**
  * Get pending alerts for an org (used by SSE alert stream).
- * Takes orgId directly — auth is handled by the SvelteKit route.
+ * Callable only by trusted server code that holds INTERNAL_API_SECRET.
  */
 export const getPendingAlertsByOrgId = query({
-	args: { orgId: v.id('organizations'), limit: v.optional(v.number()) },
+	args: { _secret: v.string(), orgId: v.id('organizations'), limit: v.optional(v.number()) },
 	handler: async (ctx, args) => {
+		requireInternalSecret(args._secret);
 		const limit = args.limit ?? 10;
 		const alerts = await ctx.db
 			.query('legislativeAlerts')

--- a/convex/networks.ts
+++ b/convex/networks.ts
@@ -644,7 +644,7 @@ export const remove = mutation({
  * Check if an org is an active member of a network (for public API stats).
  */
 export const checkMembership = query({
-	args: { networkId: v.id('orgNetworks'), orgId: v.id('organizations'), _secret: v.optional(v.string()) },
+	args: { networkId: v.id('orgNetworks'), orgId: v.id('organizations'), _secret: v.string() },
 	handler: async (ctx, { networkId, orgId, _secret }) => {
 		requireInternalSecret(_secret);
 		const member = await ctx.db

--- a/convex/networks.ts
+++ b/convex/networks.ts
@@ -644,8 +644,9 @@ export const remove = mutation({
  * Check if an org is an active member of a network (for public API stats).
  */
 export const checkMembership = query({
-	args: { networkId: v.id('orgNetworks'), orgId: v.id('organizations') },
-	handler: async (ctx, { networkId, orgId }) => {
+	args: { networkId: v.id('orgNetworks'), orgId: v.id('organizations'), _secret: v.optional(v.string()) },
+	handler: async (ctx, { networkId, orgId, _secret }) => {
+		requireInternalSecret(_secret);
 		const member = await ctx.db
 			.query('orgNetworkMembers')
 			.withIndex('by_networkId', (idx) => idx.eq('networkId', networkId))

--- a/convex/organizations.ts
+++ b/convex/organizations.ts
@@ -29,17 +29,12 @@ import type { Doc, Id } from './_generated/dataModel';
 // =============================================================================
 
 /**
- * Public query: load org by slug. No auth required.
+ * Load org by slug for organization workspace pages.
  */
 export const getBySlug = query({
 	args: { slug: v.string() },
 	handler: async (ctx, { slug }) => {
-		const org = await ctx.db
-			.query('organizations')
-			.withIndex('by_slug', (q) => q.eq('slug', slug))
-			.first();
-
-		if (!org) return null;
+		const { org } = await requireOrgRole(ctx, slug, 'member');
 
 		return {
 			_id: org._id,
@@ -54,6 +49,21 @@ export const getBySlug = query({
 			countryCode: org.countryCode,
 			_creationTime: org._creationTime
 		};
+	}
+});
+
+/**
+ * Authenticated slug availability check for organization creation.
+ */
+export const slugExists = query({
+	args: { slug: v.string() },
+	handler: async (ctx, { slug }) => {
+		await requireAuth(ctx);
+		const org = await ctx.db
+			.query('organizations')
+			.withIndex('by_slug', (q) => q.eq('slug', slug))
+			.first();
+		return !!org;
 	}
 });
 

--- a/convex/positions.ts
+++ b/convex/positions.ts
@@ -3,7 +3,7 @@
  * Used by: src/routes/s/[slug]/+page.server.ts (Power Landscape)
  */
 
-import { query, mutation } from "./_generated/server";
+import { query, mutation, internalQuery } from "./_generated/server";
 import { v } from "convex/values";
 import type { Id } from "./_generated/dataModel";
 import { requireInternalSecret } from "./_internalAuth";
@@ -45,10 +45,12 @@ export const getCounts = query({
  */
 export const getExisting = query({
   args: {
+    _secret: v.string(),
     templateId: v.id("templates"),
     identityCommitment: v.string(),
   },
-  handler: async (ctx, { templateId, identityCommitment }) => {
+  handler: async (ctx, { _secret, templateId, identityCommitment }) => {
+    requireInternalSecret(_secret);
     const reg = await ctx.db
       .query("positionRegistrations")
       .withIndex("by_templateId_identityCommitment", (idx) =>
@@ -68,7 +70,7 @@ export const getExisting = query({
 /**
  * Get position deliveries for a registration.
  */
-export const getDeliveries = query({
+export const getDeliveries = internalQuery({
   args: {
     registrationId: v.id("positionRegistrations"),
     deliveryMethod: v.optional(v.string()),
@@ -99,7 +101,7 @@ export const getDeliveries = query({
  * identityCommitment (optional) covers the tier-3+ stance-linked path used
  * when DEBATE market mechanics apply.
  */
-export const getUserDeliveries = query({
+export const getUserDeliveries = internalQuery({
   args: {
     templateId: v.id("templates"),
     pseudonymousId: v.string(),
@@ -267,12 +269,14 @@ export const register = mutation({
  */
 export const confirmMailtoSend = mutation({
   args: {
+    _secret: v.string(),
     templateId: v.id("templates"),
     identityCommitment: v.string(),
     districtCode: v.optional(v.string()),
     templateTitle: v.optional(v.string()),
   },
-  handler: async (ctx, { templateId, identityCommitment, districtCode, templateTitle }) => {
+  handler: async (ctx, { _secret, templateId, identityCommitment, districtCode, templateTitle }) => {
+    requireInternalSecret(_secret);
     // Upsert position (support implied by sending)
     const existing = await ctx.db
       .query("positionRegistrations")
@@ -314,6 +318,7 @@ export const confirmMailtoSend = mutation({
  */
 export const batchRegisterDeliveries = mutation({
   args: {
+    _secret: v.string(),
     registrationId: v.id("positionRegistrations"),
     identityCommitment: v.string(),
     recipients: v.array(v.object({
@@ -326,7 +331,8 @@ export const batchRegisterDeliveries = mutation({
       encryptedRecipientName: v.optional(v.string()),
     })),
   },
-  handler: async (ctx, { registrationId, identityCommitment, recipients }) => {
+  handler: async (ctx, { _secret, registrationId, identityCommitment, recipients }) => {
+    requireInternalSecret(_secret);
     // Verify registration exists and belongs to caller
     const reg = await ctx.db.get(registrationId);
     if (!reg || reg.identityCommitment !== identityCommitment) {
@@ -380,6 +386,7 @@ function slugify(s: string): string {
  */
 export const recordDirectDeliveries = mutation({
   args: {
+    _secret: v.string(),
     pseudonymousId: v.string(),
     templateId: v.id("templates"),
     districtCode: v.optional(v.string()),
@@ -393,7 +400,8 @@ export const recordDirectDeliveries = mutation({
       encryptedRecipientName: v.optional(v.string()),
     })),
   },
-  handler: async (ctx, { pseudonymousId, templateId, districtCode, recipients }) => {
+  handler: async (ctx, { _secret, pseudonymousId, templateId, districtCode, recipients }) => {
+    requireInternalSecret(_secret);
     const now = Date.now();
     // Pre-fetch the user's existing deliveries for this template to deduplicate
     const existing = await ctx.db

--- a/convex/positions.ts
+++ b/convex/positions.ts
@@ -6,6 +6,7 @@
 import { query, mutation } from "./_generated/server";
 import { v } from "convex/values";
 import type { Id } from "./_generated/dataModel";
+import { requireInternalSecret } from "./_internalAuth";
 
 /**
  * Get aggregate position counts for a template. K-floor at 5 on stance counts,
@@ -225,12 +226,14 @@ export const getEngagementByDistrict = query({
  */
 export const register = mutation({
   args: {
+    _secret: v.string(),
     templateId: v.id("templates"),
     identityCommitment: v.string(),
     stance: v.string(),
     districtCode: v.optional(v.string()),
   },
-  handler: async (ctx, { templateId, identityCommitment, stance, districtCode }) => {
+  handler: async (ctx, { _secret, templateId, identityCommitment, stance, districtCode }) => {
+    requireInternalSecret(_secret);
     // Check template exists
     const template = await ctx.db.get(templateId);
     if (!template) throw new Error("Template not found");

--- a/convex/revocations.ts
+++ b/convex/revocations.ts
@@ -613,7 +613,7 @@ export const getRevocationHaltStatus = query({
  * Read recent halt audit log entries for forensic review. Limited to the most
  * recent 100 records — paginate if needed for older incidents.
  */
-export const getRevocationHaltAuditLog = query({
+export const getRevocationHaltAuditLog = internalQuery({
   args: { limit: v.optional(v.number()) },
   handler: async (ctx, args) => {
     const limit = args.limit ?? 100;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -265,10 +265,9 @@ export default defineSchema({
 
 		// Semantic embeddings (768-dim Gemini vectors). All three are SERVER-ONLY:
 		// consumed for vector search, relatedness twins, concept edges, and hue
-		// projection. The public template queries that return raw documents
-		// (`getBySlug`, `list`) run them through `stripEmbeddings` so these fields
-		// never cross the client boundary; the enriched queries (`listPublic`,
-		// `getBySlugPublic`) project explicit field sets that omit them.
+		// projection. Public template queries (`list`, `search`, `listPublic`,
+		// `getBySlugPublic`) return explicit allowlist projections that omit them,
+		// so these fields never cross the client boundary.
 		locationEmbedding: v.optional(v.array(v.float64())),
 		topicEmbedding: v.optional(v.array(v.float64())),
 		// Per-tag embeddings, generated the same way as topicEmbedding (one Gemini

--- a/convex/submissions.ts
+++ b/convex/submissions.ts
@@ -2332,7 +2332,7 @@ export const cleanupExpiredWitnesses = internalMutation({
  * Get submission by ID (public query — used for retry ownership check).
  * Returns minimal fields only.
  */
-export const getPublicById = query({
+export const getPublicById = internalQuery({
 	args: { submissionId: v.id('submissions') },
 	handler: async (ctx, { submissionId }) => {
 		const sub = await ctx.db.get(submissionId);

--- a/convex/templates.ts
+++ b/convex/templates.ts
@@ -4,6 +4,7 @@ import type { FunctionReference } from "convex/server";
 import { v } from "convex/values";
 import type { Doc, Id } from "./_generated/dataModel";
 import { requireAuth, requireOrgRole, loadOrg } from "./_authHelpers";
+import { requireInternalSecret } from "./_internalAuth";
 import {
   startOfMonthUTC,
   decideIndividualAuthoring,
@@ -1137,8 +1138,9 @@ export const findByContentHash = query({
  * Find template by slug (uniqueness check).
  */
 export const findBySlug = query({
-  args: { slug: v.string() },
-  handler: async (ctx, { slug }) => {
+  args: { slug: v.string(), _secret: v.string() },
+  handler: async (ctx, { slug, _secret }) => {
+    requireInternalSecret(_secret);
     return await ctx.db
       .query("templates")
       .withIndex("by_slug", (q) => q.eq("slug", slug))
@@ -1376,6 +1378,11 @@ export const patchMetadata = mutation({
     topics: v.optional(v.array(v.string())),
   },
   handler: async (ctx, args) => {
+    const { userId } = await requireAuth(ctx);
+    const template = await ctx.db.get(args.templateId);
+    if (!template) throw new Error("Template not found");
+    if (template.userId !== userId) throw new Error("Unauthorized");
+
     await ctx.db.patch(args.templateId, {
       updatedAt: Date.now(),
       ...(args.domain !== undefined ? { domain: args.domain } : {}),

--- a/convex/templates.ts
+++ b/convex/templates.ts
@@ -92,31 +92,23 @@ function normalizeTags(topics: unknown): string[] {
   return Array.from(seen).sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
 }
 
-/**
- * Strip the server-only embedding vectors from a template document before it
- * crosses the client boundary. The 768-dim `topicEmbedding` / `locationEmbedding`
- * and the per-tag `tagEmbeddings` are consumed only server-side (relatedness +
- * concept edges, vector search); they are never part of a client-returned
- * template. Every other field is preserved.
- */
-function stripEmbeddings<T extends Record<string, unknown>>(
-  doc: T,
-): Omit<T, "topicEmbedding" | "locationEmbedding" | "tagEmbeddings"> {
-  const { topicEmbedding, locationEmbedding, tagEmbeddings, ...rest } = doc;
-  return rest;
-}
-
-function stripInternal<T extends Record<string, unknown>>(doc: T) {
-  const {
-    userId,
-    contentHash,
-    reputationDelta,
-    flaggedByModeration,
-    consensusApproved,
-    verificationStatus,
-    ...rest
-  } = stripEmbeddings(doc);
-  return rest;
+function toPublicTemplate(t: Doc<"templates">, score?: number | null) {
+  const projected = {
+    _id: t._id,
+    slug: t.slug,
+    title: t.title,
+    description: t.description,
+    domain: resolveDomain(t),
+    domainHue: t.domainHue ?? undefined,
+    type: t.type,
+    deliveryMethod: t.deliveryMethod,
+    status: t.status,
+    isPublic: t.isPublic,
+    verifiedSends: t.verifiedSends < 5 ? null : t.verifiedSends,
+    uniqueDistricts: t.uniqueDistricts < 3 ? null : t.uniqueDistricts,
+    createdAt: new Date(t._creationTime).toISOString(),
+  };
+  return score === undefined ? projected : { ...projected, _score: score };
 }
 
 /**
@@ -142,21 +134,7 @@ export const list = query({
       });
     return {
       ...result,
-      page: result.page.map((template) => ({
-        _id: template._id,
-        slug: template.slug,
-        title: template.title,
-        description: template.description,
-        domain: resolveDomain(template),
-        domainHue: template.domainHue ?? undefined,
-        type: template.type,
-        deliveryMethod: template.deliveryMethod,
-        status: template.status,
-        isPublic: template.isPublic,
-        verifiedSends: template.verifiedSends < 5 ? null : template.verifiedSends,
-        uniqueDistricts: template.uniqueDistricts < 3 ? null : template.uniqueDistricts,
-        createdAt: new Date(template._creationTime).toISOString(),
-      })),
+      page: result.page.map((template) => toPublicTemplate(template)),
     };
   },
 });
@@ -850,6 +828,7 @@ export const search = action({
       // for multi-field AND that VectorFilterBuilder can't express natively.
       const scored = templates
         .filter((t): t is NonNullable<typeof t> => t != null)
+        .filter((t) => t.status === "published" && t.isPublic)
         .filter((t) =>
           secondaryFilter ? t[secondaryFilter[0]] === secondaryFilter[1] : true,
         )
@@ -867,7 +846,7 @@ export const search = action({
         .slice(0, limit);
 
       return {
-        templates: scored.map(stripInternal),
+        templates: scored.map((t) => toPublicTemplate(t, t._score)),
         method: "semantic" as const,
       };
     } catch {
@@ -880,7 +859,7 @@ export const search = action({
       }) as Doc<"templates">[];
 
       return {
-        templates: textResults.map((t) => stripInternal({ ...t, _score: null })),
+        templates: textResults.map((t) => toPublicTemplate(t, null)),
         method: "keyword" as const,
       };
     }
@@ -908,8 +887,10 @@ export const textSearch = internalQuery({
         return search;
       });
 
-    const results = await q.take(args.limit);
-    return results;
+    const results = await q.take(Math.min(args.limit + 20, 50));
+    return results
+      .filter((t) => t.status === "published" && t.isPublic)
+      .slice(0, args.limit);
   },
 });
 

--- a/convex/templates.ts
+++ b/convex/templates.ts
@@ -106,6 +106,19 @@ function stripEmbeddings<T extends Record<string, unknown>>(
   return rest;
 }
 
+function stripInternal<T extends Record<string, unknown>>(doc: T) {
+  const {
+    userId,
+    contentHash,
+    reputationDelta,
+    flaggedByModeration,
+    consensusApproved,
+    verificationStatus,
+    ...rest
+  } = stripEmbeddings(doc);
+  return rest;
+}
+
 /**
  * Public: List published templates, ordered by creation time (newest first).
  * Paginated via Convex's built-in pagination. Embedding vectors are stripped —
@@ -127,7 +140,24 @@ export const list = query({
         numItems: Math.min(args.paginationOpts.numItems, 50),
         cursor: args.paginationOpts.cursor ?? null,
       });
-    return { ...result, page: result.page.map(stripEmbeddings) };
+    return {
+      ...result,
+      page: result.page.map((template) => ({
+        _id: template._id,
+        slug: template.slug,
+        title: template.title,
+        description: template.description,
+        domain: resolveDomain(template),
+        domainHue: template.domainHue ?? undefined,
+        type: template.type,
+        deliveryMethod: template.deliveryMethod,
+        status: template.status,
+        isPublic: template.isPublic,
+        verifiedSends: template.verifiedSends < 5 ? null : template.verifiedSends,
+        uniqueDistricts: template.uniqueDistricts < 3 ? null : template.uniqueDistricts,
+        createdAt: new Date(template._creationTime).toISOString(),
+      })),
+    };
   },
 });
 
@@ -149,8 +179,13 @@ export const getBySlug = query({
       return null;
     }
 
-    // Strip the server-only embedding vectors before returning to the client.
-    return stripEmbeddings(template);
+    return {
+      id: template._id,
+      slug: template.slug,
+      title: template.title,
+      status: template.status,
+      isPublic: template.isPublic,
+    };
   },
 });
 
@@ -832,7 +867,7 @@ export const search = action({
         .slice(0, limit);
 
       return {
-        templates: scored,
+        templates: scored.map(stripInternal),
         method: "semantic" as const,
       };
     } catch {
@@ -845,7 +880,7 @@ export const search = action({
       }) as Doc<"templates">[];
 
       return {
-        templates: textResults.map((t) => ({ ...t, _score: null })),
+        templates: textResults.map((t) => stripInternal({ ...t, _score: null })),
         method: "keyword" as const,
       };
     }
@@ -926,7 +961,7 @@ export const listByUser = query({
 export const listByOrg = query({
   args: { slug: v.string() },
   handler: async (ctx, { slug }) => {
-    const org = await loadOrg(ctx, slug);
+    const { org } = await requireOrgRole(ctx, slug, "member");
 
     const templates = await ctx.db
       .query("templates")
@@ -1120,12 +1155,13 @@ export const updateEmbeddings = mutation({
  */
 export const findByContentHash = query({
   args: { userId: v.string(), contentHash: v.string() },
-  handler: async (ctx, { userId, contentHash }) => {
+  handler: async (ctx, { contentHash }) => {
+    const { userId: authUserId } = await requireAuth(ctx);
     const templates = await ctx.db
       .query("templates")
       .filter((q) =>
         q.and(
-          q.eq(q.field("userId"), userId),
+          q.eq(q.field("userId"), authUserId),
           q.eq(q.field("contentHash"), contentHash),
         ),
       )
@@ -1141,17 +1177,18 @@ export const findBySlug = query({
   args: { slug: v.string(), _secret: v.string() },
   handler: async (ctx, { slug, _secret }) => {
     requireInternalSecret(_secret);
-    return await ctx.db
+    const template = await ctx.db
       .query("templates")
       .withIndex("by_slug", (q) => q.eq("slug", slug))
       .first();
+    return template ? { _id: template._id } : null;
   },
 });
 
 /**
  * Get user's org membership (for quota check).
  */
-export const getUserOrgId = query({
+export const getUserOrgId = internalQuery({
   args: { userId: v.string() },
   handler: async (ctx, { userId }) => {
     const membership = await ctx.db

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -1091,6 +1091,8 @@ export const getActiveCredentialHash = query({
 export const getIdentityForAtlas = query({
 	args: { userId: v.id('users') },
 	handler: async (ctx, args) => {
+		const { userId: authUserId } = await requireAuth(ctx);
+		if (args.userId !== authUserId) throw new Error('Unauthorized');
 		const user = await ctx.db.get(args.userId);
 		if (!user) return null;
 		// Derive authority from trustTier so leaf computation matches client-side value.
@@ -1112,6 +1114,8 @@ export const getIdentityForAtlas = query({
 export const getIdentityForEngagement = query({
 	args: { userId: v.id('users') },
 	handler: async (ctx, args) => {
+		const { userId: authUserId } = await requireAuth(ctx);
+		if (args.userId !== authUserId) throw new Error('Unauthorized');
 		const user = await ctx.db.get(args.userId);
 		if (!user) return null;
 		return {

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -968,6 +968,8 @@ export const verifyAddress = mutation({
 export const getDidKey = query({
 	args: { userId: v.id('users') },
 	handler: async (ctx, args) => {
+		const { userId: authUserId } = await requireAuth(ctx);
+		if (args.userId !== authUserId) throw new Error('Unauthorized');
 		const user = await ctx.db.get(args.userId);
 		if (!user) return null;
 		return { didKey: user.didKey ?? null };
@@ -1293,8 +1295,9 @@ export const updateShadowAtlasRegistration = mutation({
  * cheaper than the migration risk of introducing a counter.
  */
 export const countRegistrations = query({
-	args: {},
-	handler: async (ctx) => {
+	args: { _secret: v.string() },
+	handler: async (ctx, args) => {
+		requireInternalSecret(args._secret);
 		let count = 0;
 		let cursor: string | null = null;
 		// 1024-row page size; loop until isDone. Each page is well under the
@@ -1316,8 +1319,9 @@ export const countRegistrations = query({
  * List recent shadow atlas registrations (for spot-check reconciliation).
  */
 export const listRecentRegistrations = query({
-	args: { limit: v.optional(v.number()) },
-	handler: async (ctx, { limit }) => {
+	args: { _secret: v.string(), limit: v.optional(v.number()) },
+	handler: async (ctx, { _secret, limit }) => {
+		requireInternalSecret(_secret);
 		const max = Math.min(limit ?? 50, 100);
 		const regs = await ctx.db.query('shadowAtlasRegistrations').order('desc').take(max);
 		return regs.map((r) => ({
@@ -1338,7 +1342,7 @@ export const listRecentRegistrations = query({
  * If another user already has this commitment, merges accounts
  * (returns the canonical userId). Otherwise patches the current user.
  */
-export const bindIdentityCommitment = mutation({
+export const bindIdentityCommitment = internalMutation({
 	args: {
 		userId: v.id('users'),
 		identityCommitment: v.string(),
@@ -1346,8 +1350,6 @@ export const bindIdentityCommitment = mutation({
 		documentType: v.optional(v.string())
 	},
 	handler: async (ctx, args) => {
-		const { userId: authUserId } = await requireAuth(ctx);
-		if (args.userId !== authUserId) throw new Error('Unauthorized');
 		// Check if commitment already bound to another user (Sybil / account merge)
 		const existing = await ctx.db
 			.query('users')
@@ -1387,6 +1389,7 @@ export const bindIdentityCommitment = mutation({
 
 export const upsertRegistration = mutation({
 	args: {
+		_secret: v.string(),
 		userId: v.id('users'),
 		identityCommitment: v.string(),
 		leafIndex: v.number(),
@@ -1397,8 +1400,7 @@ export const upsertRegistration = mutation({
 		queuedAt: v.string()
 	},
 	handler: async (ctx, args) => {
-		const { userId: authUserId } = await requireAuth(ctx);
-		if (args.userId !== authUserId) throw new Error('Unauthorized');
+		requireInternalSecret(args._secret);
 		const existing = await ctx.db
 			.query('shadowAtlasRegistrations')
 			.withIndex('by_userId', (q) => q.eq('userId', args.userId))

--- a/convex/verify.ts
+++ b/convex/verify.ts
@@ -5,6 +5,7 @@
 import { query } from "./_generated/server";
 import { v } from "convex/values";
 import type { Id } from "./_generated/dataModel";
+import { requireInternalSecret } from "./_internalAuth";
 
 /**
  * Get campaign delivery by ID for verification page.
@@ -50,11 +51,14 @@ export const getCampaignForVerify = query({
  * `undefined` and the UI must render "unknown" rather than a default.
  */
 export const getCredentialByHash = query({
-  args: { credentialHash: v.string() },
-  handler: async (ctx, { credentialHash }) => {
+  args: { credentialHash: v.string(), _secret: v.string() },
+  handler: async (ctx, { credentialHash, _secret }) => {
+    requireInternalSecret(_secret);
+    const trimmedHash = credentialHash.trim();
+    if (!trimmedHash) throw new Error("Invalid credential hash");
     const cred = await ctx.db
       .query("districtCredentials")
-      .filter((q) => q.eq(q.field("credentialHash"), credentialHash))
+      .withIndex("by_credentialHash", (q) => q.eq("credentialHash", trimmedHash))
       .first();
     if (!cred) return null;
     return {

--- a/convex/waitlist.ts
+++ b/convex/waitlist.ts
@@ -1,14 +1,17 @@
 import { mutation } from "./_generated/server";
 import { v } from "convex/values";
+import { requireInternalSecret } from "./_internalAuth";
 
 export const join = mutation({
   args: {
+    _secret: v.string(),
     email: v.string(),
     emailHash: v.string(),
     userId: v.optional(v.id("users")),
     source: v.string(),
   },
   handler: async (ctx, args) => {
+    requireInternalSecret(args._secret);
     const existing = await ctx.db
       .query("waitlist")
       .withIndex("by_emailHash", (q) => q.eq("emailHash", args.emailHash))
@@ -22,7 +25,7 @@ export const join = mutation({
           updatedAt: Date.now(),
         });
       }
-      return { status: "exists" as const };
+      return { success: true as const };
     }
 
     await ctx.db.insert("waitlist", {
@@ -34,6 +37,6 @@ export const join = mutation({
       updatedAt: Date.now(),
     });
 
-    return { status: "created" as const };
+    return { success: true as const };
   },
 });

--- a/scripts/cutover-v1-credentials.ts
+++ b/scripts/cutover-v1-credentials.ts
@@ -62,7 +62,7 @@ async function main() {
   // script we rely on the backing query to return manageable volumes; if the
   // eventual candidate list exceeds ~10K rows, split by userId ranges.
   const candidates = await client.query(
-    (api as unknown as { cutover: { listActiveCredentials: unknown } }).cutover
+    (internal as unknown as { cutover: { listActiveCredentials: unknown } }).cutover
       .listActiveCredentials,
     {},
   );

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -15,6 +15,7 @@ import * as Sentry from '@sentry/sveltekit';
 import { initConvex, serverQuery, serverMutation } from 'convex-sveltekit';
 import { PUBLIC_CONVEX_URL } from '$env/static/public';
 import { mintConvexToken } from '$lib/server/convex-jwt';
+import { getInternalSecret } from '$lib/server/internal/secret-auth';
 import { api } from '$lib/convex';
 
 // ─── DUAL-STACK: Initialize Convex server-side client ───
@@ -92,7 +93,7 @@ const handleAuth: Handle = async ({ event, resolve }) => {
 			return resolve(event);
 		}
 
-		const result = await serverQuery(api.authOps.validateSession, { sessionId });
+		const result = await serverQuery(api.authOps.validateSession, { _secret: getInternalSecret(), sessionId });
 
 		if (!result) {
 			event.cookies.delete(SESSION_COOKIE, { path: '/' });
@@ -150,9 +151,7 @@ const handleAuth: Handle = async ({ event, resolve }) => {
 		// itself is stuck (would surface as 100% backfill-call rate vs
 		// expected one-shot decay as legacy users get migrated).
 		if (!user.tokenIdentifier) {
-			serverMutation(api.authOps.backfillTokenIdentifier, {
-				userId: user._id as string
-			}).catch((err) => {
+			serverMutation(api.authOps.backfillTokenIdentifier, {}).catch((err) => {
 				console.warn(
 					'[hooks.server] tokenIdentifier backfill failed for user=' +
 						(user._id as string).slice(0, 8) +

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -144,23 +144,6 @@ const handleAuth: Handle = async ({ event, resolve }) => {
 			});
 		}
 
-		// Backfill tokenIdentifier for sessions created before the fix.
-		// Backfill failure leaves the user without a tokenIdentifier, which
-		// the Convex helpers fall back to email lookup for — degraded but
-		// not broken. Worth logging so an operator sees if the backfill
-		// itself is stuck (would surface as 100% backfill-call rate vs
-		// expected one-shot decay as legacy users get migrated).
-		if (!user.tokenIdentifier) {
-			serverMutation(api.authOps.backfillTokenIdentifier, {}).catch((err) => {
-				console.warn(
-					'[hooks.server] tokenIdentifier backfill failed for user=' +
-						(user._id as string).slice(0, 8) +
-						'...:',
-					err instanceof Error ? err.message : String(err)
-				);
-			});
-		}
-
 		event.locals.user = {
 			id: user._id as string,
 			email: userEmail,
@@ -222,6 +205,16 @@ const handleAuth: Handle = async ({ event, resolve }) => {
 				const token = await mintConvexToken(event.locals.user);
 				if (token) {
 					event.locals.convexToken = token;
+					if (!user.tokenIdentifier) {
+						serverMutation(api.authOps.backfillTokenIdentifier, {}).catch((err) => {
+							console.warn(
+								'[hooks.server] tokenIdentifier backfill failed for user=' +
+									(user._id as string).slice(0, 8) +
+									'...:',
+								err instanceof Error ? err.message : String(err)
+							);
+						});
+					}
 				}
 			} catch (err) {
 				console.warn(

--- a/src/routes/api/admin/reconcile-registrations/+server.ts
+++ b/src/routes/api/admin/reconcile-registrations/+server.ts
@@ -21,6 +21,7 @@ import type { Id } from '$convex/_generated/dataModel';
 import type { RequestHandler } from './$types';
 import { env } from '$env/dynamic/private';
 import { verifyCronSecret } from '$lib/server/cron-auth';
+import { getInternalSecret } from '$lib/server/internal/secret-auth';
 
 const SHADOW_ATLAS_URL = env.SHADOW_ATLAS_API_URL || 'http://localhost:3000';
 const SHADOW_ATLAS_REGISTRATION_TOKEN = env.SHADOW_ATLAS_REGISTRATION_TOKEN || '';
@@ -77,6 +78,7 @@ export const POST: RequestHandler = async (event) => {
 					};
 
 					await serverMutation(api.users.upsertRegistration, {
+						_secret: getInternalSecret(),
 						userId: data.userId as Id<'users'>,
 						identityCommitment: data.identityCommitment,
 						leafIndex: data.atlasResult.leafIndex,
@@ -116,7 +118,9 @@ export const POST: RequestHandler = async (event) => {
 
 		if (treeInfoResponse.ok) {
 			const treeInfo = await treeInfoResponse.json() as { treeSize: number };
-			const pgCount = await serverQuery(api.users.countRegistrations, {});
+			const pgCount = await serverQuery(api.users.countRegistrations, {
+				_secret: getInternalSecret()
+			});
 
 			// Tree size >= pg count is expected (tree has padding/replaced zeros).
 			// pg count > tree size is a bug.
@@ -130,6 +134,7 @@ export const POST: RequestHandler = async (event) => {
 
 			// Spot-check a sample of recent registrations (max 50 per run)
 			const recentRegistrations = await serverQuery(api.users.listRecentRegistrations, {
+				_secret: getInternalSecret(),
 				limit: 50
 			});
 

--- a/src/routes/api/analytics/increment/+server.ts
+++ b/src/routes/api/analytics/increment/+server.ts
@@ -28,6 +28,7 @@ import {
 import { createHash } from 'crypto';
 import { serverMutation } from 'convex-sveltekit';
 import { api } from '$lib/convex';
+import { getInternalSecret } from '$lib/server/internal/secret-auth';
 
 // ============================================================================
 // In-Memory Rate Limiting
@@ -101,6 +102,7 @@ async function persistBatch(
 ): Promise<{ written: number }> {
 	try {
 		const result = await serverMutation(api.analytics.incrementBatch, {
+			_secret: getInternalSecret(),
 			increments: increments.map((inc) => ({
 				metric: inc.metric,
 				templateId: inc.dimensions?.template_id as string | undefined,

--- a/src/routes/api/debates/[debateId]/evaluate/+server.ts
+++ b/src/routes/api/debates/[debateId]/evaluate/+server.ts
@@ -131,6 +131,7 @@ export const POST: RequestHandler = async ({ params, request }) => {
 			const escResult = await escalateToGovernance(debate.debateIdOnchain);
 
 			await serverMutation(api.debates.updateStatus, {
+				_secret: getInternalSecret(),
 				debateId: debateId as Id<'debates'>,
 				status: 'awaiting_governance',
 				aiResolution: {
@@ -220,6 +221,7 @@ export const POST: RequestHandler = async ({ params, request }) => {
 
 		// Update debate status via Convex
 		await serverMutation(api.debates.updateStatus, {
+			_secret: getInternalSecret(),
 			debateId: debateId as Id<'debates'>,
 			status: 'resolved',
 			aiResolution: {

--- a/src/routes/api/debates/[debateId]/evaluate/+server.ts
+++ b/src/routes/api/debates/[debateId]/evaluate/+server.ts
@@ -7,6 +7,7 @@ import { api } from '$lib/convex';
 import type { Id } from '$convex/_generated/dataModel';
 import { escalateToGovernance, readChainResolution } from '$lib/core/blockchain/debate-market-client';
 import { verifyCronSecret } from '$lib/server/cron-auth';
+import { getInternalSecret } from '$lib/server/internal/secret-auth';
 import { FEATURES } from '$lib/config/features';
 
 // ── Rate limiting ────────────────────────────────────────────────────────
@@ -243,6 +244,7 @@ export const POST: RequestHandler = async ({ params, request }) => {
 
 		// Update per-argument AI scores via Convex
 		await serverMutation(api.debates.updateArgumentScores, {
+			_secret: getInternalSecret(),
 			debateId: debateId as Id<'debates'>,
 			scores: evaluationResult.aggregatedScores.map((agg) => ({
 				argumentIndex: agg.argumentIndex,

--- a/src/routes/api/debates/[debateId]/governance-resolve/+server.ts
+++ b/src/routes/api/debates/[debateId]/governance-resolve/+server.ts
@@ -6,6 +6,7 @@ import type { Id } from '$convex/_generated/dataModel';
 import { env } from '$env/dynamic/private';
 import { verifyCronSecret } from '$lib/server/cron-auth';
 import { FEATURES } from '$lib/config/features';
+import { getInternalSecret } from '$lib/server/internal/secret-auth';
 
 /**
  * POST /api/debates/[debateId]/governance-resolve
@@ -51,6 +52,7 @@ export const POST: RequestHandler = async ({ params, request }) => {
 	const appealDeadlineMs = Date.now() + 7 * 24 * 60 * 60 * 1000;
 
 	await serverMutation(api.debates.updateStatus, {
+		_secret: getInternalSecret(),
 		debateId: debateId as Id<'debates'>,
 		status: 'resolved',
 		winningStance: winnerArg.stance,

--- a/src/routes/api/debates/[debateId]/resolve/+server.ts
+++ b/src/routes/api/debates/[debateId]/resolve/+server.ts
@@ -9,6 +9,7 @@ import {
 } from '$lib/core/blockchain/debate-market-client';
 import { FEATURES } from '$lib/config/features';
 import { allowChainMisconfig } from '$lib/server/debate-chain-gate';
+import { getInternalSecret } from '$lib/server/internal/secret-auth';
 
 /**
  * POST /api/debates/[debateId]/resolve
@@ -109,6 +110,7 @@ export const POST: RequestHandler = async ({ params, locals }) => {
 
 	try {
 		await serverMutation(api.debates.updateStatus, {
+			_secret: getInternalSecret(),
 			debateId: debate._id,
 			status: 'resolved',
 			winningArgumentIndex: winningIndex,

--- a/src/routes/api/debates/[debateId]/settle/+server.ts
+++ b/src/routes/api/debates/[debateId]/settle/+server.ts
@@ -4,6 +4,7 @@ import { serverQuery, serverMutation } from 'convex-sveltekit';
 import { api } from '$lib/convex';
 import type { Id } from '$convex/_generated/dataModel';
 import { FEATURES } from '$lib/config/features';
+import { getInternalSecret } from '$lib/server/internal/secret-auth';
 
 /**
  * POST /api/debates/[debateId]/settle
@@ -76,6 +77,7 @@ export const POST: RequestHandler = async ({ params, request, locals }) => {
 	const winningArgumentIndex = stanceResult?.arguments?.[0]?.argumentIndex ?? undefined;
 
 	await serverMutation(api.debates.updateStatus, {
+		_secret: getInternalSecret(),
 		debateId: debateId as Id<'debates'>,
 		status: 'resolved',
 		winningStance,

--- a/src/routes/api/deliveries/record/+server.ts
+++ b/src/routes/api/deliveries/record/+server.ts
@@ -23,6 +23,7 @@ import { serverQuery, serverMutation } from 'convex-sveltekit';
 import { api } from '$lib/convex';
 import type { Id } from '$convex/_generated/dataModel';
 import { computePseudonymousId } from '$lib/core/privacy/pseudonymous-id';
+import { getInternalSecret } from '$lib/server/internal/secret-auth';
 
 export const POST: RequestHandler = async ({ request, locals }) => {
 	try {
@@ -79,6 +80,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 		const districtCode = atlas?.congressionalDistrict ?? undefined;
 
 		const result = await serverMutation(api.positions.recordDirectDeliveries, {
+			_secret: getInternalSecret(),
 			pseudonymousId,
 			templateId: templateId as Id<'templates'>,
 			districtCode,

--- a/src/routes/api/e/[id]/checkin/+server.ts
+++ b/src/routes/api/e/[id]/checkin/+server.ts
@@ -52,6 +52,7 @@ export const POST: RequestHandler = async ({ params, request, getClientAddress }
 	// `event.checkinCode` and ignores the caller-supplied `verified`
 	// flag for the verifiedAttendees counter.
 	const result = await serverMutation(api.events.publicCheckIn, {
+		_secret: getInternalSecret(),
 		eventId: params.id as Id<'events'>,
 		checkinCode: typeof checkinCode === 'string' ? checkinCode : undefined,
 		emailHash,

--- a/src/routes/api/e/[id]/rsvp/+server.ts
+++ b/src/routes/api/e/[id]/rsvp/+server.ts
@@ -5,6 +5,7 @@
  * POST /api/e/[id]/rsvp — Public RSVP to an event
  */
 
+import { getInternalSecret } from '$lib/server/internal/secret-auth';
 import { json, error } from '@sveltejs/kit';
 import { serverAction } from 'convex-sveltekit';
 import { api } from '$lib/convex';
@@ -70,6 +71,7 @@ export const POST: RequestHandler = async ({ params, request, getClientAddress }
 	try {
 		// Convex action handles: event validation, capacity claiming, PII encryption, upsert dedup, rsvpCount
 		const result = await serverAction(api.events.createRsvp, {
+			_secret: getInternalSecret(),
 			eventId: params.id as Id<'events'>,
 			email: email.toLowerCase(),
 			name: name.trim(),

--- a/src/routes/api/org/check-slug/+server.ts
+++ b/src/routes/api/org/check-slug/+server.ts
@@ -14,6 +14,6 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 		return json({ available: false });
 	}
 
-	const existing = await serverQuery(api.organizations.getBySlug, { slug });
-	return json({ available: !existing });
+	const exists = await serverQuery(api.organizations.slugExists, { slug });
+	return json({ available: !exists });
 };

--- a/src/routes/api/positions/batch-register/+server.ts
+++ b/src/routes/api/positions/batch-register/+server.ts
@@ -15,6 +15,7 @@ import type { RequestHandler } from './$types';
 import { serverMutation } from 'convex-sveltekit';
 import { api } from '$lib/convex';
 import type { Id } from '$convex/_generated/dataModel';
+import { getInternalSecret } from '$lib/server/internal/secret-auth';
 
 export const POST: RequestHandler = async ({ request, locals }) => {
 	if (!FEATURES.STANCE_POSITIONS) throw error(404, 'Not found');
@@ -59,6 +60,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 
 		// Create delivery records (mutation verifies ownership via identityCommitment)
 		const result = await serverMutation(api.positions.batchRegisterDeliveries, {
+			_secret: getInternalSecret(),
 			registrationId: registrationId as Id<'positionRegistrations'>,
 			identityCommitment,
 			recipients: recipients.map((r: { name: string; email?: string; deliveryMethod: string }) => ({

--- a/src/routes/api/positions/confirm-send/+server.ts
+++ b/src/routes/api/positions/confirm-send/+server.ts
@@ -16,6 +16,7 @@ import type { RequestHandler } from './$types';
 import { serverQuery, serverMutation } from 'convex-sveltekit';
 import { api } from '$lib/convex';
 import type { Id } from '$convex/_generated/dataModel';
+import { getInternalSecret } from '$lib/server/internal/secret-auth';
 
 export const POST: RequestHandler = async ({ request, locals }) => {
 	if (!FEATURES.STANCE_POSITIONS) throw error(404, 'Not found');
@@ -50,6 +51,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 		const templateTitle = template?.title;
 
 		const result = await serverMutation(api.positions.confirmMailtoSend, {
+			_secret: getInternalSecret(),
 			templateId: templateId as Id<'templates'>,
 			identityCommitment,
 			districtCode,

--- a/src/routes/api/positions/register/+server.ts
+++ b/src/routes/api/positions/register/+server.ts
@@ -15,6 +15,7 @@ import type { RequestHandler } from './$types';
 import { serverQuery, serverMutation } from 'convex-sveltekit';
 import { api } from '$lib/convex';
 import type { Id } from '$convex/_generated/dataModel';
+import { getInternalSecret } from '$lib/server/internal/secret-auth';
 
 export const POST: RequestHandler = async ({ request, locals }) => {
 	if (!FEATURES.STANCE_POSITIONS) throw error(404, 'Not found');
@@ -51,6 +52,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 
 		// Register position (upsert — duplicates return existing)
 		const registration = await serverMutation(api.positions.register, {
+			_secret: getInternalSecret(),
 			templateId: templateId as Id<'templates'>,
 			identityCommitment,
 			stance,

--- a/src/routes/api/templates/+server.ts
+++ b/src/routes/api/templates/+server.ts
@@ -5,6 +5,7 @@ import type { RequestHandler } from './$types';
 import { serverQuery, serverMutation } from 'convex-sveltekit';
 import { api } from '$lib/convex';
 import type { Id } from '$convex/_generated/dataModel';
+import { getInternalSecret } from '$lib/server/internal/secret-auth';
 import {
 	createApiError,
 	createValidationError,
@@ -425,7 +426,10 @@ export const POST: RequestHandler = async ({ request, locals, platform }) => {
 							.substring(0, 100);
 
 				// Slug uniqueness check via Convex
-				const existingTemplate = await serverQuery(api.templates.findBySlug, { slug });
+				const existingTemplate = await serverQuery(api.templates.findBySlug, {
+					slug,
+					_secret: getInternalSecret()
+				});
 
 				if (existingTemplate) {
 					const response: StructuredApiResponse = {

--- a/src/routes/api/v1/networks/[id]/stats/+server.ts
+++ b/src/routes/api/v1/networks/[id]/stats/+server.ts
@@ -46,7 +46,8 @@ export const GET: RequestHandler = async ({ params, request }) => {
 	// Verify the requesting org is an active member
 	const membership = await serverQuery(api.networks.checkMembership, {
 		networkId: params.id as Id<'orgNetworks'>,
-		orgId: auth.orgId as Id<'organizations'>
+		orgId: auth.orgId as Id<'organizations'>,
+		_secret: getInternalSecret()
 	});
 
 	if (!membership) {

--- a/src/routes/api/waitlist/+server.ts
+++ b/src/routes/api/waitlist/+server.ts
@@ -10,6 +10,7 @@ import { serverMutation } from 'convex-sveltekit';
 import { api } from '$lib/convex';
 import type { Id } from '$convex/_generated/dataModel';
 import { getRateLimiter } from '$lib/core/security/rate-limiter';
+import { getInternalSecret } from '$lib/server/internal/secret-auth';
 import crypto from 'node:crypto';
 import type { RequestHandler } from './$types';
 
@@ -52,6 +53,7 @@ export const POST: RequestHandler = async ({ locals, request, getClientAddress }
 	const normalized = email.toLowerCase().trim();
 
 	await serverMutation(api.waitlist.join, {
+		_secret: getInternalSecret(),
 		email: normalized,
 		emailHash: hashEmail(normalized),
 		userId: userId as Id<'users'> | undefined,

--- a/src/routes/c/[slug]/+page.server.ts
+++ b/src/routes/c/[slug]/+page.server.ts
@@ -3,6 +3,7 @@ import { error, fail } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
 import { getRateLimiter } from '$lib/core/security/rate-limiter';
 import { FEATURES } from '$lib/config/features';
+import { getInternalSecret } from '$lib/server/internal/secret-auth';
 import type { PageServerLoad, Actions } from './$types';
 
 import { serverQuery, serverAction } from 'convex-sveltekit';
@@ -108,6 +109,7 @@ export const actions: Actions = {
 
 		try {
 			const result = await serverAction(api.campaigns.submitAction, {
+				_secret: getInternalSecret(),
 				campaignId: params.slug,
 				email,
 				name,

--- a/src/routes/embed/campaign/[slug]/+page.server.ts
+++ b/src/routes/embed/campaign/[slug]/+page.server.ts
@@ -2,6 +2,7 @@
 import { error, fail } from '@sveltejs/kit';
 import { getRateLimiter } from '$lib/core/security/rate-limiter';
 import { FEATURES } from '$lib/config/features';
+import { getInternalSecret } from '$lib/server/internal/secret-auth';
 import type { PageServerLoad, Actions } from './$types';
 
 import { serverQuery, serverAction } from 'convex-sveltekit';
@@ -107,6 +108,7 @@ export const actions: Actions = {
 
 		try {
 			const result = await serverAction(api.campaigns.submitAction, {
+				_secret: getInternalSecret(),
 				campaignId: params.slug,
 				email,
 				name,

--- a/src/routes/s/[slug]/+page.server.ts
+++ b/src/routes/s/[slug]/+page.server.ts
@@ -7,6 +7,7 @@ import { getOfficials } from '$lib/core/shadow-atlas/client';
 import type { DistrictOfficialInput } from '$lib/utils/landscapeMerge';
 import { env } from '$env/dynamic/private';
 import type { Id } from '$convex/_generated/dataModel';
+import { getInternalSecret } from '$lib/server/internal/secret-auth';
 
 type DebateArgumentRow = {
 	_id: string;
@@ -148,7 +149,11 @@ export const load: PageServerLoad = async ({ locals, parent }) => {
 
 		// Existing user position via Convex
 		templateId && identityCommitment
-			? serverQuery(api.positions.getExisting, { templateId, identityCommitment })
+			? serverQuery(api.positions.getExisting, {
+					_secret: getInternalSecret(),
+					templateId,
+					identityCommitment
+				})
 					.catch(() => null)
 			: Promise.resolve(null),
 

--- a/src/routes/verify/[hash]/+page.server.ts
+++ b/src/routes/verify/[hash]/+page.server.ts
@@ -3,6 +3,7 @@ import type { PageServerLoad } from './$types';
 import { serverQuery } from 'convex-sveltekit';
 import { api } from '$lib/convex';
 import { formatTierDisplay } from '$lib/core/identity/tier-display';
+import { getInternalSecret } from '$lib/server/internal/secret-auth';
 
 /**
  * Privacy-preserving verification endpoint.
@@ -55,7 +56,10 @@ export const load: PageServerLoad = async ({ params }) => {
 		}
 
 		// Fall back to legacy credential hash verification
-		const credential = await serverQuery(api.verify.getCredentialByHash, { credentialHash: hash });
+		const credential = await serverQuery(api.verify.getCredentialByHash, {
+			credentialHash: hash,
+			_secret: getInternalSecret()
+		});
 
 		if (!credential) {
 			return { credential: null, delivery: null, error: 'Credential not found' };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
 		"strict": true,
 		"moduleResolution": "bundler",
 		"downlevelIteration": true,
+		"ignoreDeprecations": "6.0",
 		"target": "ES2020"
 	}
 	// Path aliases are handled by https://svelte.dev/docs/kit/configuration#alias


### PR DESCRIPTION
## What
The Convex data plane (quirky-chinchilla-352.convex.cloud) is directly reachable and bypasses SvelteKit auth. A pentest confirmed 10 live findings (mDL/identity oracle, raw-doc PII leak, k-anon-defeating writes, credential table scan, metric/waitlist oracles). A full classification of all **431 public functions** found **391 already safe** (the entire paid /api/v1 org surface was already secret-gated + org-scoped) and **40 exposed** — concentrated in the person layer, exactly where the pentest hit.

## Approach — default-deny with the repo's own patterns
Each of the 40 remediated at the Convex function layer; caller routes thread the secret in lockstep so anonymous UX flows keep working while direct Convex calls reject.
- **server-secret** (`requireInternalSecret`, existing `_internalAuth.ts`): 17 anonymous-but-sensitive fns (waitlist, positions, analytics, events, session validation…)
- **requireAuth** self/owner/member scope: 11 user-scoped fns (the mDL oracle → self only)
- **allowlist projection** (mirror `getBySlugPublic`): 3 leaky reads (templates list/search/getBySlug — denylist helpers deleted)
- **internalize**: 7 fns with zero public-api callers (mDL binder, cutover, …)
- **2 governance-adjacent**: org-less debate resolution (secret-gate), token backfill

## Commits (structured, one concern each)
1. `cd561f24` — the 10 confirmed findings
2. `3b0bf8f1` — the 39-function default-deny sweep
3. `285ea2a3` — integrated-review blocker (templates.search allowlist)
4. `1582b186` — org-less debate resolution bypass

## Verification
svelte-check 0 errors; change-scoped tests green at every wave; 3-lens integrated adversarial review (caught + fixed the search denylist leak). Every fix carries a code-level negative control (unauth call rejects; legit path works).

## Deploy note
Code-level only until `convex deploy`. Requires INTERNAL_API_SECRET set in Convex prod (gates) AND CF Pages prod (route threading) — deploy both together.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more secure access checks across event, campaign, debate, position, template, and waitlist flows.
  * Organization slug availability is now checked with a dedicated endpoint, improving signup and creation flows.

* **Bug Fixes**
  * Tightened access to several pages and API actions so only authorized requests can view or update sensitive data.
  * Improved template search and listing so only publicly visible templates appear in user-facing results.
  * Simplified some success responses for waitlist signup for more consistent handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->