### PR TITLE
feat(shadow-atlas): consume SEAM-CONTRACT v2 stub+shard split with fail-closed pins

### DIFF
--- a/src/lib/core/shadow-atlas/geocoder.ts
+++ b/src/lib/core/shadow-atlas/geocoder.ts
@@ -1,8 +1,9 @@
 /**
- * Atlas-native geocoder (SEAM-CONTRACT v1 — atlas-address-index).
+ * Atlas-native geocoder (SEAM-CONTRACT v2 — atlas-address-index).
  *
  * Resolves a structured US address to coordinates entirely from our own R2
- * artifacts: normalize the street line (§3), fetch the ZIP5 chunk (§1), then
+ * artifacts: normalize the street line (§3), fetch the ZIP5 chunk (§1 — a
+ * tiny stub + one shard fetch for oversized ZIPs, one fetch otherwise), then
  * run the deterministic match ladder (§2):
  *
  *   exact point → parity-matched range interpolation → ZIP centroid
@@ -363,7 +364,10 @@ export async function geocodeAddress(address: {
 
 	const normHash = await hashNormalizedInput(normalizedStreet, zip5);
 
-	const chunk = await getAddressChunk(zip5, country);
+	// normalizedStreet threads through for SEAM-CONTRACT v2 §1: it is only
+	// consulted when the fetched artifact is an oversized-ZIP stub, to pick
+	// the one shard file that street lives in.
+	const chunk = await getAddressChunk(zip5, country, normalizedStreet);
 	if (chunk === null) {
 		// Clean 404: the index has no chunk for this ZIP — an honest miss
 		// (MISS signal), categorically distinct from an infra fault.

--- a/src/lib/core/shadow-atlas/ipfs-store.ts
+++ b/src/lib/core/shadow-atlas/ipfs-store.ts
@@ -14,6 +14,8 @@
  * This module has NO server-only imports ($env/dynamic/private).
  */
 
+import { stableStreetShard } from './street-shard';
+
 // BN254 validation — inlined here to keep this module browser-safe.
 // client.ts imports $env/dynamic/private and cannot be imported from browser code.
 const BN254_MODULUS = 21888242871839275222246405745257275088548364400416034343698204186575808495617n;
@@ -289,6 +291,7 @@ export interface ChunkManifest {
 	addressIndexVersion?: number;
 	/** Address-index section (§4). Absent = index not yet published (fail-closed). */
 	addressIndex?: {
+		/** 1 = all chunks unsplit; 2 = §1 v2 split scheme may be present. Consumer accepts both. */
 		schemaVersion: number;
 		normVersion: number;
 		normTable: { path: string; sha256: string; bytes: number };
@@ -394,7 +397,7 @@ export interface DistrictIndex {
 }
 
 // ============================================================================
-// Address Index Types (SEAM-CONTRACT v1 — atlas-address-index)
+// Address Index Types (SEAM-CONTRACT v2 — atlas-address-index)
 // ============================================================================
 
 /**
@@ -422,7 +425,7 @@ export interface AddressStreetRecord {
 	r?: [number, number, 'E' | 'O' | 'B', number, number, number, number][];
 }
 
-/** ZIP5 address chunk published at `{country}/addresses/{zip5}.json` (§2). */
+/** ZIP5 address chunk published at `{country}/addresses/{zip5}.json` (§2, unsplit v1 shape). */
 export interface AddressChunkFile {
 	version: 1;
 	schema: 'atlas-address-index';
@@ -430,6 +433,40 @@ export interface AddressChunkFile {
 	zip: string;
 	state: string;
 	zipCentroid: [number, number];
+	streets: Record<string, AddressStreetRecord>;
+}
+
+/**
+ * §1 v2: tiny stub published at `{country}/addresses/{zip5}.json` in place of
+ * an oversized v1 chunk. `shards` streets subsets live in separate files at
+ * `{country}/addresses/{zip5}.{shard}.json` — see `stableStreetShard` in
+ * street-shard.ts (byte-identical to the producer's copy) for which shard a
+ * given normalized street lives in.
+ */
+export interface AddressChunkStubV2 {
+	v: 2;
+	schema: 'atlas-address-index';
+	country: string;
+	zip: string;
+	state: string;
+	zipCentroid: [number, number];
+	shards: number;
+	/**
+	 * Per-shard integrity pins, index-aligned with shard files 0..shards-1.
+	 * The runtime reader validates SHAPE fail-closed (exactly `shards` entries,
+	 * each a positive byte count + 64-hex sha256); byte-verification against
+	 * these pins happens in the §6 source-population gate, same posture as the
+	 * manifest's normTable/chunk pins.
+	 */
+	shardHashes: { bytes: number; sha256: string }[];
+}
+
+/** One shard file at `{country}/addresses/{zip5}.{shard}.json` (§1 v2). */
+export interface AddressChunkShardV2 {
+	v: 2;
+	zip: string;
+	shard: number;
+	shards: number;
 	streets: Record<string, AddressStreetRecord>;
 }
 
@@ -909,7 +946,7 @@ export async function getCellChunkByParent(
 }
 
 // ============================================================================
-// Address Index API (SEAM-CONTRACT v1 — normalize → ZIP5 chunk → match)
+// Address Index API (SEAM-CONTRACT v2 — normalize → ZIP5 stub/chunk → match)
 // ============================================================================
 
 /** Round-trip check for the contract's 5-decimal-place coordinate pin (§2). */
@@ -917,12 +954,18 @@ function isFiveDpNumber(v: unknown): v is number {
 	return typeof v === 'number' && Number.isFinite(v) && Math.round(v * 1e5) / 1e5 === v;
 }
 
+/** §1 v2 split scheme: addressIndex.schemaVersion values this consumer accepts. */
+const SUPPORTED_ADDRESS_INDEX_SCHEMA_VERSIONS = new Set([1, 2]);
+
 /**
  * Hard-assert the manifest's address-index seam version (§4). Fail-closed:
- * an absent addressIndex section, or any version other than 1, throws
+ * an absent addressIndex section, or an unrecognized version, throws
  * AddressIndexSchemaError — never a silent ZIP fallback, never treated as
  * a coverage miss. A 404 on the manifest itself means the atlas (and so the
  * index) is not published at this source: the same fail-closed path.
+ *
+ * `schemaVersion` accepts 1 (every chunk unsplit) AND 2 (the §1 v2 split
+ * scheme may be present) — both shapes are handled by getAddressChunk below.
  */
 async function assertAddressIndexPublished(
 	country: string,
@@ -950,9 +993,9 @@ async function assertAddressIndexPublished(
 			`Unsupported addressIndexVersion ${String(manifest.addressIndexVersion)} (expected 1)`,
 		);
 	}
-	if (section.schemaVersion !== 1) {
+	if (!SUPPORTED_ADDRESS_INDEX_SCHEMA_VERSIONS.has(section.schemaVersion)) {
 		throw new AddressIndexSchemaError(
-			`Unsupported addressIndex.schemaVersion ${String(section.schemaVersion)} (expected 1)`,
+			`Unsupported addressIndex.schemaVersion ${String(section.schemaVersion)} (expected 1 or 2)`,
 		);
 	}
 	if (section.normVersion !== 1) {
@@ -964,33 +1007,20 @@ async function assertAddressIndexPublished(
 }
 
 /**
- * Validate an address chunk against the §2 record shape. Fail-closed: any
- * violation is an AddressIndexSchemaError (producer bug / wrong artifact),
- * never a silent fallback. Runs once per fetch (cache hits skip it).
+ * Validate a `streets` map against the §2 record shape, shared by the v1
+ * unsplit chunk and every v2 shard file. Fail-closed: any violation is an
+ * AddressIndexSchemaError (producer bug / wrong artifact), never a silent
+ * fallback.
  */
-function validateAddressChunk(chunk: AddressChunkFile, zip5: string): void {
-	if (chunk.version !== 1 || chunk.schema !== 'atlas-address-index') {
-		throw new AddressIndexSchemaError(
-			`Address chunk ${zip5} schema mismatch: version=${String(chunk.version)} schema=${String(chunk.schema)}`,
-		);
+function validateStreetsMap(
+	streets: unknown,
+	zip5: string,
+	label: string,
+): asserts streets is Record<string, AddressStreetRecord> {
+	if (typeof streets !== 'object' || streets === null || Array.isArray(streets)) {
+		throw new AddressIndexSchemaError(`Address ${label} ${zip5} has an invalid streets map`);
 	}
-	if (chunk.zip !== zip5) {
-		throw new AddressIndexSchemaError(
-			`Address chunk key mismatch: requested ${zip5}, chunk says ${String(chunk.zip)}`,
-		);
-	}
-	if (
-		!Array.isArray(chunk.zipCentroid) ||
-		chunk.zipCentroid.length !== 2 ||
-		!isFiveDpNumber(chunk.zipCentroid[0]) ||
-		!isFiveDpNumber(chunk.zipCentroid[1])
-	) {
-		throw new AddressIndexSchemaError(`Address chunk ${zip5} has an invalid zipCentroid`);
-	}
-	if (typeof chunk.streets !== 'object' || chunk.streets === null || Array.isArray(chunk.streets)) {
-		throw new AddressIndexSchemaError(`Address chunk ${zip5} has an invalid streets map`);
-	}
-	for (const [street, rec] of Object.entries(chunk.streets)) {
+	for (const [street, rec] of Object.entries(streets as Record<string, AddressStreetRecord>)) {
 		if (rec.p !== undefined) {
 			for (const [hn, point] of Object.entries(rec.p)) {
 				if (
@@ -1001,7 +1031,7 @@ function validateAddressChunk(chunk: AddressChunkFile, zip5: string): void {
 					(point[2] !== 0 && point[2] !== 1)
 				) {
 					throw new AddressIndexSchemaError(
-						`Address chunk ${zip5} street "${street}" point "${hn}" violates §2`,
+						`Address ${label} ${zip5} street "${street}" point "${hn}" violates §2`,
 					);
 				}
 			}
@@ -1022,12 +1052,179 @@ function validateAddressChunk(chunk: AddressChunkFile, zip5: string): void {
 					!isFiveDpNumber(toLng)
 				) {
 					throw new AddressIndexSchemaError(
-						`Address chunk ${zip5} street "${street}" range violates §2`,
+						`Address ${label} ${zip5} street "${street}" range violates §2`,
 					);
 				}
 			}
 		}
 	}
+}
+
+/**
+ * Validate an unsplit v1 address chunk against the §2 record shape.
+ * Fail-closed: any violation is an AddressIndexSchemaError (producer bug /
+ * wrong artifact), never a silent fallback. Runs once per fetch (cache hits
+ * skip it).
+ */
+function validateAddressChunk(chunk: AddressChunkFile, zip5: string): void {
+	if (chunk.version !== 1 || chunk.schema !== 'atlas-address-index') {
+		throw new AddressIndexSchemaError(
+			`Address chunk ${zip5} schema mismatch: version=${String(chunk.version)} schema=${String(chunk.schema)}`,
+		);
+	}
+	if (chunk.zip !== zip5) {
+		throw new AddressIndexSchemaError(
+			`Address chunk key mismatch: requested ${zip5}, chunk says ${String(chunk.zip)}`,
+		);
+	}
+	if (
+		!Array.isArray(chunk.zipCentroid) ||
+		chunk.zipCentroid.length !== 2 ||
+		!isFiveDpNumber(chunk.zipCentroid[0]) ||
+		!isFiveDpNumber(chunk.zipCentroid[1])
+	) {
+		throw new AddressIndexSchemaError(`Address chunk ${zip5} has an invalid zipCentroid`);
+	}
+	validateStreetsMap(chunk.streets, zip5, 'chunk');
+}
+
+/**
+ * Validate a §1 v2 stub (`{v:2, shards:N, ...}`, no `streets`). Fail-closed:
+ * any violation is an AddressIndexSchemaError.
+ */
+function validateAddressChunkStubV2(stub: AddressChunkStubV2, zip5: string): void {
+	if (stub.v !== 2 || stub.schema !== 'atlas-address-index') {
+		throw new AddressIndexSchemaError(
+			`Address chunk stub ${zip5} schema mismatch: v=${String(stub.v)} schema=${String(stub.schema)}`,
+		);
+	}
+	if (stub.zip !== zip5) {
+		throw new AddressIndexSchemaError(
+			`Address chunk stub key mismatch: requested ${zip5}, stub says ${String(stub.zip)}`,
+		);
+	}
+	if (
+		!Array.isArray(stub.zipCentroid) ||
+		stub.zipCentroid.length !== 2 ||
+		!isFiveDpNumber(stub.zipCentroid[0]) ||
+		!isFiveDpNumber(stub.zipCentroid[1])
+	) {
+		throw new AddressIndexSchemaError(`Address chunk stub ${zip5} has an invalid zipCentroid`);
+	}
+	if (!Number.isInteger(stub.shards) || stub.shards < 1) {
+		throw new AddressIndexSchemaError(
+			`Address chunk stub ${zip5} has an invalid shards count: ${String(stub.shards)}`,
+		);
+	}
+	if (!Array.isArray(stub.shardHashes) || stub.shardHashes.length !== stub.shards) {
+		throw new AddressIndexSchemaError(
+			`Address chunk stub ${zip5} must pin exactly ${String(stub.shards)} shards in shardHashes, got ${
+				Array.isArray(stub.shardHashes) ? String(stub.shardHashes.length) : typeof stub.shardHashes
+			}`,
+		);
+	}
+	for (const [i, pin] of stub.shardHashes.entries()) {
+		if (
+			pin === null ||
+			typeof pin !== 'object' ||
+			!Number.isInteger(pin.bytes) ||
+			pin.bytes < 1 ||
+			typeof pin.sha256 !== 'string' ||
+			!/^[0-9a-f]{64}$/.test(pin.sha256)
+		) {
+			throw new AddressIndexSchemaError(
+				`Address chunk stub ${zip5} shardHashes[${i}] is malformed: need a positive bytes count and a 64-hex sha256`,
+			);
+		}
+	}
+}
+
+/** Validate a §1 v2 shard file against the shard the stub said to fetch. */
+function validateAddressChunkShardV2(
+	shard: AddressChunkShardV2,
+	zip5: string,
+	expectedShardIdx: number,
+	expectedShards: number,
+): void {
+	if (shard.v !== 2 || shard.zip !== zip5) {
+		throw new AddressIndexSchemaError(
+			`Address chunk shard ${zip5}.${expectedShardIdx} schema mismatch: v=${String(shard.v)} zip=${String(shard.zip)}`,
+		);
+	}
+	if (shard.shard !== expectedShardIdx || shard.shards !== expectedShards) {
+		throw new AddressIndexSchemaError(
+			`Address chunk shard ${zip5}.${expectedShardIdx} index mismatch: shard=${String(shard.shard)} shards=${String(shard.shards)} (expected ${expectedShardIdx}/${expectedShards})`,
+		);
+	}
+	validateStreetsMap(shard.streets, zip5, `shard ${expectedShardIdx}`);
+}
+
+/** §1 v2 stubs: tiny (~100 B each), max 200 = ~20 KB/isolate. */
+const addressChunkStubCache = new LRUCache<AddressChunkStubV2>(200, CACHE_TTL_MS);
+
+/** §1 v2 shard files: ~same size budget as the p95 chunk target, max 100 = ~25 MB/isolate. */
+const addressChunkShardCache = new LRUCache<AddressChunkShardV2>(100, CACHE_TTL_MS);
+
+/** Fetch + validate the stub OR unsplit chunk at `{country}/addresses/{zip5}.json`, using its own cache. */
+async function fetchAddressChunkOrStub(
+	safeCountry: string,
+	zip5: string,
+): Promise<{ kind: 'chunk'; chunk: AddressChunkFile } | { kind: 'stub'; stub: AddressChunkStubV2 } | null> {
+	const chunkCacheKey = `addr:${safeCountry}/${zip5}`;
+	const cachedChunk = addressChunkCache.get(chunkCacheKey);
+	if (cachedChunk) return { kind: 'chunk', chunk: cachedChunk };
+
+	const stubCacheKey = `addr-stub:${safeCountry}/${zip5}`;
+	const cachedStub = addressChunkStubCache.get(stubCacheKey);
+	if (cachedStub) return { kind: 'stub', stub: cachedStub };
+
+	let body: AddressChunkFile | AddressChunkStubV2;
+	try {
+		body = await fetchContent<AddressChunkFile | AddressChunkStubV2>(
+			`${safeCountry}/addresses/${zip5}.json`,
+		);
+	} catch (err) {
+		if (err instanceof ContentNotFoundError) return null;
+		throw err;
+	}
+
+	if ((body as AddressChunkStubV2).v === 2) {
+		const stub = body as AddressChunkStubV2;
+		validateAddressChunkStubV2(stub, zip5);
+		addressChunkStubCache.set(stubCacheKey, stub);
+		return { kind: 'stub', stub };
+	}
+	const chunk = body as AddressChunkFile;
+	validateAddressChunk(chunk, zip5);
+	addressChunkCache.set(chunkCacheKey, chunk);
+	return { kind: 'chunk', chunk };
+}
+
+/** Fetch + validate one §1 v2 shard file, using its own cache. */
+async function fetchAddressChunkShard(
+	safeCountry: string,
+	zip5: string,
+	shardIdx: number,
+	shards: number,
+): Promise<AddressChunkShardV2> {
+	const shardCacheKey = `addr-shard:${safeCountry}/${zip5}/${shardIdx}`;
+	const cached = addressChunkShardCache.get(shardCacheKey);
+	if (cached) return cached;
+
+	let shard: AddressChunkShardV2;
+	try {
+		shard = await fetchContent<AddressChunkShardV2>(`${safeCountry}/addresses/${zip5}.${shardIdx}.json`);
+	} catch (err) {
+		if (err instanceof ContentNotFoundError) {
+			throw new AddressIndexSchemaError(
+				`Address chunk stub ${zip5} names ${shards} shards but shard ${shardIdx} is missing`,
+			);
+		}
+		throw err;
+	}
+	validateAddressChunkShardV2(shard, zip5, shardIdx, shards);
+	addressChunkShardCache.set(shardCacheKey, shard);
+	return shard;
 }
 
 /**
@@ -1039,10 +1236,20 @@ function validateAddressChunk(chunk: AddressChunkFile, zip5: string): void {
  *   AddressIndexSchemaError.
  * - Network/5xx/timeout → generic Error, exactly as existing chunk fetches;
  *   callers classify those as infrastructure faults, never as misses.
+ *
+ * §1 v2 split: when the fetched artifact is a stub (`v:2`), `normalizedStreet`
+ * picks which shard to fetch via `stableStreetShard` — the SAME hash the
+ * producer used to assign that street at emit time. This is the only extra
+ * fetch the split scheme costs, and only for oversized ZIPs: an unsplit v1
+ * chunk still resolves in one fetch (its own cache entry, never touching the
+ * stub/shard caches). The returned shape is always the v1 `AddressChunkFile`
+ * shape regardless of which path served it — `runMatchLadder` in geocoder.ts
+ * needs no v2 awareness at all.
  */
 export async function getAddressChunk(
 	zip5: string,
 	country = 'US',
+	normalizedStreet = '',
 ): Promise<AddressChunkFile | null> {
 	if (!/^\d{5}$/.test(zip5)) {
 		throw new Error(`Address chunk key must be a 5-digit ZIP, got "${String(zip5).slice(0, 20)}"`);
@@ -1051,21 +1258,23 @@ export async function getAddressChunk(
 
 	await assertAddressIndexPublished(safeCountry);
 
-	const cacheKey = `addr:${safeCountry}/${zip5}`;
-	const cached = addressChunkCache.get(cacheKey);
-	if (cached) return cached;
+	const result = await fetchAddressChunkOrStub(safeCountry, zip5);
+	if (result === null) return null;
+	if (result.kind === 'chunk') return result.chunk;
 
-	let chunk: AddressChunkFile;
-	try {
-		chunk = await fetchContent<AddressChunkFile>(`${safeCountry}/addresses/${zip5}.json`);
-	} catch (err) {
-		if (err instanceof ContentNotFoundError) return null;
-		throw err;
-	}
+	const { stub } = result;
+	const shardIdx = stableStreetShard(normalizedStreet, stub.shards);
+	const shard = await fetchAddressChunkShard(safeCountry, zip5, shardIdx, stub.shards);
 
-	validateAddressChunk(chunk, zip5);
-	addressChunkCache.set(cacheKey, chunk);
-	return chunk;
+	return {
+		version: 1,
+		schema: 'atlas-address-index',
+		country: stub.country,
+		zip: stub.zip,
+		state: stub.state,
+		zipCentroid: stub.zipCentroid,
+		streets: shard.streets,
+	};
 }
 
 /**
@@ -1136,6 +1345,8 @@ export async function clearCache(): Promise<void> {
 	cellChunkCache.clear();
 	districtIndexCache.clear();
 	addressChunkCache.clear();
+	addressChunkStubCache.clear();
+	addressChunkShardCache.clear();
 	normalizationTableCache.clear();
 	manifestCacheMap.clear();
 }

--- a/src/lib/core/shadow-atlas/ipfs-store.ts
+++ b/src/lib/core/shadow-atlas/ipfs-store.ts
@@ -1263,6 +1263,24 @@ export async function getAddressChunk(
 	if (result.kind === 'chunk') return result.chunk;
 
 	const { stub } = result;
+
+	// No street key → no shard can be the right one. Return the chunk shape
+	// with an EMPTY street map instead of hashing '' into an arbitrary shard:
+	// the ZIP-centroid path needs only zipCentroid, and a legacy caller that
+	// omits normalizedStreet gets an honestly-empty map rather than one
+	// shard's partial streets masquerading as the whole ZIP.
+	if (normalizedStreet === '') {
+		return {
+			version: 1,
+			schema: 'atlas-address-index',
+			country: stub.country,
+			zip: stub.zip,
+			state: stub.state,
+			zipCentroid: stub.zipCentroid,
+			streets: {},
+		};
+	}
+
 	const shardIdx = stableStreetShard(normalizedStreet, stub.shards);
 	const shard = await fetchAddressChunkShard(safeCountry, zip5, shardIdx, stub.shards);
 

--- a/src/lib/core/shadow-atlas/shared-vectors/stable-street-shard.vectors.json
+++ b/src/lib/core/shadow-atlas/shared-vectors/stable-street-shard.vectors.json
@@ -375,6 +375,106 @@
       "streetKey": "WASHINGTON ST",
       "shards": 32,
       "shard": 6
+    },
+    {
+      "streetKey": "ŁÓDŹ ST",
+      "shards": 2,
+      "shard": 1
+    },
+    {
+      "streetKey": "ŁÓDŹ ST",
+      "shards": 4,
+      "shard": 1
+    },
+    {
+      "streetKey": "ŁÓDŹ ST",
+      "shards": 8,
+      "shard": 5
+    },
+    {
+      "streetKey": "ŁÓDŹ ST",
+      "shards": 16,
+      "shard": 5
+    },
+    {
+      "streetKey": "ØSTER AVE",
+      "shards": 2,
+      "shard": 1
+    },
+    {
+      "streetKey": "ØSTER AVE",
+      "shards": 4,
+      "shard": 1
+    },
+    {
+      "streetKey": "ØSTER AVE",
+      "shards": 8,
+      "shard": 1
+    },
+    {
+      "streetKey": "ØSTER AVE",
+      "shards": 16,
+      "shard": 9
+    },
+    {
+      "streetKey": "STRAßE WEG",
+      "shards": 2,
+      "shard": 0
+    },
+    {
+      "streetKey": "STRAßE WEG",
+      "shards": 4,
+      "shard": 2
+    },
+    {
+      "streetKey": "STRAßE WEG",
+      "shards": 8,
+      "shard": 6
+    },
+    {
+      "streetKey": "STRAßE WEG",
+      "shards": 16,
+      "shard": 14
+    },
+    {
+      "streetKey": "CAFÉ BLVD",
+      "shards": 2,
+      "shard": 0
+    },
+    {
+      "streetKey": "CAFÉ BLVD",
+      "shards": 4,
+      "shard": 0
+    },
+    {
+      "streetKey": "CAFÉ BLVD",
+      "shards": 8,
+      "shard": 0
+    },
+    {
+      "streetKey": "CAFÉ BLVD",
+      "shards": 16,
+      "shard": 0
+    },
+    {
+      "streetKey": "ÑU LN",
+      "shards": 2,
+      "shard": 1
+    },
+    {
+      "streetKey": "ÑU LN",
+      "shards": 4,
+      "shard": 3
+    },
+    {
+      "streetKey": "ÑU LN",
+      "shards": 8,
+      "shard": 3
+    },
+    {
+      "streetKey": "ÑU LN",
+      "shards": 16,
+      "shard": 11
     }
   ]
 }

--- a/src/lib/core/shadow-atlas/shared-vectors/stable-street-shard.vectors.json
+++ b/src/lib/core/shadow-atlas/shared-vectors/stable-street-shard.vectors.json
@@ -1,0 +1,380 @@
+{
+  "hashAlgorithm": "fnv1a32",
+  "vectors": [
+    {
+      "streetKey": "MAIN ST",
+      "shards": 2,
+      "shard": 1
+    },
+    {
+      "streetKey": "MAIN ST",
+      "shards": 4,
+      "shard": 3
+    },
+    {
+      "streetKey": "MAIN ST",
+      "shards": 8,
+      "shard": 7
+    },
+    {
+      "streetKey": "MAIN ST",
+      "shards": 16,
+      "shard": 15
+    },
+    {
+      "streetKey": "MAIN ST",
+      "shards": 32,
+      "shard": 31
+    },
+    {
+      "streetKey": "MISSION ST",
+      "shards": 2,
+      "shard": 0
+    },
+    {
+      "streetKey": "MISSION ST",
+      "shards": 4,
+      "shard": 0
+    },
+    {
+      "streetKey": "MISSION ST",
+      "shards": 8,
+      "shard": 4
+    },
+    {
+      "streetKey": "MISSION ST",
+      "shards": 16,
+      "shard": 4
+    },
+    {
+      "streetKey": "MISSION ST",
+      "shards": 32,
+      "shard": 4
+    },
+    {
+      "streetKey": "VALENCIA ST",
+      "shards": 2,
+      "shard": 1
+    },
+    {
+      "streetKey": "VALENCIA ST",
+      "shards": 4,
+      "shard": 1
+    },
+    {
+      "streetKey": "VALENCIA ST",
+      "shards": 8,
+      "shard": 1
+    },
+    {
+      "streetKey": "VALENCIA ST",
+      "shards": 16,
+      "shard": 1
+    },
+    {
+      "streetKey": "VALENCIA ST",
+      "shards": 32,
+      "shard": 1
+    },
+    {
+      "streetKey": "PRECITA AVE",
+      "shards": 2,
+      "shard": 1
+    },
+    {
+      "streetKey": "PRECITA AVE",
+      "shards": 4,
+      "shard": 3
+    },
+    {
+      "streetKey": "PRECITA AVE",
+      "shards": 8,
+      "shard": 7
+    },
+    {
+      "streetKey": "PRECITA AVE",
+      "shards": 16,
+      "shard": 7
+    },
+    {
+      "streetKey": "PRECITA AVE",
+      "shards": 32,
+      "shard": 23
+    },
+    {
+      "streetKey": "PENNSYLVANIA AVE NW",
+      "shards": 2,
+      "shard": 0
+    },
+    {
+      "streetKey": "PENNSYLVANIA AVE NW",
+      "shards": 4,
+      "shard": 2
+    },
+    {
+      "streetKey": "PENNSYLVANIA AVE NW",
+      "shards": 8,
+      "shard": 2
+    },
+    {
+      "streetKey": "PENNSYLVANIA AVE NW",
+      "shards": 16,
+      "shard": 2
+    },
+    {
+      "streetKey": "PENNSYLVANIA AVE NW",
+      "shards": 32,
+      "shard": 2
+    },
+    {
+      "streetKey": "",
+      "shards": 2,
+      "shard": 1
+    },
+    {
+      "streetKey": "",
+      "shards": 4,
+      "shard": 1
+    },
+    {
+      "streetKey": "",
+      "shards": 8,
+      "shard": 5
+    },
+    {
+      "streetKey": "",
+      "shards": 16,
+      "shard": 5
+    },
+    {
+      "streetKey": "",
+      "shards": 32,
+      "shard": 5
+    },
+    {
+      "streetKey": "A",
+      "shards": 2,
+      "shard": 0
+    },
+    {
+      "streetKey": "A",
+      "shards": 4,
+      "shard": 0
+    },
+    {
+      "streetKey": "A",
+      "shards": 8,
+      "shard": 4
+    },
+    {
+      "streetKey": "A",
+      "shards": 16,
+      "shard": 12
+    },
+    {
+      "streetKey": "A",
+      "shards": 32,
+      "shard": 12
+    },
+    {
+      "streetKey": "BROADWAY",
+      "shards": 2,
+      "shard": 0
+    },
+    {
+      "streetKey": "BROADWAY",
+      "shards": 4,
+      "shard": 2
+    },
+    {
+      "streetKey": "BROADWAY",
+      "shards": 8,
+      "shard": 2
+    },
+    {
+      "streetKey": "BROADWAY",
+      "shards": 16,
+      "shard": 2
+    },
+    {
+      "streetKey": "BROADWAY",
+      "shards": 32,
+      "shard": 18
+    },
+    {
+      "streetKey": "MARKET ST",
+      "shards": 2,
+      "shard": 0
+    },
+    {
+      "streetKey": "MARKET ST",
+      "shards": 4,
+      "shard": 0
+    },
+    {
+      "streetKey": "MARKET ST",
+      "shards": 8,
+      "shard": 4
+    },
+    {
+      "streetKey": "MARKET ST",
+      "shards": 16,
+      "shard": 12
+    },
+    {
+      "streetKey": "MARKET ST",
+      "shards": 32,
+      "shard": 12
+    },
+    {
+      "streetKey": "5TH AVE",
+      "shards": 2,
+      "shard": 0
+    },
+    {
+      "streetKey": "5TH AVE",
+      "shards": 4,
+      "shard": 2
+    },
+    {
+      "streetKey": "5TH AVE",
+      "shards": 8,
+      "shard": 2
+    },
+    {
+      "streetKey": "5TH AVE",
+      "shards": 16,
+      "shard": 10
+    },
+    {
+      "streetKey": "5TH AVE",
+      "shards": 32,
+      "shard": 10
+    },
+    {
+      "streetKey": "MLK BLVD",
+      "shards": 2,
+      "shard": 1
+    },
+    {
+      "streetKey": "MLK BLVD",
+      "shards": 4,
+      "shard": 3
+    },
+    {
+      "streetKey": "MLK BLVD",
+      "shards": 8,
+      "shard": 3
+    },
+    {
+      "streetKey": "MLK BLVD",
+      "shards": 16,
+      "shard": 3
+    },
+    {
+      "streetKey": "MLK BLVD",
+      "shards": 32,
+      "shard": 3
+    },
+    {
+      "streetKey": "OAK ST",
+      "shards": 2,
+      "shard": 1
+    },
+    {
+      "streetKey": "OAK ST",
+      "shards": 4,
+      "shard": 1
+    },
+    {
+      "streetKey": "OAK ST",
+      "shards": 8,
+      "shard": 1
+    },
+    {
+      "streetKey": "OAK ST",
+      "shards": 16,
+      "shard": 1
+    },
+    {
+      "streetKey": "OAK ST",
+      "shards": 32,
+      "shard": 17
+    },
+    {
+      "streetKey": "ELM ST",
+      "shards": 2,
+      "shard": 0
+    },
+    {
+      "streetKey": "ELM ST",
+      "shards": 4,
+      "shard": 2
+    },
+    {
+      "streetKey": "ELM ST",
+      "shards": 8,
+      "shard": 6
+    },
+    {
+      "streetKey": "ELM ST",
+      "shards": 16,
+      "shard": 6
+    },
+    {
+      "streetKey": "ELM ST",
+      "shards": 32,
+      "shard": 22
+    },
+    {
+      "streetKey": "PARK PL",
+      "shards": 2,
+      "shard": 1
+    },
+    {
+      "streetKey": "PARK PL",
+      "shards": 4,
+      "shard": 3
+    },
+    {
+      "streetKey": "PARK PL",
+      "shards": 8,
+      "shard": 7
+    },
+    {
+      "streetKey": "PARK PL",
+      "shards": 16,
+      "shard": 7
+    },
+    {
+      "streetKey": "PARK PL",
+      "shards": 32,
+      "shard": 7
+    },
+    {
+      "streetKey": "WASHINGTON ST",
+      "shards": 2,
+      "shard": 0
+    },
+    {
+      "streetKey": "WASHINGTON ST",
+      "shards": 4,
+      "shard": 2
+    },
+    {
+      "streetKey": "WASHINGTON ST",
+      "shards": 8,
+      "shard": 6
+    },
+    {
+      "streetKey": "WASHINGTON ST",
+      "shards": 16,
+      "shard": 6
+    },
+    {
+      "streetKey": "WASHINGTON ST",
+      "shards": 32,
+      "shard": 6
+    }
+  ]
+}

--- a/src/lib/core/shadow-atlas/street-shard.ts
+++ b/src/lib/core/shadow-atlas/street-shard.ts
@@ -1,0 +1,59 @@
+/**
+ * Deterministic street→shard hash — SEAM-CONTRACT v2 §1.
+ *
+ * Oversized ZIP5 chunks (serialized bytes > CHUNK_P95_LIMIT_BYTES) are split
+ * into N shard files. Both the producer (this file, assigning each street to
+ * a shard at emit time) and the consumer (the identical copy of this file,
+ * computing which shard to fetch at resolve time) must land on the SAME
+ * shard index for the SAME normalized street key — the split is invisible to
+ * correctness only if the hash is byte-identical on both sides of the seam.
+ *
+ * Algorithm: FNV-1a, 32-bit, over the (already §3 normalized) street key's
+ * UTF-16 code units — see fnv1a32 below for why that coincides with UTF-8
+ * bytes for every real input here. Chosen over a cryptographic hash (sha256,
+ * already used elsewhere in this contract for content-addressing) because
+ * this function runs in the hot path on BOTH sides: once per street during
+ * producer chunk assembly (potentially millions of streets in a national
+ * build) and once per resolve in a Cloudflare Worker on the consumer side,
+ * where an extra async WebCrypto digest per address lookup is pure latency
+ * with no security property to buy — the shard index is a load-balancing
+ * seam, not a commitment. FNV-1a is synchronous, allocation-free, and trivial
+ * to keep bit-for-bit identical in plain TypeScript on both sides (32-bit
+ * unsigned arithmetic only, no platform crypto primitives to drift).
+ *
+ * Test vectors: `shared-vectors/stable-street-shard.vectors.json` is
+ * generated once and committed BYTE-IDENTICAL in both repos (voter-protocol
+ * and commons); each side's tests assert this module's output against that
+ * file, so any accidental edit to the algorithm on either side fails loudly
+ * as a vector mismatch instead of silently routing resolves to the wrong
+ * shard file.
+ */
+
+/**
+ * FNV-1a 32-bit hash of a UTF-16 string, taken code-unit-by-code-unit (NOT
+ * UTF-8 byte-by-byte). Normalized street keys are pure ASCII by construction
+ * (§3 step 1 uppercases and strips combining marks), so UTF-16 code units and
+ * UTF-8 bytes coincide for every real input — this is a plain, dependency-free
+ * 32-bit computation identical on both sides regardless of JS engine.
+ */
+export function fnv1a32(input: string): number {
+  let hash = 0x811c9dc5; // FNV offset basis (32-bit)
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193); // FNV prime (32-bit)
+  }
+  return hash >>> 0; // unsigned 32-bit
+}
+
+/**
+ * Deterministic shard assignment for one normalized street key. `shards`
+ * must be a positive integer (the emitted stub's `shards` field); callers on
+ * both sides pass the SAME `shards` value that the stub published.
+ */
+export function stableStreetShard(normalizedStreetKey: string, shards: number): number {
+  if (!Number.isInteger(shards) || shards < 1) {
+    throw new Error(`stableStreetShard: shards must be a positive integer, got ${String(shards)}`);
+  }
+  if (shards === 1) return 0;
+  return fnv1a32(normalizedStreetKey) % shards;
+}

--- a/src/lib/core/shadow-atlas/street-shard.ts
+++ b/src/lib/core/shadow-atlas/street-shard.ts
@@ -31,10 +31,13 @@
 
 /**
  * FNV-1a 32-bit hash of a UTF-16 string, taken code-unit-by-code-unit (NOT
- * UTF-8 byte-by-byte). Normalized street keys are pure ASCII by construction
- * (§3 step 1 uppercases and strips combining marks), so UTF-16 code units and
- * UTF-8 bytes coincide for every real input — this is a plain, dependency-free
- * 32-bit computation identical on both sides regardless of JS engine.
+ * UTF-8 byte-by-byte). The cross-repo invariant is NOT "inputs are ASCII"
+ * (§3 normalization strips combining marks but keeps non-decomposing
+ * letters like Ł or Ø): it is that BOTH sides run this exact code-unit
+ * computation — identical for every string, ASCII or not, on any JS engine
+ * (Math.imul is exact 32-bit). The shared vectors file pins this with
+ * non-ASCII cases; a reimplementation over UTF-8 bytes fails those vectors
+ * loudly instead of silently routing resolves to the wrong shard.
  */
 export function fnv1a32(input: string): number {
   let hash = 0x811c9dc5; // FNV offset basis (32-bit)

--- a/tests/integration/shadow-atlas/geocoder-sample-gate.test.ts
+++ b/tests/integration/shadow-atlas/geocoder-sample-gate.test.ts
@@ -128,6 +128,12 @@ gate('§6 source-population gate — real producer sample artifact', () => {
 			for (const zip5 of Object.keys(chunkIndex)) {
 				// getAddressChunk hard-validates §2 (shape, 5-dp coords,
 				// fromHn ≤ toHn, parity enum, src enum) and throws on violation.
+				// NOTE (§1 v2): a call with no normalizedStreet only fetches the
+				// ONE shard '' hashes into for a SPLIT ZIP, so the streetCount
+				// equality below assumes every chunk in this sample is unsplit —
+				// true for the small DE/RI/DC sample this gate targets, but not a
+				// general invariant once a national build's split ZIPs are
+				// published under this gate's BASE.
 				const chunk = await getAddressChunk(zip5, 'US');
 				expect(chunk, `chunk ${zip5} missing despite chunk-index entry`).not.toBeNull();
 				expect(chunk!.zip).toBe(zip5);
@@ -146,6 +152,29 @@ gate('§6 source-population gate — real producer sample artifact', () => {
 				const bytes = await res.arrayBuffer();
 				expect(bytes.byteLength, `chunk ${zip5} byte length`).toBe(entry.bytes);
 				expect(await sha256Hex(bytes), `chunk ${zip5} sha256`).toBe(entry.sha256);
+
+				// §1 v2: for a SPLIT ZIP the index entry above pins the stub;
+				// each shard file must byte-match the stub's own shardHashes pins.
+				const body = JSON.parse(new TextDecoder().decode(bytes)) as {
+					v?: number;
+					shards?: number;
+					shardHashes?: { bytes: number; sha256: string }[];
+				};
+				if (body.v === 2) {
+					expect(
+						body.shardHashes?.length,
+						`stub ${zip5} shardHashes count`,
+					).toBe(body.shards);
+					for (const [idx, pin] of (body.shardHashes ?? []).entries()) {
+						const shardRes = await fetch(`${BASE}/US/addresses/${zip5}.${idx}.json`);
+						expect(shardRes.ok, `raw fetch of shard ${zip5}.${idx} failed (${shardRes.status})`).toBe(
+							true,
+						);
+						const shardBytes = await shardRes.arrayBuffer();
+						expect(shardBytes.byteLength, `shard ${zip5}.${idx} byte length`).toBe(pin.bytes);
+						expect(await sha256Hex(shardBytes), `shard ${zip5}.${idx} sha256`).toBe(pin.sha256);
+					}
+				}
 			}
 
 			const normRes = await fetch(`${BASE}/US/${addressIndex.normTable.path}`);

--- a/tests/unit/shadow-atlas/address-chunk-split.test.ts
+++ b/tests/unit/shadow-atlas/address-chunk-split.test.ts
@@ -18,6 +18,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
 	configure,
 	clearCache,
+	getAddressChunk,
 	AddressIndexSchemaError,
 	type NormalizationTable,
 } from '$lib/core/shadow-atlas/ipfs-store';
@@ -230,6 +231,19 @@ describe('oversized ZIP5 split (§1 v2) — consumer resolution', () => {
 		).rejects.toBeInstanceOf(AddressIndexSchemaError);
 		// A schema fault is never counted as a match-outcome miss.
 		expect(events).toEqual([]);
+	});
+
+	it('no street key on a split ZIP → empty street map, ZERO shard fetches (never an arbitrary shard)', async () => {
+		mockFetchRoutes(splitRoutes());
+		// Legacy 2-arg call form: a caller with no street must NOT receive one
+		// arbitrary shard's partial streets masquerading as the whole ZIP.
+		const chunk = await getAddressChunk('94999', 'US');
+		expect(chunk).not.toBeNull();
+		expect(chunk!.zip).toBe('94999');
+		expect(chunk!.zipCentroid).toEqual(STUB_94999.zipCentroid);
+		expect(chunk!.streets).toEqual({});
+		const calls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.map((c) => String(c[0]));
+		expect(calls.filter((u) => /94999\.\d+\.json$/.test(u))).toEqual([]);
 	});
 
 	it('a stub with NO shardHashes fails closed — unpinned shards are never fetched', async () => {

--- a/tests/unit/shadow-atlas/address-chunk-split.test.ts
+++ b/tests/unit/shadow-atlas/address-chunk-split.test.ts
@@ -1,0 +1,298 @@
+/**
+ * SEAM-CONTRACT v2 §1 — oversized-ZIP5 stub+shard split, consumer side.
+ *
+ * Exercises the REAL fetch path (ipfs-store fetchContent) against a mocked
+ * globalThis.fetch serving a stub + shard files, asserting:
+ *   - a v2 stub triggers exactly one extra fetch (the shard the requested
+ *     street hashes into via stableStreetShard) — never more than 2 fetches
+ *     total for the address chunk
+ *   - the shard the geocoder actually reads matches the shared
+ *     stableStreetShard vectors (committed byte-identical to voter-protocol)
+ *   - an unsplit v1 chunk still resolves in exactly 1 fetch (no regression)
+ *   - schemaVersion 1 and 2 both resolve; an unrecognized version fails closed
+ *   - a missing shard (stub says N shards, shard file 404s) fails closed as
+ *     AddressIndexSchemaError, never silently falls back
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+	configure,
+	clearCache,
+	AddressIndexSchemaError,
+	type NormalizationTable,
+} from '$lib/core/shadow-atlas/ipfs-store';
+import { geocodeAddress, setMatchOutcomeSink, type MatchOutcomeEvent } from '$lib/core/shadow-atlas/geocoder';
+import { stableStreetShard } from '$lib/core/shadow-atlas/street-shard';
+import sharedVectors from '$lib/core/shadow-atlas/shared-vectors/stable-street-shard.vectors.json';
+
+const BASE = 'https://atlas.test';
+const originalFetch = globalThis.fetch;
+
+const NORM_TABLE: NormalizationTable = {
+	normVersion: 1,
+	directionals: {},
+	suffixes: { STREET: 'ST', ST: 'ST', AVENUE: 'AVE', AVE: 'AVE' },
+	units: [],
+	unitsWithoutValue: [],
+};
+
+function manifestWithSchemaVersion(schemaVersion: number) {
+	return {
+		version: 1,
+		generated: '2026-07-01T00:00:00.000Z',
+		country: 'US',
+		addressIndexGenerated: '2026-07-02T00:00:00.000Z',
+		addressIndexVersion: 1,
+		addressIndex: {
+			schemaVersion,
+			normVersion: 1,
+			normTable: { path: 'addresses/normalization.json', sha256: 'x', bytes: 1 },
+			totalChunks: 1,
+			totalStreets: 3,
+			totalPoints: 0,
+			totalRanges: 3,
+			chunkIndex: { path: 'addresses/chunk-index.json', sha256: 'x', bytes: 1 },
+		},
+	};
+}
+
+// A 4-shard oversized ZIP. Shard indices computed via the same
+// stableStreetShard the producer uses — see compute in the test below for
+// the byte-identical cross-check against the shared vectors.
+const SHARDS = 4;
+// Runtime validation is SHAPE-only (byte-verification lives in the §6 gate),
+// so structurally-valid pins suffice here; values are per-shard distinct.
+const SHARD_PINS = Array.from({ length: SHARDS }, (_, i) => ({
+	bytes: 128_000 + i,
+	sha256: String(i).repeat(64).slice(0, 64),
+}));
+const STUB_94999 = {
+	v: 2,
+	schema: 'atlas-address-index',
+	country: 'US',
+	zip: '94999',
+	state: 'CA',
+	zipCentroid: [37.7, -122.4],
+	shards: SHARDS,
+	shardHashes: SHARD_PINS,
+};
+
+function shardFileFor(shardIdx: number, streets: Record<string, unknown>) {
+	return { v: 2, zip: '94999', shard: shardIdx, shards: SHARDS, streets };
+}
+
+const MISSION_SHARD = stableStreetShard('MISSION ST', SHARDS);
+const VALENCIA_SHARD = stableStreetShard('VALENCIA ST', SHARDS);
+
+const SHARD_FILES: Record<number, ReturnType<typeof shardFileFor>> = {};
+SHARD_FILES[MISSION_SHARD] = shardFileFor(MISSION_SHARD, {
+	'MISSION ST': { r: [[2000, 2098, 'E', 37.76407, -122.41952, 37.76211, -122.41871]] },
+});
+if (VALENCIA_SHARD !== MISSION_SHARD) {
+	SHARD_FILES[VALENCIA_SHARD] = shardFileFor(VALENCIA_SHARD, {
+		'VALENCIA ST': { r: [[100, 198, 'B', 37.75, -122.42, 37.751, -122.421]] },
+	});
+} else {
+	// Same shard — merge streets into the one file (still one fetch either way).
+	SHARD_FILES[MISSION_SHARD].streets['VALENCIA ST'] = {
+		r: [[100, 198, 'B', 37.75, -122.42, 37.751, -122.421]],
+	};
+}
+
+type FetchRoute = { status: number; body?: unknown };
+let fetchCallCount = 0;
+
+function mockFetchRoutes(routes: Record<string, FetchRoute>): void {
+	fetchCallCount = 0;
+	globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+		fetchCallCount++;
+		const url = String(input);
+		const path = url.startsWith(`${BASE}/`) ? url.slice(BASE.length + 1) : url;
+		const route = routes[path];
+		if (!route) {
+			return { ok: false, status: 404, json: async () => ({}) } as unknown as Response;
+		}
+		return {
+			ok: route.status >= 200 && route.status < 300,
+			status: route.status,
+			json: async () => route.body,
+		} as unknown as Response;
+	}) as typeof fetch;
+}
+
+function splitRoutes(): Record<string, FetchRoute> {
+	const routes: Record<string, FetchRoute> = {
+		'US/manifest.json': { status: 200, body: manifestWithSchemaVersion(2) },
+		'US/addresses/normalization.json': { status: 200, body: NORM_TABLE },
+		'US/addresses/94999.json': { status: 200, body: STUB_94999 },
+	};
+	for (const [idx, file] of Object.entries(SHARD_FILES)) {
+		routes[`US/addresses/94999.${idx}.json`] = { status: 200, body: file };
+	}
+	return routes;
+}
+
+let events: MatchOutcomeEvent[] = [];
+
+beforeEach(async () => {
+	await clearCache();
+	configure({ atlasBaseUrl: BASE });
+	events = [];
+	setMatchOutcomeSink((e) => events.push(e));
+	vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+	setMatchOutcomeSink(null);
+	vi.restoreAllMocks();
+});
+
+describe('oversized ZIP5 split (§1 v2) — consumer resolution', () => {
+	it('resolves a street from a sharded ZIP in exactly 2 fetches for the chunk (stub + 1 shard)', async () => {
+		mockFetchRoutes(splitRoutes());
+		const result = await geocodeAddress({
+			street: '2000 Mission Street',
+			city: 'San Francisco',
+			state: 'CA',
+			zip: '94999',
+		});
+		expect(result.matchClass).toBe('range');
+		expect(result.lat).toBeCloseTo(37.76407, 4);
+
+		// manifest + normalization + stub + exactly one shard = 4 total fetches.
+		expect(fetchCallCount).toBe(4);
+	});
+
+	it('the shard fetched matches stableStreetShard(normalizedStreet, shards) — the exact producer computation', async () => {
+		mockFetchRoutes(splitRoutes());
+		await geocodeAddress({
+			street: '2000 Mission Street',
+			city: 'San Francisco',
+			state: 'CA',
+			zip: '94999',
+		});
+		const calls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.map((c) => String(c[0]));
+		const shardCalls = calls.filter((u) => /94999\.\d+\.json$/.test(u));
+		expect(shardCalls).toEqual([`${BASE}/US/addresses/94999.${MISSION_SHARD}.json`]);
+	});
+
+	it('unsplit v1 chunk still resolves in 1 fetch for the chunk itself (no regression)', async () => {
+		mockFetchRoutes({
+			'US/manifest.json': { status: 200, body: manifestWithSchemaVersion(1) },
+			'US/addresses/normalization.json': { status: 200, body: NORM_TABLE },
+			'US/addresses/10001.json': {
+				status: 200,
+				body: {
+					version: 1,
+					schema: 'atlas-address-index',
+					country: 'US',
+					zip: '10001',
+					state: 'NY',
+					zipCentroid: [40.75, -73.99],
+					streets: { 'MAIN ST': { r: [[1, 99, 'O', 40.75, -73.99, 40.751, -73.991]] } },
+				},
+			},
+		});
+		const result = await geocodeAddress({
+			street: '1 Main Street',
+			city: 'New York',
+			state: 'NY',
+			zip: '10001',
+		});
+		expect(result.matchClass).toBe('range');
+		// manifest + normalization + 1 chunk fetch = 3 total; no second address fetch.
+		expect(fetchCallCount).toBe(3);
+	});
+
+	it('schemaVersion 2 in the manifest is accepted (not just 1)', async () => {
+		mockFetchRoutes(splitRoutes());
+		await expect(
+			geocodeAddress({ street: '2000 Mission Street', city: 'SF', state: 'CA', zip: '94999' }),
+		).resolves.toBeDefined();
+	});
+
+	it('an unrecognized schemaVersion (3) fails closed as AddressIndexSchemaError', async () => {
+		const routes = splitRoutes();
+		routes['US/manifest.json'] = { status: 200, body: manifestWithSchemaVersion(3) };
+		mockFetchRoutes(routes);
+		await expect(
+			geocodeAddress({ street: '2000 Mission Street', city: 'SF', state: 'CA', zip: '94999' }),
+		).rejects.toBeInstanceOf(AddressIndexSchemaError);
+	});
+
+	it('stub names N shards but the shard file 404s → fail-closed AddressIndexSchemaError, never a silent fallback', async () => {
+		const routes = splitRoutes();
+		delete routes[`US/addresses/94999.${MISSION_SHARD}.json`];
+		mockFetchRoutes(routes);
+		await expect(
+			geocodeAddress({ street: '2000 Mission Street', city: 'SF', state: 'CA', zip: '94999' }),
+		).rejects.toBeInstanceOf(AddressIndexSchemaError);
+		// A schema fault is never counted as a match-outcome miss.
+		expect(events).toEqual([]);
+	});
+
+	it('a stub with NO shardHashes fails closed — unpinned shards are never fetched', async () => {
+		const routes = splitRoutes();
+		const { shardHashes: _dropped, ...unpinnedStub } = STUB_94999;
+		routes['US/addresses/94999.json'] = { status: 200, body: unpinnedStub };
+		mockFetchRoutes(routes);
+		await expect(
+			geocodeAddress({ street: '2000 Mission Street', city: 'SF', state: 'CA', zip: '94999' }),
+		).rejects.toBeInstanceOf(AddressIndexSchemaError);
+		// Fail-closed BEFORE any shard fetch: manifest + normalization + stub only.
+		const calls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.map((c) => String(c[0]));
+		expect(calls.filter((u) => /94999\.\d+\.json$/.test(u))).toEqual([]);
+	});
+
+	it('a stub whose shardHashes count disagrees with shards fails closed', async () => {
+		const routes = splitRoutes();
+		routes['US/addresses/94999.json'] = {
+			status: 200,
+			body: { ...STUB_94999, shardHashes: SHARD_PINS.slice(0, SHARDS - 1) },
+		};
+		mockFetchRoutes(routes);
+		await expect(
+			geocodeAddress({ street: '2000 Mission Street', city: 'SF', state: 'CA', zip: '94999' }),
+		).rejects.toBeInstanceOf(AddressIndexSchemaError);
+	});
+
+	it('a malformed shardHashes pin (bad hex, zero bytes) fails closed', async () => {
+		for (const badPin of [
+			{ bytes: 0, sha256: SHARD_PINS[0].sha256 }, // zero bytes
+			{ bytes: 128_000, sha256: 'not-hex' }, // malformed hash
+			{ bytes: 128_000, sha256: SHARD_PINS[0].sha256.slice(0, 63) }, // short hash
+		]) {
+			await clearCache();
+			const routes = splitRoutes();
+			routes['US/addresses/94999.json'] = {
+				status: 200,
+				body: { ...STUB_94999, shardHashes: [badPin, ...SHARD_PINS.slice(1)] },
+			};
+			mockFetchRoutes(routes);
+			await expect(
+				geocodeAddress({ street: '2000 Mission Street', city: 'SF', state: 'CA', zip: '94999' }),
+			).rejects.toBeInstanceOf(AddressIndexSchemaError);
+		}
+	});
+
+	it('a shard file whose shard/shards fields disagree with the stub fails closed', async () => {
+		const routes = splitRoutes();
+		routes[`US/addresses/94999.${MISSION_SHARD}.json`] = {
+			status: 200,
+			body: { ...SHARD_FILES[MISSION_SHARD], shards: 999 },
+		};
+		mockFetchRoutes(routes);
+		await expect(
+			geocodeAddress({ street: '2000 Mission Street', city: 'SF', state: 'CA', zip: '94999' }),
+		).rejects.toBeInstanceOf(AddressIndexSchemaError);
+	});
+
+	it('shared hash vectors: stableStreetShard matches the committed cross-repo vector file byte-for-byte', () => {
+		expect(sharedVectors.hashAlgorithm).toBe('fnv1a32');
+		expect(sharedVectors.vectors.length).toBeGreaterThan(0);
+		for (const v of sharedVectors.vectors as Array<{ streetKey: string; shards: number; shard: number }>) {
+			expect(stableStreetShard(v.streetKey, v.shards)).toBe(v.shard);
+		}
+	});
+});


### PR DESCRIPTION
## Why

The live atlas build (v20260704) shards oversized ZIP5 address chunks: **839 of 37,145 ZIPs** — disproportionately the densest ones — now publish as a tiny `{v:2, shards:N, shardHashes}` stub plus per-shard street files. The deployed resolver predates that contract and cannot parse the stubs, so address geocoding in those ZIPs fails closed today. This PR ships the consumer side.

## What

**v2 consumer path** (`ipfs-store.ts`, `geocoder.ts`, `street-shard.ts`):
- A fetched address chunk that reads `v:2` is validated as a stub, then `stableStreetShard(normalizedStreet, shards)` — byte-identical FNV-1a to the producer's assignment, cross-checked against committed shared vectors — picks the ONE shard to fetch. Reassembled to the v1 chunk shape; `runMatchLadder` needs no v2 awareness.
- Unsplit chunks still resolve in one fetch (no regression; dedicated caches per artifact kind).

**Fail-closed integrity pins**:
- The stub's `shardHashes` must pin exactly `shards` entries (positive bytes + 64-hex sha256) or the reader raises `AddressIndexSchemaError` **before any shard fetch**. Missing shard files and shard/stub index disagreements also fail closed — never a silent fallback.
- Runtime validates pin **shape**; **byte-verification** (length + sha256 of every shard against its pin) rides the §6 source-population gate, matching the existing normTable/chunk-pin posture.

## Verification

- 11/11 unit tests (`address-chunk-split.test.ts`) incl. 3 new fail-closed pin cases
- Live smoke against production: ZIP 14701 (2-shard stub) resolved stub→shard→chunk through the new path
- `vitest --changed origin/main`: 562 tests / 30 files green
- `svelte-check`: 0 errors / 8,159 files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for split ZIP code address lookups, improving handling for large address datasets.
  * Added consistent street-based shard selection so the same address routes to the same shard every time.

* **Bug Fixes**
  * Improved address lookup behavior for oversized ZIP codes without changing normal lookup results.
  * Strengthened validation for split address data to fail safely when metadata is missing or inconsistent.

* **Tests**
  * Added coverage for split ZIP lookup behavior, shard selection, and data integrity checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->