### PR TITLE
Activate atlas v20260704 — resolver reads the fresh publish

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -16,8 +16,8 @@ pages_build_output_dir = ".svelte-kit/cloudflare"
 [vars]
 PUBLIC_CONVEX_URL = "https://quirky-chinchilla-352.convex.cloud"
 PUBLIC_SCROLL_RPC_URL = "https://rpc.scroll.io"
-ATLAS_BASE_URL = "https://atlas.commons.email/v20260418"
-VITE_ATLAS_BASE_URL = "https://atlas.commons.email/v20260418"
+ATLAS_BASE_URL = "https://atlas.commons.email/v20260704"
+VITE_ATLAS_BASE_URL = "https://atlas.commons.email/v20260704"
 # Cell-map trust pins (public values; paired with the atlas version above and
 # updated together at each publish — see docs/ops/LAUNCH-ACTIVATION-RUNBOOK.md).
 EXPECTED_CELL_MAP_ROOT = "0x14a6fc8eb8f8643bf420290e9d65059006b194ee335ab1cc1664838e5bc56cd3"


### PR DESCRIPTION
The quarterly build (attempt 8) published v20260704 to R2 with the three freshness clocks REAL for the first time since May:
- boundaryAsOf/generated: 2026-07-06 (TIGER2024)
- officialsGenerated: 2026-07-03 (complete 441-district coverage, vacant seats carry senators)
- addressIndexGenerated: 2026-07-06 (schemaVersion 2 shard contract; nadVintage null — honest DOT outage; 37,145 chunks)

Bumps ATLAS_BASE_URL/VITE_ATLAS_BASE_URL v20260418→v20260704 so the resolve API serves the fresh, signed build. Cell-map root/depth unchanged (identical TIGER2024 boundaries), so /api/health rootPinned/depthPinned stay green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app’s Atlas base URL configuration to use the latest service version in both public and client-facing settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->