### PR TITLE
docs(atlas): land the sourcing decision record + data-ops designs

### DIFF
--- a/docs/design/MISSING-SLOTS-SOURCING.md
+++ b/docs/design/MISSING-SLOTS-SOURCING.md
@@ -1,0 +1,211 @@
+# Missing-Slots Sourcing — Founder Decision Brief
+
+Status: **APPROVED — Wave 1 + Wave 2 in full** (founder sign-off 2026-07-04; see DECISION at bottom)
+Evidence date: all web sources fetched and adversarially verified 2026-07-04; all repo
+citations checked against `voter-protocol/packages/shadow-atlas` and `commons` the same day.
+Companion docs: `docs/research/CICERO-DATA-COMPARISON.md` (slot-occupancy correction),
+`docs/design/RESOLUTION-FRESHNESS-REMAINING.md` (refresh/publish ledger).
+
+---
+
+## The directive (empty slots must be filled — 2026-07-04)
+
+Founder directive, 2026-07-04: the empty slots **"can't be left missing."**
+
+Where the 24-slot registry (`PROTOCOL_DISTRICT_SLOTS = 24`, `shadow-atlas/src/jurisdiction.ts:80`;
+US taxonomy at `jurisdiction.ts:271-304`) stands today:
+
+- **10 slot types populated** in the source DB — **93,828 districts** total: cd 444 (slot 0),
+  sldu 1,964 (slot 2), sldl 4,879 (slot 3), county 3,235 (slot 4), place 32,620 (slot 5),
+  unsd/elsd/scsd 13,330 (slots 7-9), cousub 36,492 (slot 20), aiannh 864 (slot 22).
+  [Source-DB counts, recorded in the CICERO-DATA-COMPARISON correction, 2026-07-04.]
+- **12 slots empty** — the directive's target set: **6** (City Council Ward), **10** (Community
+  College District), **11** (Water/Sewer), **12** (Fire/EMS), **13** (Transit), **14** (Hospital),
+  **15** (Library), **16** (Park/Recreation), **17** (Conservation), **18** (Utility),
+  **19** (Judicial), **21** (Voting Precinct).
+- Slot 1 (Federal Senate) is statewide — no sub-state geometry to source. Slot 23 is overflow,
+  proposed below for census tracts.
+
+Constraints this brief operates under (all inherited, none new): open license compatible with a
+**republished, signed, commercially-metered** atlas; **$0 recurring cost** (bootstrapping posture);
+fits the existing shapefile/GeoJSON → prefix-id → rtree → H3 pipeline; raw addresses never leave
+our infra (no hosted lookup APIs as sources).
+
+Method: three parallel source-hunt briefs (slots 21+6; slots 11-18; slots 19+10+tracts), then one
+adversarial verification pass that re-fetched every load-bearing license text, killed coverage
+overclaims, and confirmed the repo wiring findings. Only verified claims appear below.
+
+## Verified source table (slot × source × coverage × license × effort)
+
+Ranked by coverage-per-ingest-effort under the constraints. License marks: ✔ = text verified
+2026-07-04; ⚠ = one-time confirmation required before the signed publish includes it.
+
+| # | Source | Slot(s) | Coverage | License (verified) | Effort | Honest label |
+|---|--------|---------|----------|--------------------|--------|--------------|
+| 1 | TIGER 2020 PL VTDs (Census) | 21 | National, MT/OR partial [data.gov series: "Only Montana and Oregon do not have complete coverage"] | CC0/public domain ✔ (data.gov record lists CC0 1.0; live HEAD 200, 42.96 MB for TX) | Trivial — existing TIGER path, canonical GEOID20 | "2020-vintage VTD, frozen until 2030" |
+| 2 | Census tracts (TIGER annual) | 23 (overflow) | National, ~85K tracts | Public domain ✔ | Trivial — one config addition to the existing TIGER path | `statistical`, not governance |
+| 3 | Federal judicial: 28 U.S.C. §§ 81-131 statute + TIGER county dissolve | 19 | National, 94 districts; DOJ UST county→district page as cross-check | Public domain (statute + TIGER) ✔ | Low — dissolve script + composition table; edge cases DC/PR/territories/Yellowstone-into-D.Wyo. | `derived:statute`, near-static |
+| 4 | EPA Community Water System Service Area Boundaries v3 (March 2026) | 11 | National: 44,000+ systems, ~99% of served population | PD-basis, **no explicit grant on page** ⚠ — 60% state/utility-submitted geometry rides on EPA republication convention; one-time EPA confirm before signing | Low — single national layer, PWSID ids | `service-area` (drinking water, not sewer), per-feature authoritative (60%) / EPA-modeled (40%) |
+| 5 | EIA Electric Retail Service Territories (U.S. Energy Atlas, ORNL-sourced) | 18 | National service territories incl. co-ops/PUDs/munis | EIA reuse policy PD-basis ⚠ — third-party-contributed carve-out + DOE-contractor provenance; one-time confirm at ingest | Low — single layer, EIA utility ids | `service-area`, incl. IOUs (no elected board) |
+| 6 | CO DOLA "All Special Districts in Colorado" (Socrata) | 11, 12, 14, 15, 16, 17 (CO only) | CO statewide, 4,235 districts | Public Domain ✔ (Socrata metadata) | Low — Socrata export, LGID ids | Per-state; scanned-drawings accuracy caveat verbatim in provenance; data as of 2026-01-04 (not "fresh-daily" — verified) |
+| 7 | WI LTSB Municipal Wards | 6 (WI only) | WI statewide, all municipalities; semiannual collections through 2026 | Open ✔ ("This is open and publicly available data…", owner `WI_Legislature`, no use restriction) | Low — semiannual refresh hook | Per-state |
+| 8 | VEST 2020 precincts (Harvard Dataverse, doi:10.7910/DVN/XPW7T7) | 21 (enrichment) | 50 states + DC, 2016-2020 only; post-2021 cadence stalled | CC BY 4.0 ✔ (Dataverse API `termsOfUse`) | Medium — heterogeneous per-state fields | Optional election-results overlay; never "current precincts" |
+| 9 | ALGED council shapefiles (OSF mv5e6) | 6 (seed) | ~150 cities + ~130 counties (approx — paper paywalled, counts PLAUSIBLE not confirmed; 1,747-locality parent study, 1989-2021) | CC BY 4.0 ✔ (OSF license API) | Medium — synthetic ids (place GEOID + district), per-city vintage check | Pre-2022-redistricting snapshot |
+| 10 | State judicial statute-dissolves (+ AR/UT-style portals) | 19 (per-state) | Per-state; whole-county circuits only (sub-county units — e.g. Cook subcircuits, TX JP precincts — not derivable) | TIGER PD + per-portal check | Medium-high — per-state statute curation | Per-state, `derived:statute` |
+| 11 | Community-college derivations (WI now; IL/TX curated) | 10 | Few states initially; WI's 16 tech-college districts re-derivable from TIGER school layers + WTCS policy manual | Re-derived from TIGER = PD ✔; **CA blocked** (FoundationCCC, licenseInfo null) | High — per-state statutory composition tables | Per-state only, never national |
+| 12 | TCEQ TX water districts (MUD/WCID/SUD) | 11 (TX governance) | TX statewide | Unverified ⚠ — one-time check | Low-medium | Per-state |
+| 13 | Big-city open-data portals (NYC/LA/Chicago…) | 6 | Incremental; top-100 cities ≈ 20% of US population | Per-portal review — ingest only explicit PD/CC0/open terms | Highest marginal — OpenAddresses-shaped license triage | Per-metro |
+| 14 | USGS Watershed Boundary Dataset (WBD, HUC-8/10/12) | 23 overflow alongside tracts (or 17 if treated as conservation-adjacent — final assignment at ingest) | National, complete | US federal work → public domain (standard USGS terms; confirm at ingest, zero expected risk) | Low — single national layer via the existing national-layer path | `hydrologic` — hydrologic units, NOT governance districts; closes Cicero's WATERSHED type |
+
+**Disqualified on verified grounds** (do not revisit without new facts):
+
+- **RDH (Redistricting Data Hub)** — license text verified verbatim: "solely for noncommercial
+  use, not for any resale" + viral no-redistribution clause. Incompatible with a signed,
+  commercially-metered atlas. Existing repo wiring (VTD GEOID extraction: `rdh-vtd-extractor.ts`,
+  `rdh-scanner.ts`, `publish-source.ts:443-444` allowlist, + 5 further touchpoints found in
+  verification: `input-validator.ts:263`, `authority-registry.ts:556`, `gap-detector.ts:629`,
+  `tiger-expected-counts.ts:684`, `.env.example:103-104`/`PRODUCTION_READINESS.md:146-147`)
+  must be re-pointed to TIGER-direct. Verification also found `data/vtd-geoids/` holds only a
+  README — the 124,179 extracted GEOIDs were never committed, so re-extraction is required
+  regardless and no RDH-derived artifact purge is needed. Fix `docs/VTD_CANONICAL_GEOIDS.md:9`
+  (VTDs absent from *annual* TIGER/Line but present in the 2020 PL 94-171 product).
+- **CA community college layer** — ArcGIS item `licenseInfo` null AND the item is a document link
+  to a FoundationCCC (nonprofit) map; needs written permission.
+- **CSDA California special-districts map** — proprietary (California CAD Solutions), no bulk download.
+- **OSM** — ODbL share-alike contaminates the signed republished atlas.
+- **Esri Living Atlas** — master-agreement redistribution restrictions.
+- **Cicero / BallotReady** — subscription; violates $0-recurring posture.
+- **HIFLD Open** — discontinued 2025-08-26, portal offline; its fire/EMS/hospital layers were
+  facility POINTS, never district polygons. SeerAI/DataLumos archives remain PD — cross-check only.
+- **NYU Marron "Atlas of Special Districts"** — does not exist (phantom lead; Marron's atlas is
+  the Atlas of Urban Expansion).
+- **FL Special District Accountability Program** — directory (~1,900 districts), no boundary GIS.
+- **Dartmouth Hospital Service Areas** — analytic constructs, not governance districts.
+- **TX Comptroller SPD sales-tax files** — sales-tax-levying subset only; supplement, never backbone.
+
+## The honest coverage ceiling
+
+What the verification pass proves **cannot be national today**, at any effort level consistent
+with the constraints:
+
+1. **Special-district governance boundaries (slots 12-17)** — structurally impossible national.
+   The 2022 Census of Governments counts **39,555 special district governments** and publishes
+   **zero polygons**; TIGER has no special-district layer. No federal boundary product exists,
+   HIFLD is dead, and the only comprehensive state maps are CO (open) and CA (proprietary).
+2. **City council wards (slot 6)** — no open national aggregation exists. RDH's "local
+   redistricting resources" is a link directory, not hosted data (verified), and its license bars
+   use anyway.
+3. **Community college districts (slot 10)** — no national layer (TIGER file-availability table
+   verified: no CC layer, no judicial layer). Statutory-composition derivation works per-state only.
+4. **State judicial (slot 19, state tier)** — no national source; whole-county circuits derivable
+   per-state from statute, sub-county judicial units not derivable at all.
+5. **Current precincts (slot 21)** — **no source at any price under the constraints supports a
+   "current precincts" claim.** TIGER VTDs are 2020-frozen until the 2030 cycle; VEST stalls at
+   2020 (50-state) / 2022-24 (state-selective); post-2020 precincts live behind RDH's
+   incompatible license. Slot 21 ships honestly as "2020-vintage VTD, MT/OR partial."
+
+What **is** national today: slots 21 (2020-frozen VTDs), 19 federal (94 statute-derived
+districts), 23 (~85K statistical tracts), and two **service-area proxies** — slot 11 water
+(44K+ systems, ~99% served population, 60/40 authoritative/modeled per-feature labels) and
+slot 18 electric — which are honest only under a `service-area` label, never as governance
+districts.
+
+Everything below that line is **per-state coverage we label per-state**: CO is the sole
+multi-type statewide fill (4,235 districts across six slots); WI fills slot 6 statewide;
+TX fills slot 11 governance-side (pending license check); ALGED seeds ~150 cities at a
+pre-2022 vintage; big-city portals add per-metro increments. Manifests must carry the Census
+of Governments per-state counts as the honesty denominator (e.g., "CO: 4,235 of ~4,400
+CoG-counted units mapped") and per-feature provenance labels (`service-area`,
+`derived:statute`, `statistical`, vintage, source license).
+
+## Proposed ingest waves
+
+**Wave 1 — national, open-license, highest coverage-per-effort (ranks 1-5).**
+Five sources, all $0, all pipeline-native:
+
+| Order | Source → slot | Gate before signed publish |
+|-------|---------------|---------------------------|
+| 1 | TIGER 2020 PL VTDs → 21 | none — CC0 verified |
+| 2 | Census tracts → 23 | none — PD; must carry `statistical` label |
+| 3 | Federal judicial dissolve → 19 | none — PD²; DOJ UST crosswalk validation |
+| 4 | EPA CWS SAB v3 → 11 | ⚠ one-time EPA license confirmation (60% submitted geometry has no explicit grant) |
+| 5 | EIA Electric Retail Service Territories → 18 | ⚠ one-time EIA/ORNL license confirmation |
+
+Wave-1 accompanying hygiene (blocking for the publish path, not for ingest dev): the **RDH
+removal sweep** — re-point VTD GEOID extraction to TIGER-direct, drop `RDH_USERNAME`/
+`RDH_PASSWORD` from the `publish-source.ts` allowlist, clear all 5 additional touchpoints
+listed above, correct `VTD_CANONICAL_GEOIDS.md:9`.
+
+Wave-1 outcome if signed off: slots 11, 18, 19, 21, 23 go from empty to nationally populated
+(two of them as labeled service-area layers), leaving only 6, 10, 12-17 slot-empty at the
+national level — which the coverage ceiling above shows is a data-reality boundary, not an
+effort boundary.
+
+**Wave 1 addendum (2026-07-04, Cicero-parity enumeration directive).** Rank 14 — USGS WBD
+watersheds — joins Wave 1: it was the single Cicero district type with no wave assignment,
+it is national + public-domain + pipeline-native like ranks 1-3, and it needs no license
+gate. With it, Wave 1 closes every Cicero boundary type except the local-council long tail
+(Wave 2) — see the parity ledger in `docs/research/CICERO-DATA-COMPARISON.md`.
+
+**Slot-21 currency addendum (2026-07-04).** The founder's currency directive produced a
+dedicated verified lane for CURRENT precincts on top of the rank-1 2020 baseline:
+`docs/design/PRECINCT-CURRENCY-LANE.md` — 23 CONFIRMED statewide between-census-updated
+sources (50.9% of US population), 4 plausible barred, 24 none; ingest tracked as P19.
+VEST (rank 8) remains the historical-election enrichment overlay; the currency lane
+supersedes it as the "freshest available" path.
+
+**Wave 2 — state-portal long tail (ranks 6-13), per-state labels mandatory.**
+CO DOLA (six slots, CO statewide) → WI LTSB wards (slot 6, WI) → TCEQ TX water (slot 11 TX,
+after its one-time license check) → VEST 2020 enrichment (slot 21 overlay) → ALGED seed
+(slot 6, ~150 cities, per-city vintage check) → state judicial statute-dissolves (slot 19,
+whole-county states first) → CCD derivations (slot 10: WI now, IL/TX curated, CA blocked) →
+big-city portals (slot 6, explicit-open-license portals only). Each Wave-2 source lands with
+its own license record in per-district provenance; no source enters the signed publish with
+an unverified license.
+
+**Explicitly OUT** (license-encumbered, subscription, dead, or phantom — the full disqualified
+list above is binding): RDH as a data source in any form; CA CCD layer without written
+FoundationCCC permission; CSDA map; OSM (ODbL); Esri Living Atlas; Cicero/BallotReady or any
+paid/subscription source; HIFLD Open (archives = offline cross-check only); NYU Marron atlas;
+FL SDAP; Dartmouth HSAs; TX Comptroller SPD files as a backbone. Nothing in either wave incurs
+recurring cost.
+
+## Serving dependency
+
+**None of this reaches users without the M9 multi-district consumer wire-up — the 10
+already-populated slots prove it.** The build side is already multi-slot: `build-h3-mapping.ts`
+maps **all** 93,828 districts across 10 slot types into the cell chunks (no layer filter,
+complete prefix→slot alias map). Yet users see congressional only, because the commons consumer
+is slot-0-hardwired:
+
+- `src/lib/core/shadow-atlas/client.ts:354` — `cellDistrictsToDistrict()` reads
+  `cellDistricts.slots[0]` and throws if empty; every live resolve flows through it
+  (`client.ts:440`).
+- `src/lib/core/shadow-atlas/client.ts:469` — `lookupAllDistricts()` (the multi-slot reader)
+  has **zero callers** (verified by grep, 2026-07-04).
+- `src/lib/core/shadow-atlas/district-format.ts:40` — `CONGRESSIONAL_SLOT_INDEX = 0` is the
+  serving contract.
+
+Ten slots of data have sat consumer-invisible through every release to date. Ingesting waves
+1-2 without M9 changes **nothing** user-visible — it grows the same invisible inventory.
+Sequencing consequence: **M9 lands with (or before) Wave 1**, and the wave-1 acceptance check
+is a resolve that returns multi-slot output from the built chunks, not a build-side count.
+One further verification remains open from the 2026-07-04 correction: assert slot occupancy in
+the **built** chunk-index when the next publish lands (source-DB occupancy is verified; built-chunk
+occupancy is asserted-but-unchecked until then).
+
+## DECISION
+
+DECISION: **APPROVED IN FULL — Wave 1 + Wave 2** (founder, 2026-07-04).
+
+1. **Wave 1** = ranks 1-5, national open-license, now. The **RDH removal sweep** is mandatory
+   and doubly grounded: the verified license (noncommercial, no redistribution) forbids our
+   commercial signed republication, **and** the founder independently confirms RDH is not
+   current enough regardless — its precinct inputs stall at the 2020-2022 era (consistent
+   with the VEST cadence finding above). Either ground alone kills it.
+2. **Wave 2** = the state-portal long tail with mandatory per-state coverage labels; no source
+   enters the signed publish with an unverified license.
+3. The two ⚠ one-time license confirmations (EPA CWS SAB, EIA territories) are **publish
+   gates** — ingest development may proceed ahead of them; signing may not.
+4. **M9 is sequenced with (or before) Wave 1** as the serving prerequisite; wave-1 acceptance
+   is a live resolve returning multi-slot output from built chunks, not a build-side count.

--- a/docs/design/PRECINCT-CURRENCY-LANE.md
+++ b/docs/design/PRECINCT-CURRENCY-LANE.md
@@ -1,0 +1,535 @@
+# Precinct Currency Lane — per-state current-precinct overlays
+
+**Status**: Adversarially verified survey (all 51 jurisdictions independently re-checked, as-of 2026-07)
+**Scope**: 50 states + DC, hunting a STATEWIDE, openly published precinct/ward/VTD boundary file that is UPDATED between censuses
+**Companion docs**: `SELF-HEALING-DATA-OPS.md` (source registry / SLO / probe machinery these rows plug into), `MISSING-SLOTS-SOURCING.md`
+
+---
+
+## 1. The honest national picture
+
+**VTDs are a decennial Census product.** The only *national* precinct-equivalent layer
+is the Census Bureau's Voting Tabulation Districts as captured in the **TIGER 2020
+PL 94-171 release** — a snapshot of state-submitted precinct approximations frozen at
+the 2020 redistricting cycle. The next national refresh is **2030**. No vendor sells a
+compliant, current, national precinct file; academic stitch-togethers (VEST, MGGG,
+Redistricting Data Hub) are research compilations with per-state vintages and
+research-grade licensing, not a serving-grade national product.
+
+**Currency therefore only exists as per-state overlays.** A minority of states operate
+a genuine statewide precinct/ward clearinghouse that updates between censuses —
+Wisconsin's LTSB (statutorily semiannual) is the archetype. Where such a source exists,
+verified, and openly licensed, we can serve *current* precinct geometry for that state.
+Where it does not, the 2020 baseline is the honest best available, and we say so.
+
+**Serving contract (non-negotiable):**
+
+1. The overlay **never replaces** the TIGER 2020 baseline. The baseline stays intact
+   and nationally uniform; overlays layer on top per state.
+2. **Every served district carries its vintage + source in provenance** (per
+   `src/lib/core/shadow-atlas/provenance.ts` conventions): a lookup answered from the
+   Wisconsin overlay says `WI LTSB, Feb 2026 collection`; a lookup answered from the
+   baseline says `Census TIGER 2020 PL`. No silent blending, no implied currency where
+   there is none.
+3. Overlay sources enter the ingest path **only at verdict CONFIRMED** (statewide scope
+   + license text observed + post-2022 update evidence independently re-fetched).
+   PLAUSIBLE rows are follow-up work, not ingest candidates.
+
+**Survey result**: **23 CONFIRMED / 4 PLAUSIBLE / 24 NONE / 0 UNSWEPT** (51 total, no
+jurisdiction skipped). The 23 CONFIRMED states cover **≈168.7M people — 50.9% of the
+2020 US resident population**. Every row below was re-verified by an independent
+verifier against the original hunter's claims; corrections and downgrades from that
+adversarial pass are recorded inline.
+
+---
+
+## 2. Per-state disposition — all 51 jurisdictions
+
+Order: CONFIRMED (23) → PLAUSIBLE (4) → NONE (24) → UNSWEPT (0).
+
+### Index
+
+| State | Verdict | Portal (short) | Cadence | Format |
+|---|---|---|---|---|
+| AR | CONFIRMED | Arkansas GIS Office (ASDI) | rolling, county-by-county, near-continuous | shapefile / ArcGIS FeatureServer |
+| CA | CONFIRMED | UC Berkeley Statewide Database (SWDB) | per-statewide-election | shp / gpkg / geojson |
+| HI | CONFIRMED | Hawaii Statewide GIS + Office of Elections | per-election-cycle | ArcGIS MapServer/FeatureServer + exports |
+| ID | CONFIRMED | Idaho SOS + ITS (The Idaho Map) | biennial (even years, statutory Jan 15 submission) | ArcGIS FeatureServer + exports |
+| IN | CONFIRMED | Indiana GIO / IndianaMap | annual | ArcGIS FeatureServer + shapefile |
+| IA | CONFIRMED | Iowa SOS + Legislative Services Agency | decennial baseline + corrections | ArcGIS FeatureServer + per-county shapefile |
+| MD | CONFIRMED | MD iMap (MDP + State Board of Elections) | rolling re-collection per cycle | ArcGIS FeatureServer + exports |
+| MA | CONFIRMED | MassGIS (Secretary of the Commonwealth data) | irregular, event-driven | Feature Service + shapefile/FGDB |
+| MI | CONFIRMED | MI Dept. of State / Bureau of Elections | per-even-year election cycle | ArcGIS Hub + shp/geojson/csv |
+| MT | CONFIRMED | Montana State Library (MSDI) | as-needed | FGDB + shapefile + MapServer |
+| NH | CONFIRMED | NH GRANIT (UNH) | as-needed (per-redistricting in practice) | shapefile (FTP) + Feature Service |
+| NM | CONFIRMED | NM SOS clearinghouse (UNM EDAC/RGIS) | as-needed, county-triggered | shp/GML/KML/GeoJSON/CSV/Excel |
+| NY | CONFIRMED | NYS GIS Clearinghouse / ITS | rolling/irregular | ArcGIS Feature Service + exports |
+| NC | CONFIRMED | NC State Board of Elections (dl.ncsbe.gov) | irregular, ~2-4×/year | shapefile (S3) + Feature Service |
+| ND | CONFIRMED | ND Secretary of State | per-election-cycle | ZIP (FGDB + Excel) |
+| RI | CONFIRMED | RIGIS (for RI Dept. of State) | per-redistricting base + ad-hoc edits | Esri hosted feature layer |
+| SC | CONFIRMED | SC Revenue & Fiscal Affairs Office | irregular bursts, running "Effective" date | shapefile + KMZ |
+| TX | CONFIRMED | Texas Legislative Council (Capitol Data Portal) | per-election-cycle | shapefile |
+| UT | CONFIRMED | UGRC (VISTA Ballot Areas, SGID) | rolling, as-needed | ArcGIS FeatureServer + exports |
+| VT | CONFIRMED | VCGI + VT Secretary of State | irregular (municipal redraws) | ArcGIS FeatureServer + exports |
+| WA | CONFIRMED | WA SOS via geo.wa.gov | annual (per general election) | Feature Service + yearly statewide ZIP |
+| WI | CONFIRMED | WI Legislature LTSB GIS Hub | semiannual, statutory (Wis. Stat. 5.15(4)(br)1) | Feature Service + full export set |
+| DC | CONFIRMED | Open Data DC (DC GIS + Board of Elections) | event-driven; current layer refreshed 2026-06 | FeatureServer/MapServer + shp/geojson/kml/csv |
+| AK | PLAUSIBLE | AK DCCED/DCRA Geoportal (Division of Elections data) | irregular | ArcGIS Feature/MapServer |
+| DE | PLAUSIBLE | Delaware FirstMap / Dept. of Elections GIS | irregular / event-driven | ArcGIS FeatureServer + shapefile |
+| LA | PLAUSIBLE | LA Legislature redistricting site | semiannual (per search evidence) | shapefile |
+| MN | PLAUSIBLE | MN SOS via MN Geospatial Commons | irregular (per unverified snippets) | shp/KML/GeoJSON (unverified) |
+| AL | NONE | AL Secretary of State | n/a | — |
+| AZ | NONE | AZ SOS / Independent Redistricting Commission | n/a | — |
+| CO | NONE | CO Geospatial Portal / SOS | n/a | — |
+| CT | NONE | CT OPM GIS / UConn MAGIC | n/a | — |
+| FL | NONE | FL Division of Elections / FGDL | n/a | — |
+| GA | NONE | GA SOS / Reapportionment Office / GIO | n/a | — |
+| IL | NONE | IL State Board of Elections | county PDF maps only | PDF |
+| KS | NONE | KS Geoportal (KLRD data) | frozen between censuses | ArcGIS Hub item |
+| KY | NONE | KyGeoNet / LRC | n/a | — |
+| ME | NONE | ME "Voting Districts" = legislative seats, not precincts | n/a | — |
+| MS | NONE | MARIS (partial: 13/82 counties) | n/a | county shapefiles |
+| MO | NONE | MO SOS / MSDIS | n/a | — |
+| NE | NONE | NE SOS / NebraskaMAP | n/a | — |
+| NV | NONE | NV SOS county-precinct-maps index | biennial submissions, PDF republish | PDF per county |
+| NJ | NONE | NJOGIS (layers frozen, "MATURE SUPPORT") | frozen | frozen Feature Service |
+| OH | NONE | none (county statutory duty, ORC 3501.05) | n/a | — |
+| OK | NONE | okmaps.org (2022-01-01 static statewide file) | static, no re-issuance | shapefile (stale) |
+| OR | NONE | data.oregon.gov (tabular crosswalk only) | n/a | tabular only, no geometry |
+| PA | NONE | PA LRC / redistricting.state.pa.us | one-time 2021 product | shapefile (2021, never refreshed) |
+| SD | NONE | none | n/a | — |
+| TN | NONE | TN Comptroller (per-county maps) | per-county | PDF/KMZ per county |
+| VA | NONE | VA Dept. of Elections GIS page | rolling per-locality, no statewide file | 134+ locality ZIPs |
+| WV | NONE | WV GIS Technical Center (county layers only) | n/a | — |
+| WY | NONE | WY Geospatial Hub (county layers only) | n/a | — |
+
+**UNSWEPT: none — 0 jurisdictions.** All 50 states + DC were swept and dispositioned.
+
+---
+
+### 2.1 CONFIRMED (23) — full records
+
+Every CONFIRMED row has (a) statewide scope, (b) license text as actually observed,
+and (c) post-2022 update evidence **independently re-fetched by a second verifier**
+against the primary source (REST JSON, FTP listings, S3 APIs, or archived captures —
+not search snippets).
+
+#### AR — Arkansas
+- **Portal**: Arkansas GIS Office (Dept. of Shared Administrative Services), publishing on behalf of the Arkansas Secretary of State — Arkansas Spatial Data Infrastructure (ASDI)
+- **URL**: https://gis.arkansas.gov/product/election-precincts/ · metadata: https://gis.arkansas.gov/Metadata/HTML/asdi.Boundaries.ELECTION_PRECINCTS_export.html · REST: https://gis.arkansas.gov/arcgis/rest/services/FEATURESERVICES/Boundaries/FeatureServer/11
+- **Format**: shapefile / ArcGIS FeatureServer (REST independently queried via `f=pjson`)
+- **Cadence**: rolling/near-continuous county-by-county updates folded into a single statewide layer
+- **License (verbatim, from the metadata HTML page, fetched directly)**: "Credits: There are no credits for this item. Use limitations: There are no access and use limitations for this item."
+- **Post-2022 evidence (independently re-fetched)**: site search surfaced dated 2025–2026 county-update posts — Conway (6/16/2026), Marion (6/11/2026), Woodruff (6/8/2026), Polk (6/3/2026), Lonoke (5/29/2026), Searcy (5/26/2026), Clark (4/30/2026), Benton (2/9/2025), Carroll/Stone/Washington (11/21/2025). The 11/24/2025 post explicitly states "The updated statewide layer is available through the Arkansas Spatial Data Infrastructure (ASDI)". Product page shows "Updated: 2026-06-17 08:00:00".
+- **Caveats**: two metadata surfaces carry STALE boilerplate contradicting the rolling evidence — the metadata HTML says "Last updated on August 8, 2019" and the REST layer description says the data "was generated following the release of the 2010 Census data and was finalized in 2012." These are legacy static-text fields never refreshed as polygons kept being edited per-county. Do not cite an exact "as-of" date from those fields.
+
+#### CA — California
+- **Portal**: California Statewide Database (SWDB), UC Berkeley School of Law — California's *de facto* statewide precinct/VTD clearinghouse (UC-operated, **not a state agency**)
+- **URL**: https://statewidedatabase.org/election.html · most recent geography: https://statewidedatabase.org/d20/g24_geo_conv.html (2024 General; 2025 Special also listed)
+- **Format**: shapefile (.shp), GeoPackage (.gpkg), GeoJSON — statewide MPREC/SRPREC files confirmed present alongside per-county files for all 58 counties
+- **Cadence**: per-election — a new statewide precinct-boundary release accompanies every statewide election (primary, general, special)
+- **License (as actually observed)**: only independently confirmable text is the site-wide footer: "© 2000-2026 UC Regents. All Rights Reserved. University of California, Berkeley." **Correction from the adversarial pass**: the hunter's quoted "free public resource" FAQ text could NOT be re-located; no formal open-data license (CC-BY etc.) is stated anywhere verifiable. **Treat the license as effectively "not stated" beyond bare copyright.**
+- **Post-2022 evidence (independently re-fetched)**: direct fetch of election.html — most recent entry is 2025 Special Election ("GEOGRAPHIC DATA: Special Election Precinct Boundaries"); preceding entry 2024 Primary/General. Direct fetch of g24_geo_conv.html confirms statewide `MPREC_SHP` / `SRPREC_SHP` downloads.
+- **Caveats**: license gap is the blocking issue for signed republication — needs a rights confirmation from SWDB before ingest ships publicly (see §3). SWDB is the standard citation used by the Census VTD program and Redistricting Data Hub.
+
+#### HI — Hawaii
+- **Portal**: Hawaii Statewide GIS Program (Office of Planning and Sustainable Development) + Hawaii Office of Elections — layer "Election Precincts - 2024" on geodata.hawaii.gov
+- **URL**: https://geodata.hawaii.gov/arcgis/rest/services/AdminBnd/MapServer/13
+- **Format**: ArcGIS FeatureServer/MapServer (exportable as shapefile/geojson via geoportal.hawaii.gov)
+- **Cadence**: irregular/per-election-cycle — a new dated layer ahead of each general election (2022 edition superseded by 2024)
+- **License (verbatim, confirmed word-for-word on https://planning.hawaii.gov/gis/download-gis-data/ — NOT the generic ehawaii.gov Terms of Use the original citation implied)**: "The contents of this web page are public domain and to the extent indicated otherwise in the Terms of Use, are exempt from Terms of Use policy restrictions... There are no expressed warranties associated with the release of this data or product. Specifically, no warranty is made that the GIS data or any subsequent updates will be error free and no warranty is made regarding the positional or thematic accuracy of the GIS data... The GIS data and any features depicted do not represent or confer any legal rights, privileges, benefits, boundaries or claims of any kind."
+- **Post-2022 evidence (independently re-fetched)**: AGOL item 37f83ac7f930421b97976956cccbd840 JSON — description "Voting Precincts in Hawaii for 2024 elections from the State Office of Elections (May 2024)"; modified epoch 1716938720000 = 2024-05-28. Live layer query `returnCountOnly` = exactly 250 precincts statewide (all 4 counties), fields include us_house/state_house/state_senate/county_council + precinct ids.
+- **Caveats**: license URL pointer in the original report was wrong (corrected above); the text itself and the verdict are solid.
+
+#### ID — Idaho
+- **Portal**: Idaho Secretary of State + Idaho Office of Information Technology Services (ITS), via The Idaho Map (TIM) / AGOL org state_of_idaho
+- **URL**: https://services1.arcgis.com/CNPdEkvnGl65jCX8/arcgis/rest/services/Idaho_Voting_Precincts_Precinct_Boundaries_-_Master_Data_-_DO_NOT_SHARE_view/FeatureServer
+- **Format**: ArcGIS FeatureServer (view service, layer 0), exports via The Idaho Map hub
+- **Cadence**: biennial, statutory — item snippet: "Data is updated in even years before state primary and general elections." County Clerks submit to SOS by Jan 15 of election years.
+- **License (verbatim via direct AGOL item JSON, item 0b4fbe4f3104487da8bc5087f9321705; condensed rendering — substance matches the hunter's fuller quote)**: "Neither the Idaho Secretary of State nor the State of Idaho assumes legal responsibility for accuracy or completeness. Users requiring verified information for official purposes should confirm data with primary sources."
+- **Post-2022 evidence (independently re-fetched)**: item JSON contentStatus `public_authoritative`, modified epoch 1780083781000 = **2026-05-29**. Live FeatureServer/0 `returnCountOnly` = exactly 976 precincts. Full statewide extent (WKID 102605).
+- **Caveats**: "DO_NOT_SHARE" in the service name is an internal naming artifact of the source view — the service resolves publicly and returns full data anonymously (confirmed by direct query). Worth a courtesy confirmation with ID SOS before republication, given the name.
+
+#### IN — Indiana
+- **Portal**: Indiana Geographic Information Office (GIO) / IndianaMap, sourced from the Indiana General Assembly and Indiana Election Division
+- **URL**: https://gisdata.in.gov/server/rest/services/Hosted/Voting_District_Boundaries_2024/FeatureServer (single layer at **id=1**)
+- **Format**: ArcGIS FeatureServer + shapefile export via IndianaMap hub
+- **Cadence**: annual — "Updated annually by Indiana General Assembly through aggregated local data." Prior editions (2020, 2023) exist in the same AGOL org, corroborating a genuine annual series.
+- **License (via direct AGOL item JSON, item a62a17919c804676ae318f2f82cb20db; condensed rendering — substance matches)**: "Product provided \"AS IS\" without warranties. User assumes all risk. Indiana Geographic Information Office disclaims liability for indirect, incidental, special, or consequential damages."
+- **Post-2022 evidence (independently re-fetched)**: item modified epoch 1780335760000 = **2026-06-01**. Live `returnCountOnly` on layer 1 = exactly **5,126** voting-district polygons. Snippet names "election district, precincts, or wards" — precinct-level, not legislative districts. Full statewide extent confirmed.
+
+#### IA — Iowa
+- **Portal**: Iowa Secretary of State + Iowa Legislative Services Agency (LSA); "Iowa_Precincts" feature service, surfaced on geodata.iowa.gov and sos.iowa.gov
+- **URL**: https://services.arcgis.com/vPD5PVLI6sfkZ5E4/arcgis/rest/services/Iowa_Precincts/FeatureServer
+- **Format**: ArcGIS FeatureServer (layer 0); per-county shapefiles on sos.iowa.gov
+- **Cadence**: **decennial baseline (2022 reprecincting) + incidental corrections — NOT a regular sub-decennial refresh.** Snippet: "Iowa Precincts - as of the 2022 Reprecincting."
+- **License**: not stated — confirmed exactly: item d394edea208c4003ac1d6bd1ec78532f JSON has `licenseInfo: null`, `description: null`; only accessInformation credit "Iowa Secretary of State, Iowa Legislatives Services Agency".
+- **Post-2022 evidence (independently re-fetched)**: item modified epoch 1706643378000 = 2024-01-30; separate dataLastEditDate 1706896912686 = 2024-02-02 — both real, distinct timestamps evidencing a correction event after the 2022 snapshot. Live `returnCountOnly` = exactly 1,660 precincts. Extent matches Iowa's bounding box exactly.
+- **Caveats**: license absent (flag for signed-republication review); cadence caveat must be preserved in provenance — this is a 2022-reprecincting product with corrections, not an annually refreshed file.
+
+#### MD — Maryland
+- **Portal**: Maryland Dept. of Planning (MDP) + State Board of Elections (SBOE), via MD iMap
+- **URL**: https://mdgeodata.md.gov/imap/rest/services/Boundaries/MD_ElectionBoundaries/FeatureServer/2
+- **Format**: ArcGIS FeatureServer (service capabilities list shapefile/FGDB/SQLite/CSV/GeoJSON export; export capability itself not separately re-tested)
+- **Cadence**: rolling/as-needed statewide re-collection tied to election cycles — description states data "were collected by the State Board of Elections (SBOE) in 2025 and aggregated by the Maryland Department of Planning (MDP)"
+- **License**: PARTIALLY verified. Layer/service `copyrightText` is a short credit string only. The full MDP/MD-iMap disclaimer ("as is" without warranty; user "assumes the entire risk"; "freely distributed as long as the metadata entry is not modified"; "acknowledge the State of Maryland") is corroborated by independent search as genuine standard MDP boilerplate but was **not observed rendered on this specific endpoint**. Treat as corroborated-but-not-page-sourced; CONFIRMED-with-caveat on the license field only.
+- **Post-2022 evidence (independently re-fetched)**: layer JSON — name "Maryland Precincts 2026", "Last Updated: 1/12/2026" verbatim; independent `returnCountOnly` = **2,091** precincts statewide.
+- **Caveats**: Howard County still reflects 2022 boundaries (no 2025 submission) — per-county vintage variance must flow into provenance.
+
+#### MA — Massachusetts
+- **Portal**: MassGIS (Bureau of Geographic Information, EOTSS); data from MA Secretary of the Commonwealth's Elections Division
+- **URL**: https://gis.data.mass.gov/datasets/massgis::wards-and-precincts-2022
+- **Format**: ArcGIS Feature Service + downloadable shapefile/File Geodatabase via MassGIS Data Hub
+- **Cadence**: irregular/event-driven — updated when LEDRC approves new municipal ward-precinct plans or legislative corrections occur
+- **License (verbatim, read directly in the MassGIS DCAT-US JSON record)**: "This GIS web service is a public resource and may be used by anyone for their purposes. The data are public records and are based on the most up to date information at the time of publication. The information contained in this service is NOT to be construed or used as a \"legal description.\" MassGIS, EOTSS and the Commonwealth of Massachusetts are not liable for errors, inaccuracies or omissions and shall be held harmless from and against all damage, loss or liability arising from any use of geospatial data that is shared. When using MassGIS data on maps or in digital applications, source credit should be stated as \"MassGIS (Bureau of Geographic Information), Commonwealth of Massachusetts EOTSS\"."
+- **Post-2022 evidence (independently re-fetched)**: parsed the DCAT-US 1.1 feed (3,425 records) directly — record "Wards and Precincts (2022)": issued 2023-06-29, **modified 2024-02-21**, publisher "MA Secretary of the Commonwealth". Companion Feature Service record (id 6d4ae7efad4f4c77907db7cbfb012e64) also modified 2024-02-21.
+- **Caveats**: statewide = cities (wards+precincts) + towns (precincts only), one layer. The Feb-2024 modification is itself ~2.3 years old; no 2025/2026 statewide re-release found in the feed. Post-2022 test passes, but "current" here means 2022-plan vintage with 2024 corrections.
+
+#### MI — Michigan
+- **Portal**: Michigan Dept. of State, Bureau of Elections, via State of Michigan GIS Open Data (Center for Shared Solutions, DTMB)
+- **URL**: https://gis-michigan.opendata.arcgis.com/datasets/Michigan::2024-voting-precincts
+- **Format**: ArcGIS Hub Feature Service + shapefile/GeoJSON/CSV download
+- **Cadence**: per-even-year election cycle — live items for 2014, 2016, 2018, 2020, 2022, 2024, and 2026 confirmed under the same `michigan_admin` owner
+- **License (verbatim, leading text)**: "This dataset is a public record and, as more fully described below, there are no restrictions on the use, reproduction, or distribution of this dataset. Notwithstanding the foregoing, the public release of this dataset should not be construed, expressed or implied, as to whether any use constitutes a legally permissible purpose. It is the sole responsibility of the user to determine if the data is usable for their purposes. This dataset is provided \"AS IS\" and on an \"AS AVAILABLE\" basis. The State of Michigan (\"State\") makes no warranties, express or implied, regarding the accuracy, adequacy, reliability, timeliness, or completeness of this dataset..." (attribution: "Michigan Department of State; Bureau of Elections. Center for Shared Solutions, Department of Technology, Management, and Budget, State of Michigan")
+- **Post-2022 evidence (independently re-fetched, WITH CORRECTION)**: the hunter's cited item id was actually the "2026 Voting Precincts" item flagged `deprecated`. The true "2024 Voting Precincts" item is **02d40893317d46569017beeb14f9c63e**: created 2024-09-11, modified 2026-04-13, contentStatus active. A live, non-deprecated 2026 item also exists — the 2024 vintage is not the newest cycle.
+- **Caveats**: publisher-acknowledged: "validation done by most, but not all jurisdictions"; "the data set is only as good as the information received from the local election official." Ingest should target the newest active cycle item at fetch time, not a pinned year.
+
+#### MT — Montana
+- **Portal**: Montana State Library (MSL) — MSDI Administrative Boundaries Framework, with the MT Secretary of State
+- **URL**: https://msl.mt.gov/geoinfo/msdi/administrative_boundaries/ · files: https://ftpgeoinfo.msl.mt.gov/Data/Spatial/MSDI/AdministrativeBoundaries/MontanaVotingPrecincts.zip (+ `_shp.zip`) · service: https://gisservice.mt.gov/arcgis/rest/services/msdi_administrative_boundaries_map_v1/MapServer/10
+- **Format**: File geodatabase (.zip) + shapefile (`_shp.zip`) + live ArcGIS MapServer layer (id 10, "Voting Precincts")
+- **Cadence**: "As needed" (metadata update field); status In work/Complete
+- **License (verbatim, verified against live FGDC XML)**: "The Montana State Library Geographic Information Services provides this product/service for informational purposes only. The Library did not produce it for, nor is it suitable for legal, engineering, or surveying purposes. Consumers of this information should review or consult the primary data and information sources to ascertain the viability of the information for their purposes. The Library provides these data in good faith but does not represent or warrant its accuracy, adequacy, or completeness... The Library reserves the right to change or revise published data and/or services at any time." Access Constraints: None; Use Constraints: as quoted.
+- **Post-2022 evidence (independently re-fetched)**: FTP listing shows .xml/.zip/_shp.zip all Last-Modified **5/21/2026**; XML Publication Date 20260506; live MapServer/10 description: "updated as part of redistricting in 2023. Thirty-four (34 counties) of the fifty-six (56) counties were updated," citing MCA 13-3-101/102.
+- **Caveats**: none material — every element (scope, license, update, live endpoint) independently reproduced.
+
+#### NH — New Hampshire
+- **Portal**: NH GRANIT (UNH Earth Systems Research Center) — statewide clearinghouse; "New Hampshire Political Districts (Voting Wards)"
+- **URL**: https://new-hampshire-geodata-portal-1-nhgranit.hub.arcgis.com/datasets/NHGRANIT::new-hampshire-political-districts-voting-wards/about · direct: https://ftp.granit.unh.edu/GRANIT_Data/Vector_Data/Administrative_and_Political_Boundaries/d-nhpolitdists/2022/NHPolitDists2022.zip
+- **Format**: shapefile (zipped, 1.2–1.3 MB, confirmed downloadable) + hosted Feature Service referenced in metadata
+- **Cadence**: `<update>As needed</update>` (status Complete) — irregular; no vintage newer than /2022/ exists in the parent directory
+- **License (verbatim, from FGDC metadata XML, independently fetched)**: `<accconst>None</accconst>` and `<useconst>None</useconst>`
+- **Post-2022 evidence (independently re-fetched)**: FTP /2022/ files Last-Modified 2023-06-07 through 2023-06-13; FGDC `<pubdate>20230608</pubdate>`, time period 20220908–20230608 (ward data current through Sept 2022, published June 2023 — genuinely post-2022). 327 polygons; fields FIPS/NAME/COUNTY/DISTRICT; credited to "NH Office of Planning and Development, 2022".
+- **Caveats**: the hunter's AGOL-Hub "modified 2025-05-11" sub-claim could not be re-verified (JS-only Hub page); CONFIRMED rests on the FTP/XML evidence. Effective cadence is per-redistricting — set staleness expectations accordingly.
+
+#### NM — New Mexico
+- **Portal**: NM Secretary of State (statutory clearinghouse under SB304/2021), operated by UNM Earth Data Analysis Center (EDAC) / RGIS
+- **URL**: https://www.sos.nm.gov/voting-and-elections/data-and-maps/gis-voting-district-data/ → https://gstore.unm.edu/apps/rgis/datasets/3b1de40a-b37e-4d35-abdd-fd40bbbbe39e/metadata/ISO-19115:2003.html
+- **Format**: ZIP / ESRI Shapefile / GML / KML / GeoJSON / JSON / CSV / MS Excel (per Transfer Options on the metadata record)
+- **Cadence**: "Maintenance and Update Frequency: As needed" — county-update-triggered
+- **License (verbatim, both texts independently confirmed on fetch)**: (1) SOS page: "Users may download the data available from the voting district data clearinghouse for free." (2) EDAC Use Constraints: "Although these data have been processed successfully on a computer system at EDAC, no warranty expressed or implied is made by the EDAC regarding the use of the data on any other system, nor does the act of distribution constitute any such warranty." Access Constraints: "None".
+- **Post-2022 evidence (independently re-fetched)**: EDAC metadata — title "New Mexico Voting Precincts July 2024", publication date 2024-07-03, abstract references the Hidalgo Precinct update. Statewide bbox confirmed (-109.05/-103.00/37.00/31.33); 1,939 precinct polygons. SB304 statutory basis confirmed on the SOS page itself.
+- **Caveats**: new vintages appear as new dataset UUIDs — change detection should watch the SOS clearinghouse page, not a pinned UUID.
+
+#### NY — New York
+- **Portal**: NYS GIS Clearinghouse / NYS ITS Geospatial Services, sourced from NYS Board of Elections + county/NYC BOEs
+- **URL**: https://data.gis.ny.gov/datasets/election-districts · service: https://services6.arcgis.com/EbVsqZ18sv1kVJ3k/arcgis/rest/services/NYS_Elections_Districts_and_Polling_Locations/FeatureServer (Election Districts layer; item 23a056702cfd40848deef9597945a998)
+- **Format**: hosted ArcGIS Feature Service, exportable shapefile/GeoJSON/CSV/FGDB/KML/Excel/SQLite/GeoPackage
+- **Cadence**: rolling/irregular
+- **License (verbatim, from item JSON licenseInfo — exact match)**: "The State of New York, acting through the New York State Office of Information Technology Services, makes no representations or warranties, express or implied, with respect to the use of or reliance on the Data provided. The User accepts the Data provided 'as is' with no guarantees that it is error free, complete, accurate, current or fit for any particular purpose and assumes all risks associated with its use. The State disclaims any responsibility or legal liability to Users for damages of any kind, relating to the providing of the Data or the use of it. Users should be aware that temporal changes may have occurred since this Data was created."
+- **Post-2022 evidence (independently re-fetched)**: item created epoch 1729618951000 = 2024-10-22, modified epoch 1781652183000 = **2026-06-16**; description states "as of June 2026" for polling data. Statewide extent [-79.997,40.405]–[-71.650,45.023]. Election-district (precinct-equivalent) granularity confirmed, not just legislative districts.
+
+#### NC — North Carolina
+- **Portal**: NC State Board of Elections (NCSBE), public S3 bucket dl.ncsbe.gov; mirrored on NC OneMap (CGIA / NC DIT)
+- **URL**: https://dl.ncsbe.gov/?prefix=ShapeFiles/Precinct/ · mirror: https://www.nconemap.gov/datasets/nconemap::voting-precincts/about (item 771ae6473a1c4ba3bc768cc2c4b10015)
+- **Format**: ESRI shapefile (.zip) on S3 (live-confirmed via S3 REST API); ArcGIS Feature/Map Service with standard exports
+- **Cadence**: irregular/as-needed tied to election cycles — full release history enumerated back to 2012 (…20220729, 20220831, 20231220, 20240723, 20250225, 20250728, 20251212) — roughly 2–4×/year recently
+- **License**: not stated as extractable dataset-specific text — independently confirmed the NC OneMap terms page is a client-rendered SPA; only the licenseInfo *pointer* (https://www.nconemap.gov/pages/terms) exists in item JSON. Flag for human license review before signed republication.
+- **Post-2022 evidence (independently re-fetched)**: direct S3 list-type=2 query — `SBE_PRECINCTS_20251212.zip` LastModified **2026-01-12T16:21:54Z** is the current latest statewide vintage (verified by enumerating the entire history, not cherry-picking). OneMap item modified epoch 1754576431000 = 2025-08-07. Item description verbatim: "It depicts voting precincts for all 100 counties in NC."
+- **Caveats**: adjacent VTD/, LegislativeDistricts/, CountyBoundary/ prefixes confirm an ongoing elections-data operation. Cheapest change-detection endpoint in the whole lane (plain S3 listing).
+
+#### ND — North Dakota
+- **Portal**: North Dakota Secretary of State, Elections Division
+- **URL**: https://www.sos.nd.gov/elections/election-resources · download: https://www.sos.nd.gov/sites/default/files/documents/elections/map-shape-files/voting-shape-files-2026.zip
+- **Format**: ZIP containing an Esri File Geodatabase + Excel companion (content-type application/zip, 1.83 MB, HEAD-confirmed)
+- **Cadence**: per-election-cycle/irregular; file named for the "2026 election cycle" — sub-annual cadence not established
+- **License**: not stated — independently confirmed via direct curl: no license/terms text accompanies the download; only usage instructions: "These files require a shapefile viewing tool to open. If you have this software, use the files to find a precinct from the map and match it up to the corresponding record in the Excel document."
+- **Post-2022 evidence (independently re-fetched)**: HTTP HEAD on the live download — `last-modified: Tue, 31 Mar 2026 14:56:29 GMT`; page text: "2026 North Dakota precinct GIS maps and Excel file (zip file)" / "Statewide Polling Places & Precincts (2026 Primary Election)".
+- **Caveats**: internal GDB timestamps not inspected (binary tooling out of scope for the pass); license absent — flag for review.
+
+#### RI — Rhode Island
+- **Portal**: RIGIS (Rhode Island Geographic Information System), compiled for the RI Dept. of State Elections Division
+- **URL**: https://www.rigis.org/datasets/edc::voting-precincts-2022/about (item 9104ca2e5e9b4cdb9985e8935ef2514d)
+- **Format**: Esri hosted feature layer, RI State Plane Feet NAD83(2011); 416 features (confirmed via direct `returnCountOnly` query)
+- **Cadence**: per-redistricting-cycle base layer (valid "in or after 2022" through 2032) with real ad-hoc edits within the cycle
+- **License (verbatim)**: "This dataset is provided 'as is.' The producer(s) of this dataset, contributors to this dataset, the Rhode Island Geographic Information System (RIGIS) consortium, the State of Rhode Island, and the University of Rhode Island do not make any warranties of any kind for this dataset and are not liable for any loss or damage however and whenever caused by any use of this dataset. Please acknowledge both RIGIS and the primary producer(s) of this dataset in any derived products. Versions of the RIGIS logo suitable for both printed and web-based products are available at https://info.rigis.org/pages/logos. This dataset should be used to map elections held in or after 2022. While the precinct numbers may be similar as in elections from 2021 or early, redistricting in 2022 shifted precinct boundaries. To map elections from 2011 through 2021 use the Voting Precinct 2016 file found on RIGIS."
+- **Post-2022 evidence (independently re-fetched, stronger than the original citation)**: bypassed the JS-only Hub page and hit the REST item API directly — item modified epoch 1736180289000 = **2025-01-06** (created 2023-11-27); layer `editingInfo.lastEditDate` epoch 1726084871267 = **2024-09-11**. Both directly-observed post-2022 edit timestamps from the authoritative service.
+- **Caveats**: the hunter's "Access Constraints: None" phrase was not found on the item JSON (likely from an unlocated FGDC XML) — dropped from this record.
+
+#### SC — South Carolina
+- **Portal**: SC Revenue and Fiscal Affairs Office (RFA) — Political GIS Data / Precinct Demographics & Redistricting
+- **URL**: https://rfa.sc.gov/programs-services/precinct-demographics/jurisdictional-mapping/political-gis-data
+- **Format**: Esri shapefile (statewide, 13,275,292 bytes verified) + KMZ, NAD 1983(2011) State Plane SC feet; DBF header reports **2,310** precinct records statewide; full SC State Plane extent confirmed
+- **Cadence**: irregular/as-needed re-issuance under a running "Effective" date label; NOT literally annual — internal process log shows edit bursts (Nov 2023, Jan–Jun 2024, Nov 2024, Jan 2025)
+- **License**: not stated on the dataset page — full page text searched for license/terms/disclaimer/copyright/use-constraint; only a generic nav "Privacy and Disclaimers" link. Flag for review.
+- **Post-2022 evidence (independently re-fetched, with corrections)**: live rfa.sc.gov times out from datacenter tooling; the verifier pulled the Wayback CDX list (46 captures) and fetched the most recent snapshot (2025-06-03): "SC Voting Precinct Files" / "Statewide Precinct Shapefile (zip 13 MB)" / "SC Voting Precincts Shapefile Effective 1/1/2025" — then **downloaded and unzipped the actual 13.3 MB shapefile** and extracted all 672 dated lineage Process entries, finding genuine edits through 2024-11-18, 2025-01-02, 2025-01-09. **Corrections**: internal file is `SC_VoterPrecincts.shp` (not "2025Precincts.shp"), zip-entry timestamp Jan 10 2025 (not Aug 2025), metadata CreaDate 20230515. The hunter's lineage-chain narrative was embellished; the update-cadence conclusion stands on the verifier's own binary inspection.
+- **Caveats**: RFA-as-statewide-maintainer attribution is plausible but was not independently re-verified (legislative-oversight presentation unreachable). Live-site WAF/timeout means probes need a browser-grade fallback.
+
+#### TX — Texas
+- **Portal**: Texas Legislative Council — Capitol Data Portal
+- **URL**: https://data.capitol.texas.gov/dataset/vtds
+- **Format**: shapefile (.shp in .zip)
+- **Cadence**: per-election-cycle — a new VTD vintage per primary/general (2022 and 2024 vintages both present; historical vintages retained)
+- **License (CORRECTED — stronger than originally reported)**: the CKAN dataset page has a dedicated License module reading exactly: "Creative Commons Attribution" (linked to opendefinition.org/licenses/cc-by, i.e. **CC-BY**). Per-dataset license field, not a site-wide disclaimer.
+- **Post-2022 evidence (independently re-fetched via Wayback snapshot 20260106081212, HTTP 200 — live host Cloudflare-blocks automated fetch)**: resource list confirms `VTDs_24PG.zip` (SHP, "2024 Primary & General Elections VTDs Shapefile"), `VTDs_24PG_Pop.zip`, RED605 population PDF/XLS, plus prior `VTDs_22G.zip` / `VTDs_22P.zip`. Page states "There are 9,712 VTDs in the 2024 primary & general elections VTDs shapefile."
+- **Caveats**: Cloudflare 403 on automated fetch (both WebFetch and curl w/ browser UA) — probe design must treat WAF 403 as reachability-unknown, not source-death; the CKAN API endpoint is the better probe target.
+
+#### UT — Utah
+- **Portal**: Utah UGRC (Utah Geospatial Resource Center) — VISTA Ballot Areas, State Geographic Information Database (SGID)
+- **URL**: https://gis.utah.gov/products/sgid/political/voter-precincts/ (AGOL item d33f596419d74948a45070275632b8e0)
+- **Format**: ArcGIS FeatureServer (+ shapefile/FGDB downloads per SGID conventions)
+- **Cadence**: rolling/as-needed — county clerks submit updates as annexations and precinct/subprecinct changes occur
+- **License (verbatim, agreed by two independent channels — raw item JSON + product page)**: "The data, including but not limited to geographic data, tabular data, and analytical data, are provided \"as is\" and \"as available\", with no guarantees relating to the availability, completeness, or accuracy of data, and without any express or implied warranties. These data are provided as a public service for informational purposes only. You are solely responsible for obtaining the proper evaluation of a location and associated data by a qualified professional. UGRC reserves the right to change, revise, suspend or discontinue published data and services without notice at any time. Neither UGRC nor the State of Utah are responsible for any misuse or misrepresentation of the data. UGRC and the State of Utah are not obligated to provide you with any maintenance or support. The user assumes the entire risk as to the quality and performance of the data. You agree to hold the State of Utah harmless for any claims, liability, costs, and damages relating to your use of the data. You agree that your sole remedy for any dissatisfaction or claims is to discontinue use of the data. This work is licensed under a Creative Commons Attribution 4.0 International License." (**CC-BY-4.0**)
+- **Post-2022 evidence (independently re-fetched)**: item modified epoch 1783084331000 = **2026-04-03**; version-history dates corroborated (2026-04-03, 2025-09-16, 2025-04-25, 2025-04-01, 2025-01-15, 2024-12-19, 2024-01-12, plus older). "All 29 counties in Utah" — full statewide coverage.
+- **Caveats**: item description's "Current as of 1/31/2022" refers to the political-district redraw, not the precinct layer's maintenance — cite the modified/version-history dates.
+
+#### VT — Vermont
+- **Portal**: Vermont Center for Geographic Information (VCGI) + VT Secretary of State — Vermont Open Geodata Portal
+- **URL**: https://geodata.vermont.gov/datasets/VCGI::vt-data-vermont-municipal-voting-districts/about (item fae5aad934a74108812dbe8ecd6232d4)
+- **Format**: ArcGIS FeatureServer (+ shapefile/GeoJSON/CSV/KML downloads via the portal)
+- **Cadence**: irregular — updated when municipalities redraw wards/districts; this vintage tied to the 2022 redistricting cycle, released for Town Meeting Day 2023
+- **License (verbatim)**: "VCGI and the State of Vermont make no representations of any kind, including but not limited to the warranties of merchantability or fitness for a particular use, nor are any such warranties to be implied with respect to the data."
+- **Post-2022 evidence (independently re-fetched)**: raw item JSON — modified epoch 1687964393000 = 2023-06-28, description verbatim: "Statewide layer of municipal (local) election voting districts (wards) in Vermont. Compiled by VCGI using best available information from Vermont Municipalities and the Vermont Secretary of State. Current as of June 2023."
+- **Caveats**: "current as of June 2023" is now ~3 years old — still the most recent state-published vintage, legitimately post-2022-redistricting. 9 named unincorporated gores/grants documentedly excluded (no municipal government). Front-end page didn't render for the verifier; the item JSON (authoritative) matched the hunter character-for-character.
+
+#### WA — Washington
+- **Portal**: WA Geospatial Open Data Portal (geo.wa.gov), data from WA Office of the Secretary of State; mirrored as direct ZIPs on sos.wa.gov
+- **URL**: https://geo.wa.gov/datasets/wa-geoservices::statewide-precincts/about · service: https://services.arcgis.com/jsIt88o09Q0r1j8h/arcgis/rest/services/Statewide_Precincts_2019General_SPS/FeatureServer · https://www.sos.wa.gov/elections/data-research/election-data-and-maps/reports-data-and-statistics/precinct-shapefiles
+- **Format**: ArcGIS Feature Service (single statewide layer, **8,208 records** confirmed via live query) with csv/shapefile/sqlite/geoPackage/filegdb/geojson/kml/excel exports; plus yearly statewide ZIP (shapefile) downloads back to 2004
+- **Cadence**: annual, per general election
+- **License (verbatim, exact match to item licenseInfo)**: "Provided as-is. Washington Office of the Secretary of State reserves the right to alter, suspend, re-host, or retire this service at any time and without notice. This service can be used in custom web applications and software products. Your use of this service in these types of tools forms a dependency on the service definition (available fields, layers, etc.) If you form any dependency on this service, be aware of a significant risk to your purposes. Consider mitigating your risk by extracting the source data and using it to host your own service in an environment under your control."
+- **Post-2022 evidence (independently re-fetched)**: item f5431071d8f74a7fb655bf0477ccfc2e — snippet "Voting precincts within the State of Washington as defined by the Office of the Secretary of State. December 2025.", modified epoch 1766076860000 = **2025-12-18**. sos.wa.gov page confirms `.../2025-11/Statewide_Precincts_2025General.zip` + `Statewide_Splits_2025General.zip` and the full year sequence.
+- **Caveats**: the license itself recommends extracting source data and self-hosting — exactly our ingest model. Note the service path retains a legacy "2019General" name.
+
+#### WI — Wisconsin (archetype)
+- **Portal**: Wisconsin Legislature — Legislative Technology Services Bureau (LTSB) GIS Hub
+- **URL**: item: https://www.arcgis.com/sharing/rest/content/items/1ed4da2e296e4ae687fd9d35baca57be ("WI Municipal Wards (2026)") · service: https://services1.arcgis.com/FDsAtKBk8Hy4cAH0/arcgis/rest/services/WI_Wards_Jan_2026/FeatureServer · hub: https://gis-ltsb.hub.arcgis.com/pages/download-data
+- **Format**: ArcGIS Feature Service (statewide, all counties/municipalities), shapefile/geojson/csv/sqlite/geoPackage/filegdb/kml/excel exports
+- **Cadence**: **semiannual, statutorily mandated** — Wis. Stat. 5.15(4)(br)1: county clerks transmit municipality/ward/supervisory-district boundaries to LTSB by January 15 and July 15 each year (census-year exception: March/October 15)
+- **License (verbatim, exact match to item licenseInfo)**: "This is open and publicly available data. Use this data at your own risk. The LTSB is not liable for any damages or errors that result in using this data."
+- **Post-2022 evidence (independently re-fetched)**: item + service JSON — "Wisconsin Municipal Wards collected in February 2026 through LTSB's GeoData Collector", created epoch 1772136755000 = 2026-02-26, modified 1773074566000 = 2026-03-09. Same org also hosts "WI Municipal Wards (Current)" (modified 2026-03-10) and a "Live Collection" web map modified epoch 1782917761000 = **2026-07-01** — updated within days of verification.
+- **Caveats**: none — strongest CONFIRMED in the survey; this is the archetype the lane is built around.
+
+#### DC — District of Columbia
+- **Portal**: Open Data DC (DC GIS / DC Office of Planning + DC Board of Elections)
+- **URL**: https://opendata.dc.gov/maps/DCGIS::voting-precinct (item 8d512fde2ba34212ad07e9579d55496f) · service: https://maps2.dcgis.dc.gov/dcgis/rest/services/DCGIS_DATA/Administrative_Other_Boundaries_WebMercator/MapServer/0 · wards: https://opendata.dc.gov/datasets/DCGIS::wards-from-2022/about
+- **Format**: ArcGIS FeatureServer/MapServer (live-queried), shapefile ZIP, GeoJSON, KML, CSV, OGC WMS
+- **Cadence**: precincts: irregular/event-driven — current layer delineated 2024, reloaded 2026-06-24; wards: decennial only
+- **License (verbatim, via live item JSON)**: current Voting Precinct layer: "Creative Commons Attribution 4.0 International License". Wards from 2022: "This work is licensed under a Creative Commons Attribution 4.0 International License." (**CC-BY-4.0**)
+- **Post-2022 evidence (independently re-fetched)**: live FeatureServer query returned features with CREATED=1782344505000 / EDITED=1782344816000 = **2026-06-24T23:41–23:46Z** — feature-level data-load evidence, not a metadata touch. Item created/modified 2026-06-30. `returnCountOnly` = **144** precincts covering the full District extent.
+- **Caveats**: **this row reverses the original hunter's verdict** — the hunter cited only the frozen "Voting Precinct 2019" layer and concluded DC had no live product because of the Vote Centers law (D.C. Law 24-342). The current "Voting Precinct" item is separate, BOE-attributed, and actively maintained; its own description acknowledges Vote Centers while confirming precincts persist as an administrative/reporting geography. "Statewide" = citywide (single jurisdiction).
+
+---
+
+### 2.2 PLAUSIBLE (4) — follow-up confirms required; BARRED from ingest until confirmed
+
+#### AK — Alaska
+- **Portal**: Alaska DCCED/DCRA Community Database Online on the State of Alaska Geoportal (gis.data.alaska.gov), precinct lines from the AK Division of Elections
+- **URL**: https://gis.data.alaska.gov/maps/DCCED::precincts/about · service: https://maps.commerce.alaska.gov/server/rest/services/Govt_Related/Govt_House_and_Senate_Districts/MapServer/4
+- **What IS independently confirmed**: statewide scope, publisher attribution, and post-2022 modification — geoportal search-API JSON shows createdDate 2023-02-06, modifiedDate **2024-11-12**, description "Part of Alaska Division of Elections Statewide Election Framework. Alaska Precincts based on 2022 Redistricting."; raw MapServer JSON confirms "Alaska election precinct boundaries… Sourced from the Alaska Division of Elections."
+- **Why not CONFIRMED**: the license/disclaimer full text and the shapefile-download claim rest solely on the hunter — the Hub about page is JS-only and returned no usable content on two fetch attempts. Layer copyrightText is just an attribution string ("SOA DCCED DCRA, SOA DE"), not a reuse license.
+- **To confirm**: human-browser read of the Hub about/download page for license + export options. (elections.alaska.gov remains WAF-blocked.)
+
+#### DE — Delaware
+- **Portal**: Delaware FirstMap / Dept. of Elections GIS
+- **URL**: https://enterprise.firstmap.delaware.gov/arcgis/rest/services/Boundaries/DE_Political_Boundaries/FeatureServer/0
+- **What IS independently confirmed**: the parent FeatureServer's own description states "Election district boundaries were most recently revised in November 2023" — first-party, on-page post-2022 evidence. Statewide scope and state-agency hosting are solid.
+- **Why not CONFIRMED**: (1) **no license text exists anywhere found** — only a Copyright credit ("The Delaware General Assembly & Department of Elections"); FirstMap has no terms page (/terms 404s). (2) **Identity question**: Delaware's own elections maps page lists "Election Districts" (RD-ED) and never uses the word "precinct" — RD-ED reads as a legislative-sub-district building block; equivalence to a polling-place precinct/ward unit is unverified and in active tension with the state's own terminology.
+- **To confirm**: license determination + a definitional answer (from DE Dept. of Elections) on whether RD-EDs are the precinct-equivalent civic unit.
+
+#### LA — Louisiana
+- **Portal**: Louisiana Legislature redistricting site (redist.legis.la.gov)
+- **URL**: https://redist.legis.la.gov/default_ShapeFiles2020
+- **What IS independently corroborated (search-level only)**: a second independent search pass surfaced "2026 Precinct Shapefile has been updated to reflect precinct changes submitted to the Legislature as of January 27, 2026" (spring cycle, parish submissions under R.S. 18:532/532.1); semiannual spring/fall cadence.
+- **Why not CONFIRMED**: *.la.gov is DNS-blocked from the verification environment (SERVFAIL on redist.legis.la.gov, www.legis.la.gov, house.louisiana.gov — resolver-level, not a dead site). Nobody on this pass has personally seen the page; license text unverified (generic Legislature disclaimer known from snippets only).
+- **To confirm**: fetch from an unblocked network; capture license text + the dated shapefile listing. Likely the strongest PLAUSIBLE — semiannual cadence would rank it beside WI.
+
+#### MN — Minnesota
+- **Portal**: MN Secretary of State (Elections Division) via MN Geospatial Commons (gisdata.mn.gov)
+- **URL**: https://gisdata.mn.gov/dataset/bdry-votingdistricts
+- **What happened**: both the hunter and the verifier independently hit the Radware bot-management wall across the mn.gov domain family (WebFetch 303-redirected to a generic IT-services page; curl with browser UA returned the "Unusual Activity" interstitial). Nothing — scope, license, vintage — could be personally observed.
+- **Why not CONFIRMED**: access barrier, not a debunking. Format/cadence claims are search-snippet-only.
+- **To confirm**: human browser session (or unblocked network) against the Geospatial Commons dataset page / CKAN API.
+
+---
+
+### 2.3 NONE (24) — no statewide, openly published, between-census-updated file
+
+For each: what was checked, why NONE, and the re-verification status from the adversarial pass.
+
+- **AL** — SOS election-data page fetched directly via curl: only Voter Registration Statistics PDFs (2002–2026) and precinct-level election RESULTS tables; grep for shapefile/GIS/.shp/geojson/"precinct boundar"/"ward boundar" across the full HTML: zero substantive hits. **NONE upheld, independently spot-checked.**
+- **AZ** — No statewide product found at SOS or the Independent Redistricting Commission; irc.az.gov/gis-data returns 403 (consistent with the hunter's blocked access). IRC's statutory mandate is congressional/legislative maps, not precincts. County-by-county (Maricopa, Pima, Pinal) not re-checked — not required to overturn. **NONE upheld.**
+- **CO** — Colorado Geospatial Portal / State Demography Office / SOS: no statewide precinct product; the "Voting Districts" layer is decennial Census TIGER pass-through, not CO-authored; county precinct GIS (Douglas, Boulder, Fremont) with no state aggregator. **Not independently re-fetched this pass (no candidate URL existed); internally consistent with CO's county-administered structure — flagged as not independently fetched.**
+- **CT** — OPM GIS/DAPA + UConn MAGIC: only decennial 2010 Census VTD on MAGIC; OPM publishes redistricting maps, not precincts; 169 towns each administer their own districts. **Not independently re-fetched (no URL to check); flagged as such.**
+- **FL** — dos.fl.gov precinct-level data is election RESULTS (tabular), not boundary GIS; FGDL/geodata.floridagio.gov carry no state-authored precinct layer; 67 county Supervisors of Elections; statute requires notification to the Secretary of State, not GIS delivery. **Not independently re-fetched (GA was this batch's designated spot-check); flagged as such.**
+- **GA** — Spot-check attempted on all three primary sources: data-hub.gio.georgia.gov (JS shell, no content), sos.ga.gov/election-data-hub (403), legis.ga.gov reapportionment (JS shell). Inconclusive but nothing surfaced contradicting NONE; statewide boundary compilation exists only via third parties (VEST/RDH/ARC). 159 counties / 3,000+ precincts, county stewardship. **NONE left unchanged.**
+- **IL** — **Independently confirmed via curl** (WebFetch was Cloudflare-403'd; direct GET returns the plain IIS directory listing): elections.il.gov/precinctmaps/ = per-county PDF folders. **Correction to the hunter**: post-2022 activity exists (Cook County folder 12/10/2024 with per-township PDF packages dated 12/5/2024; DuPage 7/20/2023) — but it is PDF-only, per-county/per-township, no statewide GIS. elections.il.gov/shape/ carries only legislative/congressional shapefiles, no precinct layer of any vintage. **NONE upheld (grounds corrected).**
+- **KS** — hub.kansasgis.org "Voting Districts" (KLRD): substantive content "Current as of 2022"; KLRD does not maintain precincts between censuses (next cycle 2028). Catalog "modified 2026-05-06" is a re-index, not a data update. **Re-check inconclusive this pass (Hub page is a JS shell; needs REST JSON fetch) — verdict stands on the fails-the-between-census-test finding.**
+- **KY** — **Independently re-confirmed**: LRC GIS-Data page returns 403 (matches hunter); opengisdata.ky.gov JS-rendered; independent search surfaces only county-level sources (Jefferson/LOJIC, Lexington). **NONE confirmed.**
+- **ME** — **Independently re-verified via the ArcGIS sharing REST JSON** (item e9304363e34e4425b784360f14d435e5): "Maine Voting Districts" is 2021 legislative/congressional/county-commissioner redistricting seats + town boundaries + census blocks — wrong data type, not precincts/wards. License field verbatim re-verified: "Access: Public. Use: User assumes risk." Minor correction: modified 2025-03-27 (hunter said 2024) — verdict unaffected. Ward/precinct administration is town-clerk-level with no state standardization. **NONE confirmed.**
+- **MS** — **Independently fetched** maris.mississippi.edu UpdatedVotingPrecincts page: exactly 13 of 82 counties, files `<COUNTY>_Precincts_2023.zip`, "Current Data: 2023", sourced from "Golden Triangle PDD and other individual counties"; no statewide file mentioned. sos.ms.gov 403-blocked (referral-text sub-claim unverified; immaterial). **NONE confirmed.**
+- **MO** — **Independently verified twice**: sos.mo.gov/elections/maps offers only State Senate + State House PDF maps (WebFetch succeeded before a later curl hit the WAF); msdis.missouri.edu mapdata index fetched (200), grepped for precinct/voting district: zero matches. County/city layers (St. Louis City/County, Jackson) per hunter, not re-verified. **NONE confirmed.**
+- **NE** — sos.nebraska.gov / nebraskamap.gov DNS-failed from the tool; corroborated via search: SOS hosts 2020-census redistricting maps (congressional/legislative), not precincts. Independent third-party confirmation: MGGG's NE-shapefiles repo had to hand-stitch precincts from NebraskaMAP + county officials, and even that is 2018-vintage. Counties (Cass, Lancaster, Sarpy) publish independently. **NONE stands, third-party-corroborated.**
+- **NV** — SOS county-precinct-maps page is the statutory collection point (NRS 293.206, biennial March-31 even-year submissions) but republishes a per-county PDF index, no merged statewide GIS. Direct fetch 403; curl returned a live Imperva/Incapsula interstitial (read in raw HTML). Snippets vaguely reference an "interactive GIS-based map" that could not be substantiated as a downloadable statewide dataset — flagged unresolved, not contradicting. **NONE kept (confidence downgraded by the access wall, not the finding).**
+- **NJ** — **Independently re-confirmed from primary-source JSON**: NJOGIS statewide "Election Districts" + "Ward Boundaries" items are both "MATURE SUPPORT… no longer updated. Available for historical reference only" (2018–2023 Election Security Initiative products); Dec-2024 modified timestamps are metadata touches. ArcGIS API search restricted to owner:NJOGIS returns exactly these two frozen items, no successor ("Voting Districts - 2024" search hit was a listing artifact). Current data is county/municipal only. Full licenseInfo captured (as-is/no-warranty/no-duty-to-update). **NONE fully reconfirmed.**
+- **OH** — No state product; precinct-setting is a county statutory duty (ORC 3501.05). ohiosos.gov Cloudflare-403s automated fetch (consistent with bot protection, not fabrication). **Independently verified via GitHub API**: mggg/ohio-precincts — "Shapefile of voting precincts in Ohio (as of 2016)", pushed_at 2019-11-14 — the only statewide stitch-together is stale academic work. **NONE corroborated.**
+- **OK** — **Independently fetched the live okmaps.org item (200 OK)**: metadata Date = 2022-01-01, "2020 Voter Precincts", statewide merged from all 77 counties; license lines verified verbatim ("This data is for general public use." / "Data is free. Some fees may apply to offline requests to cover reproduction costs."). Genuinely statewide and free — **fails the post-2022-update test**; no re-issuance found. **NONE confirmed.**
+- **OR** — **Independently reproduced exactly**: data.oregon.gov r7vb-b9k4 JSON API returns only county/precinct/split/district_code fields — zero geometry; a pure precinct-to-district crosswalk table. **NONE confirmed.**
+- **PA** — Live redistricting.state.pa.us refused connections (matches hunter). **Verified via Wayback CDX**: fetched the most recent snapshot (2026-04-11) — still the static one-time 2021 Census-VTD-correction shapefile product; no 2022+ release in any snapshot through April 2026. Checked 8+ months past the hunter's window; unchanged. **NONE confirmed and strengthened.**
+- **SD** — **Independently re-queried the AGOL REST search API**: all SD precinct items are county/city-owned (Sioux Falls, Fall River, Natrona-style county accounts) or off-topic; no state-agency item. SOS elections path tried returned 404 (no GIS download page). **NONE confirmed.**
+- **TN** — **Independently fetched the live Comptroller page**: four per-county product categories only (Land Use, County District Maps, Parcel Data, County Indices); no statewide precinct file; custom-data contact only. **NONE re-verified.**
+- **VA** — **Independently re-verified by direct fetch**: elections.virginia.gov GIS page = per-locality ZIPs only, all 134 counties/independent cities listed separately; "as current as possible" rolling per-locality language; no combined statewide file. Cross-checked VGIN (200 OK) + AGOL search + data.virginia.gov CKAN: no statewide VA precinct item from any state authority. **NONE upheld.**
+- **WV** — **Independently re-ran AGOL search**: 21 results, all county-specific (Jefferson, Marion) or generic redistricting-review layers; nothing owned by WVGISTC/mapwv/SOS statewide. **NONE upheld.**
+- **WY** — **Independently re-ran AGOL search**: 3 results, all county-owned (Sheridan, Carbon, Natrona); no SOS or Geospatial-Hub statewide layer; state directs users to counties / voter lookup tool. **NONE upheld.**
+
+### 2.4 UNSWEPT (0)
+
+None. All 51 jurisdictions were swept and dispositioned above. (Agent-loss count from the hunt: 0.)
+
+---
+
+## 3. Proposed overlay ingest wave — CONFIRMED rows only
+
+Ranked by 2020 Census resident population covered. **PLAUSIBLE rows (AK, DE, LA, MN)
+are explicitly barred from this list** — they are follow-up confirms (see §2.2); if all
+four confirm they would add ≈12.1M people (~3.6%).
+
+License gate legend — **clear**: explicit open/attribution license or "no
+restrictions" text observed; **review**: no license text observed (or not
+page-verified) → human license review before *signed republication* (attribution-only
+serving may still be fine; counsel call, per the same rule as county terms in §5).
+
+| # | State | 2020 pop | Source | License gate | Notes |
+|---|---|---:|---|---|---|
+| 1 | CA | 39,538,223 | UC Berkeley SWDB | **review** | No reuse license beyond UC Regents copyright — get rights confirmation from SWDB first. Largest single prize in the lane. |
+| 2 | TX | 29,145,505 | TX Legislative Council | clear (CC-BY) | WAF blocks automated fetch — ingest via CKAN API/mirror path. |
+| 3 | NY | 20,201,249 | NYS ITS / BOE | clear (as-is disclaimer, no use restriction) | Rolling; includes NYC. |
+| 4 | NC | 10,439,388 | NCSBE S3 bucket | **review** (terms page is JS-only) | Cheapest change detection (S3 listing). |
+| 5 | MI | 10,077,331 | MI BOE / DTMB | clear ("no restrictions on the use, reproduction, or distribution") | Ingest newest active cycle item, not a pinned year. |
+| 6 | WA | 7,705,281 | WA SOS | clear (as-is; explicitly invites self-hosting) | Annual vintages + Dec-2025 service. |
+| 7 | MA | 7,029,917 | MassGIS | clear ("may be used by anyone"; credit required) | 2022 plans + 2024 corrections. |
+| 8 | IN | 6,785,528 | IN GIO | clear (as-is disclaimer) | Annual series; 5,126 districts. |
+| 9 | MD | 6,177,224 | MD iMap / SBOE | **review** (disclaimer corroborated, not page-verified) | Howard Co. lags at 2022 — per-county vintage in provenance. |
+| 10 | WI | 5,893,718 | WI LTSB | clear ("open and publicly available") | Archetype; statutory semiannual. |
+| 11 | SC | 5,118,425 | SC RFA | **review** (no license text on page) | WAF/timeouts — needs resilient fetch path. |
+| 12 | UT | 3,271,616 | UGRC | clear (CC-BY-4.0) | Rolling, well-versioned. |
+| 13 | IA | 3,190,369 | IA SOS / LSA | **review** (licenseInfo null) | Decennial-plus-corrections — provenance must not imply annual currency. |
+| 14 | AR | 3,011,524 | AR GIS Office | clear ("no access and use limitations") | Highest churn — rolling county updates. |
+| 15 | NM | 2,117,522 | NM SOS / UNM EDAC | clear (free download; no access constraints) | New vintages = new UUIDs; watch the SOS page. |
+| 16 | ID | 1,839,106 | ID SOS / ITS | clear (as-is disclaimer; public_authoritative) | Courtesy-confirm the "DO_NOT_SHARE" service name. |
+| 17 | HI | 1,455,271 | HI Statewide GIS / OOE | clear (public domain per GIS program page) | 250 precincts; per-cycle layers. |
+| 18 | NH | 1,377,529 | NH GRANIT | clear (access/use constraints: None) | Effectively per-redistricting cadence. |
+| 19 | RI | 1,097,379 | RIGIS | clear (as-is; acknowledge RIGIS + producers) | 2022 base + real ad-hoc edits. |
+| 20 | MT | 1,084,225 | MT State Library | clear (access: none; informational-use disclaimer) | FGDB+shp on FTP; May-2026 publication. |
+| 21 | ND | 779,094 | ND SOS | **review** (no license text) | Per-cycle ZIP (FGDB). |
+| 22 | DC | 689,545 | Open Data DC | clear (CC-BY-4.0) | 144 precincts; June-2026 reload. |
+| 23 | VT | 643,077 | VCGI / SOS | clear (no-warranty disclaimer, no use restriction) | June-2023 vintage — oldest CONFIRMED; provenance must say so. |
+
+**Total: 168,668,046 people (50.9% of the 2020 resident population of 331,449,281).**
+
+Suggested tranching within the wave: start with the **clear-license, machine-friendly
+REST/S3 sources** (TX via API path, NY, MI, WA, MA, IN, WI, UT, AR, HI, RI, MT, DC —
+then NM, ID, NH, VT, ND after its license check), run the **license-review five** (CA,
+NC, MD, SC, IA + ND) in parallel as a legal/ops task, and land CA the moment SWDB
+confirms rights — it alone is 23% of the lane's population.
+
+---
+
+## 4. Source-registry rows (P14 `SOURCE_REGISTRY` additions)
+
+One row per CONFIRMED source, following `SourceHealthConfig` in
+`SELF-HEALING-DATA-OPS.md` §Source registry. Common fields for all rows:
+`class: 'boundary-geometry'`, `retryBudget: 6`, `ownerSlots: '21'` (precinct/VTD
+overlay slot; the overlay never owns the baseline slots). `configSite` is assigned when
+the overlay ingest config lands (P17-style wave). **Rows enter `SOURCE_REGISTRY` with
+their ingest tranche** — registering un-ingested sources would page on data we don't
+serve yet.
+
+`expectedIntervalDays` is derived from the REAL observed cadence (§2.1), with slack so
+the staleness breach fires on genuine silence, not on normal jitter. No cadence below
+is invented; where a source is decennial-plus-corrections, the interval says so
+honestly rather than pretending currency.
+
+| id | probe/fetch target | expectedIntervalDays | freshness | lane | probe method | cadence basis |
+|---|---|---:|---|---|---|---|
+| `precinct-ar` | AR FeatureServer/11 (checksum) | 90 | rolling | **fetch** | — | county updates land ~monthly; silence past a quarter is anomalous |
+| `precinct-ca` | statewidedatabase.org/election.html | 400 | vintage | probe | conditional-get | ≥1 statewide release/election year |
+| `precinct-hi` | geodata.hawaii.gov AdminBnd/MapServer/13 `?f=pjson` | 780 | vintage | probe | get | biennial (per general election) |
+| `precinct-id` | AGOL item 0b4fbe4f…21705 `?f=json` | 780 | vintage | probe | get | biennial, statutory even-year updates |
+| `precinct-in` | gisdata.in.gov Voting_District_Boundaries_{yyyy} service root | 400 | vintage | probe | get + nextVintage template `Voting_District_Boundaries_{yyyy}` | annual series (2020/2023/2024… editions) |
+| `precinct-ia` | AGOL item d394edea…532f `?f=json` | 3650 | vintage | probe | get | decennial reprecincting + opportunistic corrections — honest interval, probe still daily |
+| `precinct-md` | MD_ElectionBoundaries FeatureServer/2 `?f=pjson` | 400 | rolling | probe | get | annual-ish SBOE re-collection (2025 collection → 2026-01 publish) |
+| `precinct-ma` | AGOL item 6d4ae7ef…2e64 `?f=json` (or DCAT record) | 730 | rolling | probe | get | irregular LEDRC-event-driven; last real change 2024-02 |
+| `precinct-mi` | AGOL search API `owner:michigan_admin title:"Voting Precincts"` | 780 | vintage | probe | get (search JSON; picks up new cycle items) | per-even-year cycle |
+| `precinct-mt` | ftpgeoinfo.msl.mt.gov MontanaVotingPrecincts.zip | 730 | rolling | probe | head (Last-Modified is meaningful) | as-needed; 2023 redistricting + 2026-05 publication |
+| `precinct-nh` | ftp.granit.unh.edu d-nhpolitdists/ parent listing | 3650 | vintage | probe | get (listing; new vintage = new subfolder) | as-needed, per-redistricting in practice |
+| `precinct-nm` | sos.nm.gov gis-voting-district-data page | 730 | rolling | probe | conditional-get (new vintages get new UUIDs — watch the SOS page, not the UUID) | as-needed, county-triggered; last vintage 2024-07 |
+| `precinct-ny` | AGOL item 23a05670…5998 `?f=json` | 365 | rolling | probe | get | rolling; modified 2026-06 |
+| `precinct-nc` | S3 `list-type=2&prefix=ShapeFiles/Precinct/` (checksum of listing) | 180 | rolling | **fetch** | — | 2–4 releases/year observed 2022→2026 |
+| `precinct-nd` | sos.nd.gov voting-shape-files-{yyyy}.zip | 780 | vintage | probe | head + nextVintage template `voting-shape-files-{yyyy}.zip`, windowMonths [1–4 of even years] | per-election-cycle |
+| `precinct-ri` | AGOL item 9104ca2e…514d `?f=json` (+ layer editingInfo) | 730 | vintage | probe | get | 2022 base + ad-hoc edits (2024-09, 2025-01) |
+| `precinct-sc` | rfa.sc.gov political-gis-data page | 400 | rolling | probe | get (WAF risk: treat 403/timeout as reachability-unknown → escalate to browser-grade fallback, not fetch-breach) | burst edits under a running Effective date, ~annual re-issuance |
+| `precinct-tx` | data.capitol.texas.gov CKAN `package_show?id=vtds` | 780 | vintage | probe | get (CKAN API, NOT the Cloudflare-fronted HTML) | per-election-cycle (22P/22G/24PG…) |
+| `precinct-ut` | AGOL item d33f5964…b8e0 `?f=json` (checksum on modified) | 180 | rolling | **fetch** | — | 2–4 versioned updates/year, unannounced |
+| `precinct-vt` | AGOL item fae5aad9…32d4 `?f=json` | 3650 | vintage | probe | get | municipal-redraw-driven; last real change 2023-06 — interval reflects reality |
+| `precinct-wa` | AGOL item f5431071…fc2e `?f=json` | 400 | vintage | probe | get + nextVintage on sos.wa.gov `Statewide_Precincts_{yyyy}General.zip`, windowMonths [11,12,1] | annual per general election |
+| `precinct-wi` | AGOL item 1ed4da2e…57be `?f=json` | 230 | vintage | probe | get + nextVintage via LTSB hub new-cycle items, windowMonths [2,3,8,9] (post Jan-15/Jul-15 statutory deadlines) | statutory semiannual |
+| `precinct-dc` | AGOL item 8d512fde…496f `?f=json` | 730 | rolling | probe | get | event-driven; 2024 delineation, 2026-06 reload |
+
+Lane rationale: `fetch` (daily change-check with checksum semantics) is reserved for
+the three rolling sources whose updates are frequent, unannounced, and cheap to
+checksum (AR FeatureServer, NC S3 listing, UT item JSON). Everything else is `probe`
+(daily reachability + window-gated next-vintage checks) — per the lane-exclusivity
+invariant, exactly one lane owns each source's clock. WAF-fronted sources (TX, SC)
+carry probe configs that distinguish bot-wall 403s from real outages so we don't burn
+retryBudget on Cloudflare/Imperva interstitials.
+
+---
+
+## 5. What full national currency would take — the ~3,033-county problem
+
+The 23 state overlays take served-precinct currency from 0% to ~51% of population for
+roughly $0 in recurring cost. The remaining ~49% lives in NONE states where precinct
+boundaries are maintained by ~county-level authorities (the US has ~3,033 organized
+county governments; NONE-state counties are the relevant subset). Three tiers, in
+strictly increasing cost:
+
+**Tier 1 — state overlays (this lane, ≈$0).**
+The 23 CONFIRMED sources above, plus the 4 PLAUSIBLE follow-ups (AK, DE, LA, MN —
+≈12.1M more people if all confirm; LA's semiannual statutory cadence would make it a
+top-tier source). Cost is one-time ingest engineering plus the existing self-healing
+probe/change-check machinery. No new infra, no vendors, no addresses leaving our
+control.
+
+**Tier 2 — county open-GIS discovery sweep (agentic, measurable, ≈$0 marginal).**
+Many NONE-state counties already publish open precinct GIS: Maricopa/Pima (AZ), Cook/
+DuPage/Lake/Will (IL), Douglas/Boulder/Fremont (CO), Fulton + ARC (GA), Jefferson/
+Lexington (KY), St. Louis City/County + Jackson (MO), Cass/Lancaster/Sarpy (NE),
+Jefferson/Marion (WV), Sheridan/Carbon/Natrona (WY), and so on — every one surfaced
+during this survey without even looking hard. The same agentic hunt that produced this
+document enumerates county GIS portals per NONE state, applies the same
+CONFIRMED/PLAUSIBLE/NONE bar per county, and feeds CONFIRMED counties into the same
+registry/probe/ingest machinery with `id: precinct-{st}-{countyfips}`. Coverage becomes
+a measurable number (population-weighted % per state), and the self-healing lane keeps
+it honest. The deliverable is partial-state overlays with county-level provenance —
+served districts in covered counties get currency; the rest stay on the 2020 baseline,
+labeled as such. No overstatement: a state is never marked "current" because three of
+its counties are.
+
+**Tier 3 — records-request / digitization long tail (paid data-ops, customer-gated).**
+The counties with no open GIS — PDF maps (IL townships, NV per-county index, TN
+KMZ/PDF), paper filings, or nothing online — require a standing data-ops program:
+records requests, digitization, county-clerk relationships, per-county refresh
+tracking. This is exactly the VEST/RDH cost structure, and it is why no vendor sells a
+current national file. Per the bootstrapping cost posture, this tier incurs **no
+spend until a paying customer of this capability closes**, and then only for the
+geographies that customer needs (proofWeight saturates sublinearly — saturating
+contained geographies beats thin national coverage anyway). **License review is
+per-county and non-optional here**: county terms are not uniformly open, and non-open
+terms may bar signed republication of derived boundaries — same gate as the
+license-review rows in §3, applied at county grain.
+
+The three tiers are strictly ordered by cost and strictly decreasing in
+population-per-dollar. Tier 1 is this lane. Tier 2 is a repeat of this hunt one level
+down, on machinery that already exists. Tier 3 is a business decision that a customer
+signs, not an engineering default.

--- a/docs/design/RESOLUTION-FRESHNESS-REMAINING.md
+++ b/docs/design/RESOLUTION-FRESHNESS-REMAINING.md
@@ -58,7 +58,7 @@ under `convex-test` (no mock-ledger mirror).
 - [ ] **Schedule `check-changes.ts`** — LOW/latent, needs a durable-DB decision.
   WHERE: `voter-protocol/packages/shadow-atlas/src/scripts/check-changes.ts` (no invoker in `.github/`). Detector is real but never fires autonomously. Durable checksum-DB location is the cost-posture blocker (CI SQLite is ephemeral).
 
-- [ ] **Provision a real `REDRAW_SIGNAL` feed source** — LOW / by-design-manual.
+- [ ] **Provision a real `REDRAW_SIGNAL` feed source** — ELEVATED (was LOW) per the verified Cicero comparison 2026-07-04: their 2023-26 mid-decade record is a public black box, making published effective-dates + fail-loud downgrades our most benchmarkable freshness win after the first publish. Still posture-gated on feed-source cost.
   WHERE: `commons/src/lib/core/shadow-atlas/redraw-guard.ts` (6 hand-curated states; no feed/cron wired). Mid-cycle redraws beyond the 6 coded states go undetected.
 
 Operator-adjacent (not launch blockers): `INTERNAL_API_SECRET` must match on CF Pages + prod Convex (unverified against live prod env); orgs need issued `apiKeys` rows to call the resolve API (customer onboarding).

--- a/docs/design/SELF-HEALING-DATA-OPS.md
+++ b/docs/design/SELF-HEALING-DATA-OPS.md
@@ -1,0 +1,620 @@
+# Self-Healing Data Ops — Shadow Atlas source freshness
+
+**Status:** DESIGN (approved shape for hypergraph nodes P14 + P15)
+**Founder directives (2026-07-04):** (1) resolve every district possible; (2) "agentically
+address data that fails to update after a certain number of retries over the preset update
+interval."
+**Cost posture:** no recurring paid services. Everything below runs on GitHub Actions
+(public repo — standard-runner minutes are free) plus infra that already exists (the R2
+bucket and the change-detection SQLite DB that already round-trips through it). The only
+metered spend is Anthropic API usage in the remediation lane, which is zero in steady
+state and fires only on an SLO breach, bounded by hard caps (§Failure modes).
+
+All `file:line` references are `voter-protocol/packages/shadow-atlas/` unless prefixed.
+
+---
+
+## The loop
+
+```
+        (exists today)                      (P14 — new)
+┌───────────────────────────┐   ┌────────────────────────────────┐
+│ FETCH LANE                │   │ PROBE LANE                     │
+│ daily change-check        │   │ same scheduled job, new step:  │
+│ (schedule 06:00 +         │   │ method-appropriate reachability│
+│ dispatch): checksum       │   │ probes (HEAD / conditional GET │
+│ compare over              │   │ / range-GET first-bytes) for   │
+│ getAllCanonicalSources =  │   │ EVERY registry source the      │
+│ muni-derived sources + 2  │   │ fetch lane never touches: NAD, │
+│ congressional seeds ONLY; │   │ ADDRFEAT, BAF, tract-centroids,│
+│ HEAD ×3 backoff,          │   │ TIGER national + next-vintage, │
+│ download ×6 (retry lane)  │   │ tigerweb-cd, intl officials…   │
+└─────────────┬─────────────┘   └───────────────┬────────────────┘
+              │     every attempt, either lane   │
+              ▼                                  ▼
+   ┌─────────────────────────────────────────────────────┐
+   │ health ledger row (P14) — same SQLite DB, same R2   │
+   │ round-trip; the quarterly full fetch ALSO writes    │
+   │ attempts, but only when the operator dispatches it  │
+   └──────────────────────────┬──────────────────────────┘
+                              ▼
+   ┌──────────────────────────────────────┐   ┌──────────────────────────┐
+   │ breach evaluation (P14)              │   │ agentic remediation lane │
+   │ fetch-breach: failures ≥ retryBudget │──▶│ (P15): diagnose →        │
+   │ staleness: past expectedInterval     │   │ test-gated fix PR — or — │
+   │ → structured breach record + deduped │   │ escalation w/ evidence;  │
+   │   `atlas-slo-breach` issue           │   │ HUMAN MERGES (auto-merge │
+   └──────────────────────────────────────┘   │ NEVER); operator publish │
+                                              │ unchanged                │
+                                              └──────────────────────────┘
+```
+
+Two lanes, because the daily change-check does NOT cover the full source registry —
+see §Daily probe lane for the explicit coverage split. Exactly one lane owns each
+source's daily reachability clock; the operator-dispatched quarterly is a third,
+*unscheduled* writer that additionally proves full-fetch/parse health when it runs.
+
+Detection and retry already exist and are not redesigned here:
+
+- **Detection**: `.github/workflows/shadow-atlas-change-check.yml` runs daily
+  (`cron '0 6 * * *'`, L31-34), round-trips `change-detection/shadow-atlas.db` through R2
+  (get L80-90, put L99-110), runs `npm run changes:check` (`src/scripts/check-changes.ts`),
+  and raises a deduped `atlas-change-alert` GitHub issue on detections (L112-153).
+  `ChangeDetector.checkForChange` (`src/acquisition/change-detector.ts:201-247`) does
+  HEAD → etag ‖ last-modified ‖ body-sha256, with 3-attempt exponential backoff
+  (L86-91) and a 5s timeout (L96).
+- **Retry**: `src/distribution/addresses/download-pool.ts` — `downloadWithRetry`
+  (L142-184): 6 retries, 2s→60s backoff, jitter, `Retry-After` honored on 429/503,
+  fail-loud exhaustion; `downloadZipToCache` (L217-247) with zip-completeness resume
+  cache. Plus the SQLite download DLQ (`src/acquisition/download-dlq.ts`).
+
+What is missing — and what this design adds — is the seam between them and action.
+There are **two** gaps, not one:
+
+1. **Error-swallow.** A fetch error inside `checkForChange` is swallowed as "no change"
+   (`change-detector.ts:238-246`), so a source the daily check *does* cover can
+   silently die forever.
+2. **Coverage punt — stated plainly.** The daily change-check only ever fetches
+   `getAllCanonicalSources` = muni-derived selected sources + the 2 congressional
+   seeds (`congress-legislators-current`, `tiger-cd119`) appended to them
+   (`change-detector.ts:647-733`, seeds L154-174). NAD, ADDRFEAT, BAF,
+   tract-centroids, the TIGER national layers, tigerweb-cd, and the UK/CA/AU/NZ
+   officials sources are fetched ONLY by the operator-dispatched quarterly or by
+   unscheduled scripts. Without a new daily touchpoint their `last_attempt` /
+   `consecutive_failures` never advance between quarterlies, and fetch-breach is
+   **structurally dead** for exactly the sources most likely to rot.
+
+The loop closes both: every attempt outcome from either lane lands in a **health
+ledger** (P14), a **daily probe lane** (P14, §Daily probe lane) reaches every registry
+source the fetch lane doesn't, the scheduled run evaluates **SLO breaches** against a
+**source registry** (P14), and a breach fires the **agentic lane** (P15) which either
+opens a test-gated fix PR against source-acquisition config/code or escalates with
+evidence. A human merges. The operator-dispatched publish
+(`shadow-atlas-quarterly.yml`) is untouched.
+
+---
+
+## Source registry + SLOs
+
+One typed config, `packages/shadow-atlas/src/acquisition/source-health.ts`, is the
+single source of truth. Shape:
+
+```ts
+interface SourceHealthConfig {
+  id: string;                     // stable key, matches detector sourceIds where they exist
+  class: 'boundary-geometry' | 'boundary-assignment' | 'municipal'
+       | 'address' | 'officials' | 'signal' | 'infra';
+  url: string | { template: string; params: string[] };  // or ref to existing config site
+  configSite: string;             // file:line where the URL/vintage actually lives —
+                                  //   this is the agent's edit target on breach
+  expectedIntervalDays: number | null;  // freshness window; null = frozen product
+  retryBudget: number;            // consecutive failed attempts before fetch-breach
+  freshness: 'vintage' | 'rolling' | 'frozen' | 'manual';
+  ownerSlots?: string;            // which atlas slots go stale if this dies (jurisdiction.ts:262)
+  // Daily-lane assignment. INVARIANT: exactly one lane owns each source's
+  // reachability clock (dual writes would let a bare probe 200 reset
+  // consecutive_failures accumulated by a failing checksum fetch).
+  //   'fetch' — covered by getAllCanonicalSources (muni-derived + the 2 seeds)
+  //   'probe' — daily reachability probe (§Daily probe lane)
+  //   'none'  — manual/dormant rows, skipped by both lanes
+  lane: 'fetch' | 'probe' | 'none';
+  probe?: {                       // required when lane === 'probe'
+    method: 'head' | 'conditional-get' | 'get';  // first choice; prober auto-falls
+                                  //   back HEAD → range-GET (`Range: bytes=0-0`)
+                                  //   on 405/501/hang — www2.census.gov mishandles
+                                  //   HEAD intermittently
+    url?: string;                 // override when probe target ≠ fetch URL
+                                  //   (directory listing, sample county, service root)
+    sample?: 'rotate-daily';      // per-file families (BAF ×56, per-state TIGER):
+                                  //   probe ONE date-rotated representative per day
+    nextVintage?: {               // vintage sources only: window-gated probe of the
+      template: string;           //   NEXT vintage URL, recorded on the derived
+      windowMonths: number[];     //   `<id>@next-vintage` ledger row
+    };
+  };
+}
+```
+
+Two breach semantics share the config (both are the founder's "fails to update after a
+certain number of retries over the preset update interval"):
+
+- **fetch-breach** — `consecutive_failures >= retryBudget`. The source is unreachable or
+  unparseable. Applies to every class.
+- **staleness-breach** — `now - last_success > expectedIntervalDays`. For
+  `freshness: 'vintage'` sources this means the *next expected vintage* never appeared
+  inside its release window (e.g. TIGER2025 URL still 404 in October) — the **probe
+  lane** probes the next-vintage URL daily while inside the release window, recording
+  outcomes on a derived `<id>@next-vintage` ledger row (§Daily probe lane); the breach
+  fires when the window closes without a 2xx. Current-vintage reachability probes
+  deliberately do NOT advance a vintage source's staleness clock — a 200 on TIGER2024
+  proves the old file still serves, not that TIGER2025 arrived. `frozen` products never
+  staleness-breach; `manual` rows are skipped entirely.
+
+Full enumeration of current upstreams (intervals matched to real upstream cadence —
+TIGER annual, congress-legislators weekly, NAD quarterly, court redraws sporadic):
+
+| id | class | config site | upstream cadence | expectedInterval | retryBudget | owner slots |
+|---|---|---|---|---|---|---|
+| `tiger-cd119` | boundary-geometry | `providers/tiger-manifest.ts:107`; detector seed `acquisition/change-detector.ts:167` | annual (July) + redistricting years [2021,2022,2031,2032] + census 2030 | 400d | 3 | cd (slot 0) |
+| `tiger-state-{cd,sldu,sldl,county}` (per-state) | boundary-geometry | `acquisition/change-detection-adapter.ts:233-242` (URL template) | annual | 400d | 3 | cd/sldu/sldl per BAF map |
+| `tiger-place` | boundary-geometry | `providers/tiger-place.ts:423`; national `providers/census/census-tiger-parser.ts:260` | annual | 400d | 3 | place |
+| `tiger-tract-centroids` | boundary-geometry | `hydration/tract-centroid-index.ts:49,126` (TIGER2024/TRACT) | annual | 400d | 3 | PIP substrate (all slots) |
+| `tiger-national-{aiannh,cbsa,state,county,zcta520,uac,mil}` | boundary-geometry | `providers/tiger-manifest.ts:93-183` | annual | 400d | 3 | context + aiannh |
+| `bef-cd119` | boundary-geometry | `hydration/bef-overlay.ts:33` | per-congress (~2y) | 800d | 3 | cd overlay |
+| `baf-2020-{ST}` (56 files) | boundary-assignment | `hydration/baf-downloader.ts:8,49`; entities L10-13 | frozen 2020 product; revised only on mid-decade redistricting | null (frozen) — daily probe lane, date-rotated sample (§Daily probe lane) | 3 | slots 0-5, 7-9, 20-21 (`jurisdiction.ts:262`) |
+| `ward-arcgis-{city}` | municipal | `hydration/ward-registry.ts:34` (per-city FeatureServer URLs) | sporadic municipal redistricting; endpoints are the most fragile upstreams we have | 30d reachability | 5 | ward (slot 6) |
+| `addrfeat-{vintage}` | address | `scripts/build-address-index.ts:336` (directory-index crawl), `--addrfeat-vintage` L164-165 | annual (TIGER) | 400d | 3 | address src:1 |
+| `nad` | address | quarterly workflow input `nad_url` (`shadow-atlas-quarterly.yml:78-84`); vintage gate `distribution/addresses/nad-vintage.ts:18-35` | quarterly | 120d | 3 | address src:0 |
+| `congress-legislators-current` | officials | detector seed `acquisition/change-detector.ts:154-174`; ingest `scripts/ingest-legislators.ts:85-86` | repo commits ~weekly; membership changes sporadic | 7d | 3 | US federal officials |
+| `tigerweb-cd` | officials | `providers/international/us-provider.ts:216-217` | service availability | 30d | 3 | CD geometry service |
+| `uk-mps` | officials | `scripts/ingest-uk-mps.ts:102` (members-api.parliament.uk) | API; elections sporadic | 30d | 3 | UK officials |
+| `ca-mps` | officials | `scripts/ingest-canadian-mps.ts:93` (represent.opennorth.ca) | API | 30d | 3 | CA officials |
+| `au-mps` | officials | `scripts/ingest-au-mps.ts:9` (aph.gov.au **scrape**) | scrape — fragile | 30d | 5 | AU officials |
+| `nz-mps` | officials | `scripts/ingest-nz-mps.ts` | scrape/API | 30d | 5 | NZ officials |
+| `redraw-signal` | signal | commons `src/lib/core/shadow-atlas/redraw-guard.ts` + `redraw-signal.data.ts` | court redraws — sporadic; TODAY hand-curated (6 states), no feed wired | `manual` until a feed is provisioned (ledger item, ELEVATED 2026-07-04) | — | redraw guard |
+| `dc-urls` | infra (dormant) | `config/providers.ts:132` | referenced | manual | — | DC |
+| `ipfs-gateways` | infra | `config/providers.ts:174-180` | distribution-side availability | 7d reachability | 3 | serving, not acquisition — **escalate-only**, never in the fix lane |
+
+Lane assignment for `ward-arcgis-{city}` is **explicit `lane: 'fetch'`**: its per-city
+FeatureServer endpoints enter through the change-DB muni selections that
+`getAllCanonicalSources` walks, and they are deliberately excluded from the probe list
+(lane exclusivity — a probe 200 would reset `consecutive_failures` accrued by failing
+content fetches).
+
+**Implemented truth: id shape.** `getAllCanonicalSources` emits NUMERIC autoincrement
+ids for every muni-derived source (`sources.id INTEGER PRIMARY KEY AUTOINCREMENT`,
+`db/schema.sql`) — never a synthetic `ward-arcgis-{city}` string. The `ward-arcgis`
+registry row is therefore a template, evaluated by **aggregating every real ledger row
+whose recorded URL matches the ward-arcgis family** (`isWardArcgisFamilyUrl`: a
+FeatureServer/MapServer REST path), not by an id prefix. The aggregate takes the WORST
+city's `consecutive_failures` (one fragile endpoint failing shouldn't be diluted by many
+healthy ones) and the MOST RECENT success across the family. Because `ward-registry.ts`
+derives from `attributed-council-districts.json` rather than the change DB's
+source→selection walk, the prober **asserts at startup** that at least one real
+`getAllCanonicalSources` entry's URL matches the ward-arcgis family this run, recording a
+(persisted, not console-only) fetch-lane config breach when none does — absence is loud,
+never a silent neither-lane gap.
+
+**Implemented truth: staleness driver.** The design table lists `ward-arcgis-{city}`'s
+SLO as "30d **reachability**", not content staleness — and muni content checks are
+due-filtered to ~once/year (annual, July), which cannot service a 30-day interval on its
+own (see "Implemented truth: cadence" below). This row's staleness therefore keys off the
+daily reachability-probe clock (`last_probe_at`, aggregated the same worst/most-recent way
+as above), not the content-check clock. Its fetch-breach still reads the content clock's
+`consecutive_failures` — a real failing FeatureServer endpoint on an actual checksum check
+is what that alarm means.
+
+Directive (1) — *resolve every district possible* — is why `ownerSlots` is a first-class
+column: a breach report names exactly which resolution slots go stale, and the future
+wave (reserved slots 10-19: community-college / water / fire / transit / hospital /
+library / park / conservation / utility / judicial special districts,
+`jurisdiction.ts:255-305`, "to be populated via the ingestion platform's scanner
+infrastructure") onboards into this loop by adding a registry row — no new machinery.
+Note there is no source labeled "P12" anywhere in either repo; the future-wave sources
+are exactly the reserved-slot list above plus the commons-side `REDRAW_SIGNAL` feed.
+
+---
+
+## Daily probe lane
+
+**Why this lane exists.** The daily change-check's fetch surface is
+`getAllCanonicalSources` = muni-derived selected sources + the 2 congressional seeds,
+and nothing else (`change-detector.ts:647-733`, seeds L154-174). Every other registry
+source — NAD, ADDRFEAT, BAF, tract-centroids, the TIGER national layers, tigerweb-cd,
+the UK/CA/AU/NZ officials sources — is fetched only when the operator dispatches the
+quarterly or runs an unscheduled script. **Full-fetch failures for quarterly-only
+sources can therefore only be observed when the quarterly actually runs.** Without this
+lane, those sources' `last_attempt`/`consecutive_failures` never advance daily and
+fetch-breach is structurally dead for them — the punt earlier drafts of this design
+buried. The probe lane is the cure: a lightweight prober that runs as a step **in the
+same scheduled change-check workflow**, iterates the FULL source registry, and issues a
+method-appropriate reachability probe for every `lane: 'probe'` row.
+
+**Mechanics.** New module `src/acquisition/source-prober.ts` (thin CLI wrapper
+`src/scripts/probe-sources.ts`, `--db` flag like `check-changes.ts`), wired into
+`shadow-atlas-change-check.yml` after the R2 DB get and **before the breach-evaluation
+pass**, so probe attempts are visible to the same run's evaluation; the DB put stays
+after both lanes and before the alert steps. Per source, per its registry `probe`
+config:
+
+- **HEAD** first; on 405/501/hang, automatic fallback to **range-GET**
+  (`Range: bytes=0-0`, 206 or 200 = success) — `www2.census.gov` intermittently
+  mishandles HEAD, which is why the fallback is built in, not bolted on;
+- **conditional GET** (`If-None-Match` / `If-Modified-Since`) where we hold a
+  validator — a 304 is a success;
+- plain **GET first-bytes** for API/scrape targets that reject HEAD (ArcGIS service
+  roots, aph.gov.au).
+
+Outcome semantics: 200/206/304 = attempt **success** (stamps `last_attempt_at`, resets
+`consecutive_failures`); 4xx/5xx/timeout/DNS failure = attempt **failure** (stamps
+`last_attempt_at`, increments `consecutive_failures`, stores `last_error`). Same 5s
+timeout and ×3 backoff posture as the detector.
+
+**A probe outcome is NOT content-change detection.** A 304/200 HEAD proves
+reachability and advances the fetch-breach clock; checksum change detection stays the
+change-detector's job where it runs, and content/parse integrity for quarterly-only
+sources still comes only from the quarterly full fetch. Clock rules, per freshness
+class:
+
+| freshness | probe success advances staleness clock (`last_success_at`)? | staleness driver |
+|---|---|---|
+| `rolling` | yes — endpoint alive IS the freshness signal at this SLO | no successful touch in `expectedIntervalDays` |
+| `frozen` | moot — frozen never staleness-breaches | none (fetch-breach only) |
+| `vintage` | **no** — old-vintage reachability ≠ new vintage arrived | window-gated `<id>@next-vintage` probe: still no 2xx when the window closes |
+| quarterly ingest products (NAD) | **no** | last successful quarterly ingest older than `expectedIntervalDays` — an explicit operator-nudge alarm, not a probe artifact |
+
+**Lane exclusivity invariant.** The prober's CONTENT-clock pass skips every
+`lane: 'fetch'` row. In particular `congress-legislators-current` is NOT content-probed —
+dual-writing to `consecutive_failures`/`last_success_at` would let a bare HEAD 200 reset
+failures accumulated by a failing checksum check, masking exactly the failure class the
+ledger exists to catch.
+
+**Implemented truth: cadence.** The daily change-check runs `checkScheduledSources`,
+which due-filters to sources whose `updateTriggers` apply NOW — `congress-legislators-
+current` only in January, `tiger-cd119`/ward munis only in July. That is NOT "a daily
+fetch lane" for those rows; it is an annual content check. Fixed on both sides:
+
+- **The 2 congressional seeds check DAILY, for real.** `check-changes.ts` explicitly
+  content-checks `congress-legislators-current` and `tiger-cd119` on every run — not via
+  a scheduler rewrite, but by additionally calling `checkSourcesBatch` on the 2 seeds
+  whenever the due-filter didn't already include them this run. These are 2 cheap
+  HEAD/checksum requests; their `consecutive_failures`/`last_success_at` now genuinely
+  advance daily, servicing their 7d/400d SLOs as designed.
+- **Muni rows (including ward-arcgis) stay content-check due-filtered** (annual, July) —
+  that invariant is unchanged. But the prober ADDITIONALLY runs a daily reachability
+  probe (`probeFetchLaneReachability`, source-prober.ts) over the fetch lane: the 2 seeds
+  (redundant with the always-due content check above, cheap) plus a date-rotated SAMPLE
+  of muni sources (bounded volume — `getAllCanonicalSources` can return thousands of
+  municipalities; probing all of them daily would blow the "~a dozen requests/day" cost
+  posture). This probe writes ONLY two SEPARATE columns —
+  `probe_consecutive_failures`/`last_probe_at` — and NEVER
+  `consecutive_failures`/`last_success_at`, the columns the content/checksum clock alone
+  owns. A probe 200 can never mask a failing content fetch; a probe failure can never
+  fabricate one. The two clocks are structurally disjoint columns on the same row, not
+  merely disjoint lanes on different rows.
+
+**Probe target list** (the `lane: 'probe'` complement of the fetch lane):
+
+| source | probe |
+|---|---|
+| `nad` | HEAD the configured/last-known release zip URL (`nad_url`) |
+| `addrfeat-{vintage}` | GET the TIGER ADDRFEAT directory listing + HEAD one sample county zip |
+| `baf-2020-{ST}` | HEAD one date-rotated representative state zip (full 56-file family covered over the rotation) |
+| `tiger-tract-centroids` | HEAD one sample TRACT zip under the pinned vintage |
+| `tiger-national-{aiannh,cbsa,state,county,zcta520,uac,mil}` | HEAD one date-rotated manifest layer |
+| `tiger-state-{cd,sldu,sldl,county}` | HEAD one date-rotated (state, layer) sample from the URL template |
+| `tiger-place` | HEAD the national places zip |
+| `bef-cd119` | HEAD |
+| `tiger-cd119` next vintage | window-gated HEAD of the `TIGER{next}` CD URL (July–Oct), recorded on `tiger-cd119@next-vintage` |
+| `tigerweb-cd` | GET service root `?f=json`, first bytes |
+| `uk-mps` | HEAD/GET members-api.parliament.uk endpoint |
+| `ca-mps` | GET represent.opennorth.ca (tiny response) |
+| `au-mps` | GET first-bytes (scrape target; HEAD often blocked) |
+| `nz-mps` | GET first-bytes |
+| `ipfs-gateways` | HEAD gateway roots (registry already marks escalate-only) |
+
+**Cost:** ~a dozen HEAD-class requests/day (family sampling keeps BAF/ADDRFEAT/
+per-state templates at one representative each), on free public-repo runner minutes.
+$0, no new secrets, no new infra — consistent with the cost posture at the top of
+this doc.
+
+---
+
+## Health ledger
+
+**No new infra.** The ledger lives inside the same SQLite DB that already round-trips
+R2 in the change-check workflow (`CHANGE_DB_KEY: change-detection/shadow-atlas.db`,
+`shadow-atlas-change-check.yml:67`; get-before L80-90, put-after L99-110, secret-gated
+no-op fallback). Fresh DBs get schema via the same `createSQLiteAdapter` path that fixed
+the `no such table: municipalities` bootstrap (`check-changes.ts:31-35`), so the ledger
+table is added there:
+
+```sql
+CREATE TABLE IF NOT EXISTS source_health (
+  source_id            TEXT PRIMARY KEY,      -- matches SourceHealthConfig.id
+  last_attempt_at      TEXT,
+  last_success_at      TEXT,
+  consecutive_failures INTEGER NOT NULL DEFAULT 0,
+  last_error           TEXT,                  -- 'HTTP 404 …' / 'timeout' / 'parse: …'
+  breach_state         TEXT NOT NULL DEFAULT 'ok',
+                       -- ok | breached | remediating | escalated | manual
+  breach_opened_at     TEXT,
+  remediation_ref      TEXT,                  -- breach-issue / fix-PR URL
+  probe_consecutive_failures INTEGER NOT NULL DEFAULT 0,
+                       -- daily reachability probe clock for lane:'fetch'
+                       -- rows (see "Implemented truth: cadence" above) —
+                       -- NEVER written by content checks, never read for
+                       -- fetch-breach except by ward-arcgis's staleness
+                       -- driver (an explicit "reachability" SLO)
+  last_probe_at         TEXT,
+  registered_at         TEXT                  -- first attempt of any kind
+                       -- ever recorded for this row — the real, persisted
+                       -- anchor for the never-succeeded staleness grace
+                       -- (previously re-derived as "now" on every run,
+                       -- making that grace infinite in production; fixed by
+                       -- stamping this column on first insert and threading
+                       -- it into evaluateSourceHealth from check-changes.ts)
+);
+```
+
+The one code change this requires outside new files: `checkForChange` collapses fetch
+errors to `null` ("no change", `change-detector.ts:238-246`) — correct for checksum
+semantics, fatal for health. P14 threads an attempt-outcome hook out of the detector
+(success / failure + error string per sourceId) **without changing what counts as a
+change** — no spurious `modified` events, checksum behavior byte-identical.
+
+Write ordering in the workflow stays as today, with the probe step slotted in: get DB
+→ run probe lane (`probe-sources`, attempt rows for every `lane: 'probe'` source) →
+run checks (fetch lane, ledger rows written per attempt) → evaluate breaches → **put
+DB** → alert steps — so ledger durability survives alert failure, same reasoning as
+the existing put-before-alert placement (L99-110). Both lanes write the same
+`source_health` rows; window-gated next-vintage probes write derived
+`<id>@next-vintage` rows (same DDL, derived key — no schema change). Precedents this copies rather than invents: the JSON checksum cache with Zod
++ safe-empty fallback (`change-detection-adapter.ts:93-120`), the download DLQ's
+persist-immediately/restart-safe posture (`download-dlq.ts:1-60`), and the event-log-as-
+durable-KV trick for state with no owning row (`change-detector.ts:407-496, 709-719`).
+The officials side keeps its existing, separate freshness story (`ingestion_log` DDL
+`db/officials-schema.sql:213`, reader `hydration/freshness-monitor.ts:70,186-220`,
+CLI `hydration/check-freshness.ts`); the ingest scripts' success/failure rows become
+ledger attempts when those scripts run in CI, but the officials DB itself is not merged
+into the change-detection DB.
+
+---
+
+## Breach evaluation
+
+Runs inside the existing scheduled change-check job — no new workflow for detection.
+`check-changes.ts` gains a post-check evaluation pass (pure function
+`evaluateSourceHealth(ledger, registry, now)` in `source-health.ts`, unit-testable
+with injected clock):
+
+```
+for each registry row (skip lane = 'none' / freshness = 'manual'):
+  fetch-breach:     consecutive_failures >= retryBudget
+                    (counter advanced DAILY by the row's one owning lane —
+                     fetch lane or probe lane)
+  staleness-breach: expectedIntervalDays != null
+                    AND now - last_success_at > expectedIntervalDays
+                    (last_success_at advanced per the freshness-class clock
+                     rules in §Daily probe lane; vintage sources additionally
+                     require the in-window <id>@next-vintage probe to have
+                     never returned 2xx)
+  grace:            a source that has never succeeded gets one expectedInterval
+                    from registration before staleness-breach can fire
+                    (fetch-breach still applies)
+```
+
+**The two lanes, stated explicitly, because breach evaluation is only as live as the
+attempts feeding it:**
+
+- **Fetch lane** (exists today): the change-detector's checksum checks over
+  `getAllCanonicalSources` — muni-derived selected sources + the 2 congressional
+  seeds, and nothing else. These rows get real fetch/parse outcomes daily via the
+  P14 outcome hook.
+- **Probe lane** (P14, §Daily probe lane): every other registry source gets a daily
+  method-appropriate reachability probe. These rows get reachability outcomes daily;
+  their **full-fetch/parse failures can only be observed when the operator-dispatched
+  quarterly actually runs** — that structural fact is WHY the probe lane exists.
+  Without it, fetch-breach for quarterly-only sources could never fire between
+  quarterlies, and their staleness intervals would be decoupled from any live signal.
+
+A breach emits a **structured breach record** to `--health-summary ./health-summary.json`
+(sibling of the existing `--summary` detections file, same exit-0 posture — the issue is
+the alarm, not a red run):
+
+```json
+{
+  "breaches": [{
+    "sourceId": "tiger-cd119",
+    "breachType": "staleness",
+    "class": "boundary-geometry",
+    "configSite": "packages/shadow-atlas/src/providers/tiger-manifest.ts:107",
+    "expectedIntervalDays": 400,
+    "retryBudget": 3,
+    "lastSuccessAt": "2025-08-14T06:02:11Z",
+    "consecutiveFailures": 5,
+    "attempts": [{ "at": "…", "error": "HTTP 404 https://www2.census.gov/…" }],
+    "urlChecked": "https://www2.census.gov/geo/tiger/TIGER2025/CD/…",
+    "ownerSlots": "cd (slot 0)"
+  }]
+}
+```
+
+The workflow then mirrors the proven alert pattern (`shadow-atlas-change-check.yml:
+112-153`): `jq '.breaches|length'` → `$GITHUB_OUTPUT`; gated on
+`R2_ACCESS_KEY_ID != '' && breaches > 0`; idempotent `gh label create atlas-slo-breach`;
+**one open issue per source** (title `SLO breach: <sourceId>`, comment-if-open else
+create) with the breach record verbatim in a fenced JSON block — that block is the
+remediation lane's machine-readable input. The record also flips the ledger row to
+`breached` + stamps `breach_opened_at`/`remediation_ref`. Recovery is automatic at the
+detection layer: the next successful check resets `consecutive_failures`, flips
+`breached → ok`, and comments "recovered" on + closes the breach issue.
+
+---
+
+## The agentic lane
+
+A separate workflow, `.github/workflows/shadow-atlas-remediate.yml`, so its permissions
+and secrets are isolated from the change-check job.
+
+**Trigger:** `issues: [labeled]` filtered to `atlas-slo-breach` (fires exactly once per
+label transition — natural storm damper) plus `workflow_dispatch` (inputs:
+`issue_number`, `source_id`, `dry_run` default `true`) for operator-driven runs.
+
+**Runner choice — `anthropics/claude-code-action@v1` in explicit-prompt automation
+mode.** Grounded basis: automation mode takes a `prompt` input directly (no `@claude`
+mention needed; works on `schedule`/`workflow_dispatch`/issue events), with
+`claude_args` as a CLI passthrough for `--allowedTools "…"`, `--model`, `--max-turns N`,
+plus `anthropic_api_key`, `github_token`, and `settings` inputs. The action is a
+maintained wrapper over the `claude` CLI, so it buys the mode-detection and GitHub-token
+plumbing while `--allowedTools` retains exactly the tool-scoping control we need.
+**Fallback documented, not chosen:** plain `npm install -g @anthropic-ai/claude-code`
++ `claude -p "<prompt>" --allowedTools … --output-format json` — take this path only if
+we need bespoke stdout parsing beyond what "write your conclusion to a file, workflow
+jq's it" covers (that file-based pattern is already how the change-check consumes
+`--summary`). Minimal shape:
+
+```yaml
+- uses: anthropics/claude-code-action@v1
+  with:
+    prompt: ${{ steps.contract.outputs.prompt }}
+    anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+    claude_args: |
+      --allowedTools "Read,Grep,Glob,Edit,Write,Bash(npm run changes:check*),Bash(npx vitest run packages/shadow-atlas*),Bash(curl -I *),Bash(git checkout -b remediate/*),Bash(git add *),Bash(git commit *),Bash(git push origin remediate/*),Bash(gh pr create *),Bash(gh issue comment *)"
+      --max-turns 30
+```
+
+**Diagnosis prompt contract.** IN (assembled by a workflow step, fully self-contained):
+
+1. the breach record JSON, verbatim from the issue body's fenced block;
+2. the source's full registry row — critically `configSite`, the `file:line` the fix
+   almost certainly lives at;
+3. the recent attempt/error tail from the ledger (last 10 attempts);
+4. repo facts: npm not pnpm; the acquisition test command; the allowed edit surface;
+   the guardrails block verbatim.
+
+OUT — exactly one of, never neither:
+
+- **Fix PR**: branch `remediate/<source-id>/<YYYYMMDD>`, edits confined to
+  source-acquisition config/code (`packages/shadow-atlas/src/{acquisition,providers,
+  hydration,config,scripts}` + tests). Expected fix classes: vintage path bump
+  (TIGER2024→TIGER2025), moved URL, renamed ArcGIS layer id, schema/Zod drift, header
+  or throttle requirement, backoff tuning. PR body sections are mandatory: **Breach
+  evidence** (record verbatim) / **Diagnosis** / **What was tried** (probe transcript)
+  / **Fix** / **Proof** (test output + live-probe exit code) / **Rollback note**.
+- **Escalation**: a comment on the breach issue carrying the same evidence triad —
+  what failed, what was tried, proposed fix (or "no automatable fix: <reason>") — plus
+  label `atlas-needs-human`.
+
+**Test gates the PR must pass (in-job, before `gh pr create`):**
+
+1. `npx vitest run packages/shadow-atlas/src/__tests__/unit/acquisition/` green;
+2. `npm run changes:check -- --db /tmp/fresh.db --summary /tmp/s.json` completes exit 0
+   on a fresh DB (bootstrap path intact);
+3. a live HEAD probe of the corrected URL returns 2xx/3xx, transcript pasted into
+   the PR's Proof section.
+
+These run **inside the remediate job** because PRs created with the default
+`GITHUB_TOKEN` do not trigger `pull_request` workflows (GitHub's anti-recursion rule) —
+so repo CI on the PR requires either a human close/reopen or a repo-scoped fine-grained
+PAT (`REMEDIATION_PAT`) later; in-job gates are the floor either way, and their output
+in the PR body is the reviewable evidence.
+
+**Auto-merge NEVER — a human merges.** On PR open the ledger row moves to
+`remediating` with `remediation_ref` = PR URL; it returns to `ok` only when a
+subsequent scheduled check actually succeeds (merged fix proven by the loop itself,
+not by the merge event).
+
+---
+
+## Guardrails
+
+Verbatim, non-negotiable, from the founder directive block:
+
+> the agent lane fixes SOURCE-ACQUISITION config/code via TEST-GATED PRs only; it NEVER
+> touches published artifacts, the signed manifest, trust pins, or the operator-
+> dispatched publish; escalation must carry evidence (what failed, what was tried,
+> proposed fix).
+
+Operationalized:
+
+- **Edit surface allowlist**: `packages/shadow-atlas/src/{acquisition,providers,
+  hydration,config,scripts}` + their tests. Explicit denies: `.github/workflows/**`
+  (no self-modification, no publish-workflow tampering), distribution signing /
+  manifest / pin code, any published artifact path. Enforced twice: in
+  `--allowedTools` scoping AND as a diff-check step that fails the job if the branch
+  touches a denied path.
+- **Secrets / token scoping per job**:
+  - change-check job (exists): R2 keys (scoped use: the `change-detection/*` key only)
+    + `GITHUB_TOKEN` with `issues: write, contents: read` — unchanged.
+  - remediate job: `ANTHROPIC_API_KEY` in the agent step only; `GITHUB_TOKEN` with
+    `contents: write` (branch push), `pull-requests: write`, `issues: write` — and
+    nothing else: **no `actions:` permission** (cannot dispatch the quarterly publish),
+    **no R2 secrets in its env, ever** (cannot write the checksum store, the atlas DB,
+    or any artifact), no `id-token`. Read-only everywhere except branch-push and
+    PR/issue creation.
+  - dry-run job variant carries `issues: write` **only** — it cannot push even if
+    prompted to.
+- **The publish stays operator-dispatched**: `shadow-atlas-quarterly.yml` is human-
+  triggered, and its manifest-pinned download + sha256 verification chain
+  (L326-329, 429-449, 524-542) is the boundary the agent lane structurally cannot
+  cross — there is no code path from a merged acquisition-config PR to a published
+  artifact without the operator running the publish and its pin checks passing.
+- **Blast radius of a wrong merge**: acquisition code only. The worst outcome of a
+  bad agent PR that a human mistakenly merges is a broken *check*, which the next
+  daily run surfaces red or as a fresh breach — never a corrupted published atlas.
+
+---
+
+## Failure modes of the loop itself
+
+1. **Agent can't fix it** (upstream product discontinued, licensing wall, CAPTCHA,
+   politics): escalation comment with the evidence triad + `atlas-needs-human` label;
+   ledger → `escalated`; the lane will not re-fire for that source until a human
+   removes the label. Silence is impossible by contract — a post-step asserts exactly
+   one of {PR exists, escalation comment exists} and reddens the run otherwise (the
+   meta-alarm).
+2. **Runner quota / cost**: Actions minutes are free (public repo, standard runners).
+   Anthropic API spend is the only metered cost: bounded by `--max-turns`, **one
+   remediation run per source per 24h**, and a **global cap of 3 runs/day** (pre-flight
+   step counts today's workflow runs and no-ops beyond the cap). Steady state = $0.
+3. **Loop storm**: one open breach issue per source (dedupe-by-title, as P5 does);
+   the `labeled` trigger fires once per transition; the pre-flight guard no-ops if an
+   open PR matches `remediate/<source-id>/*` or ledger state is
+   `remediating`/`escalated`; 72h cooldown after a merged fix that did not heal before
+   a second attempt on the same source.
+4. **Plausible-but-wrong fix**: human merge + the three in-job gates + the live-probe
+   requirement; see blast-radius note above — published artifacts are unreachable.
+5. **False-positive breach** (transient upstream outage — Census maintenance windows
+   are real): retryBudget × daily cadence means ≥3 consecutive days of failure before a
+   fetch-breach; tune budgets during the observation phase, not after arming.
+6. **Fresh-ledger noise**: parallels the known first-R2-seeded-run caveat in the
+   change-check (`shadow-atlas-change-check.yml:122-125`). Never-succeeded sources get
+   one expectedInterval of staleness grace from registration; fetch-breach still
+   applies so a genuinely dead new source is caught.
+7. **The loop's own workflow breaks** (YAML rot, action deprecation, expired key): the
+   daily schedule reddens — deliberately the same red-run-as-staleness-alarm posture
+   the quarterly already uses (`shadow-atlas-quarterly.yml:87-97`).
+
+---
+
+## Rollout
+
+1. **P14 first — observe only.** Registry + ledger + daily probe lane + breach
+   evaluation + deduped breach issues, all inside the existing change-check workflow.
+   No agent. Bake for ≥2 weeks of daily runs; tune `retryBudget`/
+   `expectedIntervalDays` — and per-source probe methods against real upstream HEAD
+   behavior — against the observed false-positive rate (target: zero spurious breach
+   issues in a quiet week).
+2. **P15 second — dry-run before arming.** Ship `shadow-atlas-remediate.yml` with
+   `dry_run` defaulting `true`: the diagnose-only job (issues:write only) posts its
+   diagnosis + proposed fix as a breach-issue comment — no branch, no PR, structurally
+   no push permission. Human grades several real or induced-breach diagnoses.
+3. **Arm.** Flip the default to `dry_run: false`; the PR lane goes live. Auto-merge
+   stays off permanently; the operator publish ritual is unchanged.
+4. **Growth.** New sources — slots 10-19 special districts via the scanner
+   infrastructure (`jurisdiction.ts:255-305`), the provisioned `REDRAW_SIGNAL` feed
+   (commons `redraw-guard.ts`, ledger-elevated), international expansions — join by
+   adding one registry row each. That is the whole onboarding cost, and it is how
+   directive (1) compounds: every district we can resolve stays resolvable because the
+   source that feeds it cannot die silently.

--- a/docs/research/CICERO-DATA-COMPARISON.md
+++ b/docs/research/CICERO-DATA-COMPARISON.md
@@ -1,0 +1,108 @@
+# Cicero vs. Shadow Atlas — Founder Comparison (from the verified mapping, all sources re-fetched 2026-07-04)
+
+## The catalog gap
+
+Cicero's data breadth genuinely exceeds ours, and by a lot: they serve 13 live district types (8 legislative plus school, judicial, census, county, watershed — confirmed in their API enum) across a curated catalog of ~380 US local jurisdictions and ~55 Canadian ones, plus national/provincial coverage in the UK, Germany, Australia, and New Zealand, against our one live slot — US congressional. They claim 10,000+ current US officials with structured contact fields including 12 social account types [vendor-claimed, sponsored SD Times piece 2025-10-03]; we serve exactly 537, with state/local reach only via paid per-query agentic search and empty international tables. They are also the incumbent Google itself named as a successor when the Civic Representatives API shut down 2025-04-30 [verified]. Our county/sldu/sldl data exists in the source DB but is unserved; the 24-slot architecture is latent, theirs is shipping. That is a multi-year data-operations catalog we do not have, and no positioning language changes it.
+
+## Class-by-class table
+
+| Class | What we have live | What Cicero has | Cadence: us / them | Who wins + why |
+|---|---|---|---|---|
+| **1. Boundary geometry** | US congressional only, served; county/sldu/sldl ingested but unserved; 24-slot architecture latent. Per-resolve `tigerVintage`/`boundaryAsOf` | 13 district types incl. school/judicial/county/census/watershed; ~380 US + ~55 CA local jurisdictions; UK/DE/AU/NZ national+provincial; catalog doc dated 2022-11-29, pre-acquisition [verified] | TIGER-annual, published / 2-week post-approval upload [vendor-claimed 2021, never benchmarked; public tracker frozen at the 2020 cycle] | **Cicero on breadth, decisively.** We win boundary provenance — they expose no boundary-source vintage at all [verified absence]. Their cadence claim beats ours but is unauditable: frame as "claimed-faster, unauditable," never concede "faster" |
+| **2. Officials** | Exactly 537 (congress-legislators); state/local via agentic search, no DB; intl empty. `officialsAsOf` clock per resolve | "10,000+ current US officials" [vendor-claimed] spanning federal/state exec+leg + curated local; intl MPs; rich contact fields, 12 social types; committees self-admitted stale; no staff fields | Nightly-adjacent ours (clocked) / "daily refresh," same-day post-election [vendor-claimed]; per-record `last_update_date` only | **Cicero, ~20x on structured breadth.** Do not contest this class on coverage. Our only edges: the as-of clock, exactness of what we do claim, zero address egress |
+| **3. Address layer** | Atlas-native geocoder, self-hosted NAD + ADDRFEAT; raw address never leaves infra we control (hard constraint, satisfied by design) | Hosted geocode via unnamed third party (omgeo-schema inference, evidenced both ends); "rooftop" + 150M-address claims [vendor PR, no methodology]; no on-prem; addresses stored under a purpose-limited but transferable/sublicensable license, best-efforts deletion [verified ToU] | NAD quarterly + ADDRFEAT annual, published / Melissa address base, unspecified | **Split.** Assume Melissa wins raw precision until we benchmark (their claims are PR, but the prior favors a first-rank address company). We win custody outright and permanently — architecturally unfixable for a hosted product |
+| **4. Redraw signal** | 6 hand-curated state effective-dates; resolver fail-louds a confidence downgrade; no live feed | 2-week commitment [vendor, 2021]; `valid_on_or_after` future districts; free `redistricting_event` endpoint; tracker frozen 2021; zero public evidence on any 2023-26 redraw (AL/GA/NC/NY/LA/TX/MO/OH/CA) [verified absence of evidence] | Manual, published dates / claimed-fast, black-box since 2022 | **Split.** They win claimed 50-state coverage at low-medium confidence; we win auditability at high confidence. The asymmetry is the product: their freshness is a trust-me, ours is a show-you |
+| **5. Trust pins / provenance** | sha256 + Ed25519 signed manifests, on-chain anchoring, three independent per-resolve as-of clocks | `valid_from`/`valid_to`/`last_update_date` + geocode `score`/`partial_match`. That is the entire surface — no dataset clocks, no boundary vintage, no changelog, no versioned releases, no signatures [verified absence] | Quarterly signed releases / none | **Us, outright.** No Cicero analogue exists. This plus Class-3 custody is the spearhead |
+
+Pricing context for every row: Cicero is $0.0596/lookup at 5K down to $0.0088 at 1M [verified at cicerodata.com/pricing]. The old "$0.03-0.04" figure is true only at the 10K-25K tiers. Do not build a price umbrella above ~$0.01 for volume buyers.
+
+## What Cicero structurally cannot offer
+
+Only claims that survived verification:
+
+1. **Address sovereignty.** Every Cicero lookup ships the raw address to their hosted cloud and onward to an unnamed third-party geocoder, stored under a purpose-limited but transferable/sublicensable license with best-efforts-only deletion and no on-prem option [verified: API docs + ToU]. As a hosted product this is architecturally unfixable. It is our hard constraint, satisfied by design.
+2. **Auditable freshness.** They publish no boundary vintage, no dataset as-of clocks, no changelog, no versioned or signed releases [verified absence across docs, site, terms]. A customer cannot distinguish a Cicero district resolved against a current map from one resolved against a stale one. Our three per-resolve clocks and published effective dates make staleness inspectable.
+3. **Cryptographic verifiability.** No signatures, no anchoring, no manifest hashes — a category they lack entirely, reinforced by ~4 years of dormant public comms and a tracker frozen at the 2020 cycle [verified].
+4. **Fail-loud redraw semantics.** Cicero returns districts with no signal that a map is contested or newly redrawn; our resolver downgrades confidence and says so. Their mid-decade record 2023-26 is a public black box [verified absence of evidence — cite it as exactly that].
+5. **Honest coverage enumeration, ironically.** Their own artifacts triply contradict the "9 countries at all levels" homepage claim (availability PDF: 7 countries; Melissa's own acquisition PR: 6, with UK/DE/AU/NZ explicitly national+provincial only) [verified]. Usable offensively, and a standard we must hold ourselves to.
+
+## What this means for P11 + the refresh roadmap
+
+The comparison does not change the top of the roadmap — it sharpens why it's the top, and it reorders the middle.
+
+1. **The first operator-dispatched quarterly publish is now the whole ballgame, not just a checklist item.** Our entire winning axis is provable freshness, and until that dispatch lands, `officialsAsOf`/`boundaryAsOf` read `null` in prod. Cicero's weakness is unauditable freshness; ours today is *auditably null* — the worst possible version of our own pitch. Nothing else on the refresh roadmap matters until this flips.
+2. **Do not chase their cadence.** Daily-officials parity is a data-ops treadmill Melissa already funds, against a vendor-claimed number we can't falsify. Our differentiation is not recency, it's provable recency: quarterly-with-clocks beats claimed-daily-without-clocks for any buyer who needs to audit. Skip cadence-parity investments entirely.
+3. **The redraw-signal feed rises in relative priority.** The ledger ranks it LOW; the verified mid-decade black box argues it's the highest-leverage refresh item *after* the publish. Publishing effective dates + fail-loud downgrades for the 2023-26 redraws is a demonstrable, benchmarkable win in the one arena where Cicero has zero public record. Keep it posture-gated on feed-source cost, but move it ahead of the schedule-trigger and check-changes alarms in intent.
+4. **Refresh unit economics must survive sub-cent competition.** At 100K+ credits Cicero is $0.009-0.016/lookup [verified]. Per-resolve refresh cost has to stay compatible with that, or we price on the provenance axis (verified-resolve premium) rather than the commodity-lookup axis. The comparison says: price the axis we win.
+5. **Do not spend refresh money broadening the officials catalog pre-revenue.** 537 exact + agentic tail is the honest posture; a structured 10K-row DB is Cicero's moat, not ours.
+
+## Claims discipline
+
+What we still must not say:
+
+- **Never "fresher than Cicero"** — congressional or otherwise. Their claimed cadence beats TIGER-annual. Correct frame: "their freshness is claimed and unauditable; ours is published and signed."
+- **Never contest live breadth.** Our live reach is congressional-only. Do not cite the 24-slot architecture or CHUNKED-ATLAS spec slots as live coverage.
+- **Never quote "$0.03-0.04/lookup" as Cicero's price.** Tier-bound: true only at 10K-25K; $0.009-0.016 at volume.
+- **Never pitch their ToU as an unrestricted data land-grab.** The license grant is purpose-limited with a deletion clause. The honest — and still damning — form: hosted-only, raw addresses transit and are stored on infra they control under a transferable/sublicensable grant, best-efforts deletion, no on-prem.
+- **Never say Cicero "missed" the 2023-25 redraws.** No public evidence either way. Say: "no auditable public record of handling any post-2022 redraw."
+- **Mark as vendor-claimed, always:** 10,000+ officials, daily refresh, 2-week redistricting, rooftop precision, 3%/150M. None independently benchmarked.
+- **Don't demo the clocks as live proof until the quarterly publish lands.** They read null in prod today. Provenance ≠ recency, and we've written that into our own ledger — keep it in the pitch.
+
+Sources: cicerodata.com/pricing, app.cicerodata.com/docs, Cicero availability PDF (2022-11-29), Medium FAQ (2021-08-24), GlobeNewswire 2024-03-27, SD Times sponsored 2025-10-03, Yahoo 2024-11-13, dev.to ProgramEquity 2022-12-22, Google Civic turndown notice — all re-fetched 2026-07-04 per the verified mapping. Our-side facts: `docs/design/RESOLUTION-FRESHNESS-REMAINING.md` (commons), shadow-atlas live-reach memory (congressional-only, PRs #60/#61).
+
+---
+## CORRECTION (2026-07-04, post-publication — verified against the source DB + build code)
+The "one live slot" framing UNDERSTATES our data. The source DB carries ~93K districts
+across TEN slot types (cd 444, sldu 1,964, sldl 4,879, county 3,235, place 32,620,
+unsd/elsd/scsd 13,330, cousub 36,492, aiannh 864), and `build-h3-mapping.ts` maps ALL of
+them into the cell chunks (no layer filter; complete prefix→slot alias map). What is
+congressional-only is (a) the commons CONSUMER (`cellDistrictsToDistrict` reads slot 0;
+`lookupAllDistricts` has zero callers) and (b) OFFICIALS attachment (537 federal). The
+honest boundary-type gap vs Cicero's 13 is therefore "10 shipped-in-data vs 13, consumer
+wire-up pending (M9)" — they hold judicial/watershed/census we lack; we hold township/
+tribal/3-way-school granularity. Officials depth, international, curated local
+jurisdictions: their lead is unchanged. FOUNDER DIRECTIVE (2026-07-04): the empty slots
+(6, 10, 11-19, 21) "can't be left missing" — sourcing hunt + ingest waves tracked in
+docs/design/MISSING-SLOTS-SOURCING.md. Pending verification: slot occupancy in the BUILT
+chunks (assert against the new build's chunk-index when the publish lands).
+
+---
+## PARITY LEDGER (2026-07-04 — directive: "resolve all public data Cicero has — and more")
+
+Type-by-type against Cicero's 13-type API enum (8 legislative + school/judicial/census/
+county/watershed). Status legend: **LIVE** = served today · **IN-DATA** = in source DB +
+chunks, consumer wire-up = M9 · **W1/W2** = approved ingest wave (D2) · **GAP** = named,
+with the honest reason.
+
+| # | Cicero type | Our slot | Status | Path to parity-or-beyond |
+|---|---|---|---|---|
+| 1 | NATIONAL_LOWER (US House) | 0 | **LIVE** | — (the served slot) |
+| 2 | NATIONAL_UPPER (US Senate) | 1 | **LIVE** | 100 senators attach via state match |
+| 3 | NATIONAL_EXEC | n/a | GAP (trivial) | no polygon needed; static executive attach when officials lane opens |
+| 4 | STATE_UPPER | 2 | **IN-DATA** (1,964) | M9 |
+| 5 | STATE_LOWER | 3 | **IN-DATA** (4,879) | M9 |
+| 6 | STATE_EXEC | state poly | boundary ✔ / officials GAP | 50-row static gubernatorial table is cheap; officials lane deliberately unchased pre-revenue (roadmap §5) |
+| 7 | LOCAL (council) | 6 | **W2** | WI LTSB + ALGED (~150 cities) + big-city portals; place polys (slot 5, 32,620) live as city-level fallback. Cicero's own local coverage is ~380 CURATED jurisdictions — per-metro labels make our honest tail comparable, not embarrassing |
+| 8 | LOCAL_EXEC (mayor) | 5 | boundary **IN-DATA** / officials GAP | same officials lane |
+| 9 | COUNTY | 4 | **IN-DATA** (3,235) | M9 |
+| 10 | SCHOOL | 7/8/9 | **IN-DATA** (13,330) | M9 — and 3-way unified/elementary/secondary granularity vs their single type |
+| 11 | JUDICIAL | 19 | **W1** | federal 94 via §§81-131 statute-dissolve; state circuits W2 (whole-county states); sub-county circuits not derivable from open sources — labeled |
+| 12 | CENSUS | 23 | **W1** | TIGER tracts ~85K, `statistical` label |
+| 13 | WATERSHED | 23/17 | **W1 (addendum)** | USGS WBD HUC-8/10/12, PD national, `hydrologic` label — was the one unassigned type; closed by the 2026-07-04 addendum |
+
+**The "and more" column — in-data or approved, no Cicero analogue:** VTDs/precincts
+(slot 21, W1, CC0, "2020-vintage frozen until 2030"); townships/county-subdivisions
+(slot 20, IN-DATA 36,492); tribal AIANNH (slot 22, IN-DATA 864); drinking-water service
+areas (slot 11, W1, O8-gated); electric retail territories (slot 18, W1, O8-gated);
+CO's six special-district slots + TX water districts (W2, per-state); school-type
+granularity; and the provenance axis itself (three per-resolve clocks, signed manifests,
+on-chain anchoring — category-absent at Cicero).
+
+**Honest residual gaps after all approved waves:** structured officials depth (their
+10K+ vendor-claimed vs our 537-exact + agentic tail — deliberate, roadmap §5; cheap
+partial moves exist when wanted: 50 governors static, openstates/people CC0 ≈7.4K state
+legislators); international boundaries (their UK/DE/AU/NZ national+provincial + ~55 CA
+local vs our 4 officials-only ingest scripts — OSM/ODbL share-alike license review
+required before any signed republish, design-deferred); sub-county judicial; MT/OR VTD
+partial; CA community-college (blocked on FoundationCCC license). Serving gate for every
+row above: **M9**, then the built-chunk occupancy assertion.


### PR DESCRIPTION
Lands the founder-signed decision record and design docs from the resolution arc — these existed only on local disk:

- **MISSING-SLOTS-SOURCING** — verified slot×source×license table; DECISION block approving Wave 1 + Wave 2 in full (RDH removed on license AND currency grounds)
- **PRECINCT-CURRENCY-LANE** — per-state overlay strategy over the decennial 2020 VTD base; 23 confirmed statewide sources; 6 states flagged for license review before signing
- **SELF-HEALING-DATA-OPS** — per-source freshness SLOs + agent-diagnosed fix-PR lanes (agents touch acquisition config only, never published artifacts or trust pins)
- **CICERO-DATA-COMPARISON** — verified catalog comparison + parity ledger
- **RESOLUTION-FRESHNESS-REMAINING** — REDRAW_SIGNAL feed item elevated per the verified comparison

Docs only — no code paths.