### PR TITLE
feat(api): serve all populated district types from resolve-address

### DIFF
--- a/src/lib/core/shadow-atlas/client.ts
+++ b/src/lib/core/shadow-atlas/client.ts
@@ -30,6 +30,8 @@ import {
 } from './ipfs-store';
 import type { ResolutionProvenance } from './provenance';
 import { AddressIndexSchemaError } from './ipfs-store';
+import { US_SLOT_NAMES, CONGRESSIONAL_SLOT_INDEX } from './district-format';
+import { SERVED_SLOT_SET } from './coverage';
 import {
 	geocodeAddress,
 	matchClassPrecision,
@@ -249,40 +251,11 @@ export interface ShadowAtlasResponse {
 // ============================================================================
 
 /**
- * Slot index → jurisdiction metadata.
- * Inline from voter-protocol jurisdiction.ts (will import after cross-repo exports P0).
+ * Slot index → jurisdiction metadata: US_SLOT_NAMES, imported from
+ * ./district-format (shared server/browser module) alongside
+ * CONGRESSIONAL_SLOT_INDEX. The served-slot allowlist gating which slots
+ * reach the public wire lives in ./coverage (SERVED_SLOT_SET).
  */
-/**
- * Canonical slot → jurisdiction mapping.
- * MUST match voter-protocol CIRCUIT_SLOT_NAMES (authority-mapper.ts)
- * and US_JURISDICTION (jurisdiction.ts). Any divergence is a correctness bug.
- */
-const US_SLOT_NAMES: ReadonlyArray<{ jurisdiction: string; label: string }> = [
-	/* 0  */ { jurisdiction: 'congressional', label: 'Congressional District' },
-	/* 1  */ { jurisdiction: 'federal-senate', label: 'Federal Senate' },
-	/* 2  */ { jurisdiction: 'state-senate', label: 'State Senate' },
-	/* 3  */ { jurisdiction: 'state-house', label: 'State House/Assembly' },
-	/* 4  */ { jurisdiction: 'county', label: 'County' },
-	/* 5  */ { jurisdiction: 'city', label: 'City/Municipality' },
-	/* 6  */ { jurisdiction: 'city-council', label: 'City Council Ward' },
-	/* 7  */ { jurisdiction: 'unified-school', label: 'Unified School District' },
-	/* 8  */ { jurisdiction: 'elementary-school', label: 'Elementary School District' },
-	/* 9  */ { jurisdiction: 'secondary-school', label: 'Secondary School District' },
-	/* 10 */ { jurisdiction: 'community-college', label: 'Community College District' },
-	/* 11 */ { jurisdiction: 'water-sewer', label: 'Water/Sewer District' },
-	/* 12 */ { jurisdiction: 'fire', label: 'Fire/EMS District' },
-	/* 13 */ { jurisdiction: 'transit', label: 'Transit District' },
-	/* 14 */ { jurisdiction: 'hospital', label: 'Hospital District' },
-	/* 15 */ { jurisdiction: 'library', label: 'Library District' },
-	/* 16 */ { jurisdiction: 'park', label: 'Parks/Recreation District' },
-	/* 17 */ { jurisdiction: 'conservation', label: 'Conservation District' },
-	/* 18 */ { jurisdiction: 'utility', label: 'Utility District' },
-	/* 19 */ { jurisdiction: 'judicial', label: 'Judicial District' },
-	/* 20 */ { jurisdiction: 'township', label: 'Township/MCD' },
-	/* 21 */ { jurisdiction: 'precinct', label: 'Voting Precinct' },
-	/* 22 */ { jurisdiction: 'tribal', label: 'Tribal/Native Area' },
-	/* 23 */ { jurisdiction: 'overflow', label: 'Other Special District' },
-];
 
 /**
  * Result of a multi-district lookup across all 24 jurisdiction slots.
@@ -309,7 +282,7 @@ function slotToDistrict(slotValue: string, slotIndex: number): District {
 	const jurisdiction = meta?.jurisdiction ?? `slot-${slotIndex}`;
 
 	// Congressional district (slot 0): convert substrate ID format
-	if (slotIndex === 0) {
+	if (slotIndex === CONGRESSIONAL_SLOT_INDEX) {
 		const districtCode = convertDistrictId(slotValue);
 		return {
 			id: districtCode,
@@ -352,7 +325,7 @@ function cellDistrictsToMulti(cellDistricts: CellDistricts): MultiDistrictResult
  * Returns the congressional district (slot 0).
  */
 function cellDistrictsToDistrict(cellDistricts: CellDistricts): District {
-	const cdRaw = cellDistricts.slots[0];
+	const cdRaw = cellDistricts.slots[CONGRESSIONAL_SLOT_INDEX];
 	if (!cdRaw) {
 		throw new Error('Cell has no congressional district assignment');
 	}
@@ -364,6 +337,65 @@ function cellDistrictsToDistrict(cellDistricts: CellDistricts): District {
 		jurisdiction: 'congressional',
 		districtType: 'congressional',
 	};
+}
+
+/**
+ * One resolved boundary entry in the multi-type districts array.
+ * Wire-shape (snake_case district_type) for parity with the legacy district field.
+ */
+export interface ResolvedDistrictEntry {
+	/**
+	 * Stable district identifier.
+	 * - congressional: display code "MN-08" / "VT-AL" (identical to the legacy district.id)
+	 * - all other types: atlas id "{type-alias}-{TIGER GEOID}", e.g. "sldu-27011"
+	 */
+	id: string;
+	/** Raw TIGER/Census GEOID with the alias prefix stripped, e.g. "27011", "2711B", "2708". */
+	geoid: string;
+	/** Human-readable name, e.g. "Minnesota's 8th Congressional District", "State Senate 27011". */
+	name: string;
+	/** Public district-type slug (see US_SLOT_NAMES) — same value as district_type. */
+	jurisdiction: string;
+	/** Public district-type slug, e.g. "congressional", "state-senate", "county". */
+	district_type: string;
+}
+
+/**
+ * Project a cell's slot array onto the public multi-type wire shape.
+ * Emits ONLY slots in the served allowlist (SERVED_SLOT_SET) — a type never
+ * reaches the wire unless the coverage disclosure describes it. Ordered by
+ * canonical slot index ascending.
+ */
+function slotsToResolvedDistricts(slots: (string | null)[]): ResolvedDistrictEntry[] {
+	const out: ResolvedDistrictEntry[] = [];
+	for (let i = 0; i < slots.length; i++) {
+		const raw = slots[i];
+		// typeof guard: a malformed publish putting a non-string in ANY served
+		// slot must skip that slot, never take down the whole resolution.
+		if (!raw || typeof raw !== 'string' || !SERVED_SLOT_SET.has(i)) continue;
+		const meta = US_SLOT_NAMES[i];
+		const jurisdiction = meta?.jurisdiction ?? `slot-${i}`;
+		const geoid = raw.replace(/^[a-z]+-/, '');
+		if (i === CONGRESSIONAL_SLOT_INDEX) {
+			const code = convertDistrictId(raw);
+			out.push({
+				id: code,
+				geoid,
+				name: buildDistrictName(code),
+				jurisdiction,
+				district_type: jurisdiction,
+			});
+		} else {
+			out.push({
+				id: raw,
+				geoid,
+				name: `${meta?.label ?? jurisdiction} ${geoid}`,
+				jurisdiction,
+				district_type: jurisdiction,
+			});
+		}
+	}
+	return out;
 }
 
 /**
@@ -379,6 +411,58 @@ export class AtlasInfraError extends Error {
 		super(message, options);
 		this.name = 'AtlasInfraError';
 	}
+}
+
+/**
+ * Fetch the 24-slot district array for a coordinate. Single source of the
+ * chunk-fetch + infra-classification logic shared by the single- and
+ * multi-type views (lookupDistrict and resolveAddress).
+ *
+ * @throws AtlasInfraError on a store infrastructure fault (never a coverage miss)
+ * @throws Error('No district data…') on an honest outside-coverage miss
+ * @throws Error on invalid coordinates
+ */
+async function lookupCellSlots(
+	lat: number,
+	lng: number,
+): Promise<{ cellIndex: string; slots: (string | null)[] }> {
+	if (lat < -90 || lat > 90) {
+		throw new Error(`Invalid latitude: ${lat}. Must be between -90 and 90.`);
+	}
+	if (lng < -180 || lng > 180) {
+		throw new Error(`Invalid longitude: ${lng}. Must be between -180 and 180.`);
+	}
+
+	const cellIndex = latLngToCell(lat, lng, H3_RESOLUTION);
+
+	// Fetch only the ~8 KB chunk for this cell's H3 res-3 parent.
+	// getChunkForCell already converts a clean all-404 (ContentNotFoundError) to null —
+	// the honest coverage miss handled below. Any other rejection is an infrastructure
+	// fault (5xx, timeout, DNS), classified as AtlasInfraError so callers never convert
+	// an outage into a district miss.
+	let slots: (string | null)[] | null;
+	try {
+		slots = await getChunkForCell(cellIndex);
+	} catch (err) {
+		if (err instanceof ContentNotFoundError) {
+			slots = null;
+		} else {
+			throw new AtlasInfraError(
+				`Atlas chunk fetch failed for cell ${cellIndex}: ` +
+					(err instanceof Error ? err.message : String(err)),
+				{ cause: err },
+			);
+		}
+	}
+
+	if (!slots) {
+		throw new Error(
+			`No district data for H3 cell ${cellIndex} at (${lat.toFixed(4)}, ${lng.toFixed(4)}). ` +
+			'Location may be outside US coverage area.'
+		);
+	}
+
+	return { cellIndex, slots };
 }
 
 /**
@@ -402,42 +486,10 @@ export async function lookupDistrict(lat: number, lng: number): Promise<District
 	}
 
 	try {
-		const cellIndex = latLngToCell(lat, lng, H3_RESOLUTION);
-
-		let cellDistricts: CellDistricts | undefined;
-
-		// Fetch only the ~8 KB chunk for this cell's H3 res-3 parent.
-		// getChunkForCell already converts a clean all-404 (ContentNotFoundError) to null —
-		// the honest coverage miss handled below. Any other rejection is an infrastructure
-		// fault (5xx, timeout, DNS), classified as AtlasInfraError so callers never convert
-		// an outage into a district miss.
-		let slots: (string | null)[] | null;
-		try {
-			slots = await getChunkForCell(cellIndex);
-		} catch (err) {
-			if (err instanceof ContentNotFoundError) {
-				slots = null;
-			} else {
-				throw new AtlasInfraError(
-					`Atlas chunk fetch failed for cell ${cellIndex}: ` +
-						(err instanceof Error ? err.message : String(err)),
-					{ cause: err },
-				);
-			}
-		}
-		if (slots) {
-			cellDistricts = { slots };
-		}
-
-		if (!cellDistricts) {
-			throw new Error(
-				`No district data for H3 cell ${cellIndex} at (${lat.toFixed(4)}, ${lng.toFixed(4)}). ` +
-				'Location may be outside US coverage area.'
-			);
-		}
+		const { cellIndex, slots } = await lookupCellSlots(lat, lng);
 
 		return {
-			district: cellDistrictsToDistrict(cellDistricts),
+			district: cellDistrictsToDistrict({ slots }),
 			// Merkle proof: null until cipher integrates client-side path computation.
 			// Callers already handle null proof (serve-only mode).
 			merkleProof: null,
@@ -1128,6 +1180,14 @@ export interface AddressResolutionResult {
 		jurisdiction: string;
 		district_type: string;
 	} | null;
+	/**
+	 * ALL populated, served boundary types for the resolved cell, ordered by canonical
+	 * slot index ascending (congressional first when present). Includes the congressional
+	 * entry (same id as `district`). [] when the cell is outside coverage. Only types in
+	 * the served-slot allowlist are emitted — a type never appears here unless the
+	 * coverage disclosure describes it.
+	 */
+	districts: ResolvedDistrictEntry[];
 	officials: OfficialsResponse | null;
 	cell_id: string | null;
 	/** Resolution provenance — source + boundary-geometry vintage (mirrors upstream ProvenanceRecord). */
@@ -1246,20 +1306,32 @@ export async function resolveAddress(address: {
 	const { lat, lng, matchedAddress } = geocoded;
 	const precisionFactor = matchClassPrecision(geocoded.matchClass);
 
-	// Step 2: District lookup via H3 + IPFS (local, no server call)
+	// Step 2: District lookup via H3 + atlas chunk (local, no server call).
+	// ONE chunk fetch feeds both views: the legacy slot-0 district (back-compat,
+	// confidence semantics unchanged) and the multi-type districts array.
 	let district: AddressResolutionResult['district'] = null;
+	let districts: ResolvedDistrictEntry[] = [];
 	let cellId: string | null = null;
 	let districtMissed = false;
 
 	try {
-		const lookupResult = await lookupDistrict(lat, lng);
-		district = {
-			id: lookupResult.district.id,
-			name: lookupResult.district.name,
-			jurisdiction: lookupResult.district.jurisdiction,
-			district_type: lookupResult.district.districtType,
-		};
-		cellId = lookupResult.cell_id;
+		const { cellIndex, slots } = await lookupCellSlots(lat, lng);
+		cellId = cellIndex;
+		districts = slotsToResolvedDistricts(slots);
+		const primary = districts.find((d) => d.district_type === 'congressional') ?? null;
+		if (primary) {
+			district = {
+				id: primary.id,
+				name: primary.name,
+				jurisdiction: primary.jurisdiction,
+				district_type: primary.district_type,
+			};
+		} else {
+			// Chunk exists but carries no congressional assignment: the PRIMARY miss
+			// semantics stay keyed to slot 0 exactly as before (confidence 0 + warning),
+			// while any populated non-congressional boundaries still surface honestly.
+			districtMissed = true;
+		}
 	} catch (err) {
 		// An atlas infrastructure fault (R2/IPFS outage, timeout) is NOT a coverage miss —
 		// it must never be converted into a districtMissed (billable) result. Propagate it.
@@ -1329,6 +1401,7 @@ export async function resolveAddress(address: {
 			country: countryCode,
 		},
 		district,
+		districts,
 		officials,
 		cell_id: cellId,
 		provenance,

--- a/src/lib/core/shadow-atlas/client.ts
+++ b/src/lib/core/shadow-atlas/client.ts
@@ -375,7 +375,10 @@ function slotsToResolvedDistricts(slots: (string | null)[]): ResolvedDistrictEnt
 		if (!raw || typeof raw !== 'string' || !SERVED_SLOT_SET.has(i)) continue;
 		const meta = US_SLOT_NAMES[i];
 		const jurisdiction = meta?.jurisdiction ?? `slot-${i}`;
-		const geoid = raw.replace(/^[a-z]+-/, '');
+		// Strip through the FIRST hyphen whatever the alias prefix contains
+		// (letters today; digits/underscores must not break geoid derivation).
+		const sep = raw.indexOf('-');
+		const geoid = sep > 0 ? raw.slice(sep + 1) : raw;
 		if (i === CONGRESSIONAL_SLOT_INDEX) {
 			const code = convertDistrictId(raw);
 			out.push({

--- a/src/lib/core/shadow-atlas/coverage.ts
+++ b/src/lib/core/shadow-atlas/coverage.ts
@@ -1,0 +1,92 @@
+/**
+ * Per-district-type coverage disclosure for the resolve-address API.
+ *
+ * HONESTY CONTRACT: this table is the allowlist of served boundary types. A slot
+ * is emitted in resolve results ONLY if listed here, so disclosure and emission
+ * can never drift. When an atlas publish populates a new slot, serving it requires
+ * adding a row here (and updating the OpenAPI mirror) — verified by unit tests.
+ *
+ * Coverage classes are machine-readable and factual, never marketing adjectives:
+ *   - 'national': present wherever that district type exists in US governance.
+ *   - 'partial':  known regional/structural limits or build gaps — absence of the
+ *     type in a response is NOT evidence that no such district exists there.
+ * A type absent from this table has zero live atlas data and is not served at all.
+ *
+ * Freshness is NOT stamped here — it already lives in the response's asOf clocks
+ * and provenance.tigerVintage. This table is code-versioned with the deploy.
+ * Ops rule: on each atlas publish, diff the live district-index top-level slot
+ * keys against SERVED_SLOTS and reconcile before flipping the version pin.
+ */
+import { US_SLOT_NAMES } from './district-format';
+
+export type CoverageClass = 'national' | 'partial';
+
+export interface DistrictTypeCoverage {
+	coverage: CoverageClass;
+	/** Factual scope note (governance-structure reality or known build gap). */
+	note?: string;
+}
+
+export interface ResolveCoverage {
+	/** Keyed by public district_type. A type absent from this map is not served at all. */
+	boundaryTypes: Record<string, DistrictTypeCoverage>;
+	/** District types for which officials rosters exist. Currently ['congressional']. */
+	officialsTypes: readonly string[];
+}
+
+/** Slots with live atlas data, in canonical slot order. Keep in sync with the atlas publish. */
+const SERVED_SLOTS: ReadonlyArray<{ slot: number } & DistrictTypeCoverage> = [
+	{ slot: 0, coverage: 'national' },
+	{ slot: 2, coverage: 'national' },
+	{
+		slot: 3,
+		coverage: 'national',
+		note: 'Nebraska (unicameral legislature) and DC have no state house layer.'
+	},
+	{ slot: 4, coverage: 'national' },
+	{
+		slot: 5,
+		coverage: 'partial',
+		note: 'Incorporated places only, and place ingestion is incomplete in the current build; absence does not by itself mean an unincorporated location.'
+	},
+	{
+		slot: 7,
+		coverage: 'national',
+		note: 'Absent where a state splits elementary/secondary school districts — see elementary-school and secondary-school.'
+	},
+	{
+		slot: 8,
+		coverage: 'partial',
+		note: 'Only in states that operate split elementary/secondary school districts.'
+	},
+	{
+		slot: 9,
+		coverage: 'partial',
+		note: 'Only in states that operate split elementary/secondary school districts.'
+	},
+	{ slot: 20, coverage: 'national' },
+	{
+		slot: 22,
+		coverage: 'partial',
+		note: 'Federally recognized tribal areas; ingestion is incomplete in the current build.'
+	}
+];
+
+/** Fast membership check used by the resolver to gate slot emission. */
+export const SERVED_SLOT_SET: ReadonlySet<number> = new Set(SERVED_SLOTS.map((s) => s.slot));
+
+/**
+ * Static disclosure object embedded in every resolve-address response.
+ * Deeply frozen — one shared instance serves every request.
+ */
+export const DISTRICT_COVERAGE: ResolveCoverage = Object.freeze({
+	boundaryTypes: Object.freeze(
+		Object.fromEntries(
+			SERVED_SLOTS.map(({ slot, coverage, note }) => [
+				US_SLOT_NAMES[slot].jurisdiction,
+				Object.freeze(note ? { coverage, note } : { coverage })
+			])
+		)
+	),
+	officialsTypes: Object.freeze(['congressional'])
+});

--- a/src/lib/core/shadow-atlas/district-format.ts
+++ b/src/lib/core/shadow-atlas/district-format.ts
@@ -40,6 +40,42 @@ const FIPS_TO_STATE: Record<string, string> = {
 export const CONGRESSIONAL_SLOT_INDEX = 0;
 
 /**
+ * Canonical slot → jurisdiction mapping for the 24-slot districts[] array
+ * stored in atlas chunks and proof public inputs.
+ *
+ * MUST match voter-protocol CIRCUIT_SLOT_NAMES (authority-mapper.ts) and
+ * US_JURISDICTION (jurisdiction.ts). Any divergence is a correctness bug.
+ * The `jurisdiction` slugs are the public, stable district_type identifiers
+ * emitted on the wire — never renamed or reused; new types may be added.
+ */
+export const US_SLOT_NAMES: ReadonlyArray<{ jurisdiction: string; label: string }> = [
+	/* 0  */ { jurisdiction: 'congressional', label: 'Congressional District' },
+	/* 1  */ { jurisdiction: 'federal-senate', label: 'Federal Senate' },
+	/* 2  */ { jurisdiction: 'state-senate', label: 'State Senate' },
+	/* 3  */ { jurisdiction: 'state-house', label: 'State House/Assembly' },
+	/* 4  */ { jurisdiction: 'county', label: 'County' },
+	/* 5  */ { jurisdiction: 'city', label: 'City/Municipality' },
+	/* 6  */ { jurisdiction: 'city-council', label: 'City Council Ward' },
+	/* 7  */ { jurisdiction: 'unified-school', label: 'Unified School District' },
+	/* 8  */ { jurisdiction: 'elementary-school', label: 'Elementary School District' },
+	/* 9  */ { jurisdiction: 'secondary-school', label: 'Secondary School District' },
+	/* 10 */ { jurisdiction: 'community-college', label: 'Community College District' },
+	/* 11 */ { jurisdiction: 'water-sewer', label: 'Water/Sewer District' },
+	/* 12 */ { jurisdiction: 'fire', label: 'Fire/EMS District' },
+	/* 13 */ { jurisdiction: 'transit', label: 'Transit District' },
+	/* 14 */ { jurisdiction: 'hospital', label: 'Hospital District' },
+	/* 15 */ { jurisdiction: 'library', label: 'Library District' },
+	/* 16 */ { jurisdiction: 'park', label: 'Parks/Recreation District' },
+	/* 17 */ { jurisdiction: 'conservation', label: 'Conservation District' },
+	/* 18 */ { jurisdiction: 'utility', label: 'Utility District' },
+	/* 19 */ { jurisdiction: 'judicial', label: 'Judicial District' },
+	/* 20 */ { jurisdiction: 'township', label: 'Township/MCD' },
+	/* 21 */ { jurisdiction: 'precinct', label: 'Voting Precinct' },
+	/* 22 */ { jurisdiction: 'tribal', label: 'Tribal/Native Area' },
+	/* 23 */ { jurisdiction: 'overflow', label: 'Other Special District' },
+];
+
+/**
  * Compare two BN254 field hex strings by numeric value, not string equality.
  *
  * `0x1`, `0x01`, `0x0001` all represent the same field element but compare

--- a/src/lib/server/api-v1/openapi.ts
+++ b/src/lib/server/api-v1/openapi.ts
@@ -8,7 +8,7 @@ export const openApiSpec = {
 	openapi: '3.1.0',
 	info: {
 		title: 'Commons Public API',
-		version: '1.0.0',
+		version: '1.1.0',
 		description:
 			'Public REST API for Commons — campaign management, supporter CRM, and verified civic action. All endpoints require Bearer token authentication via API key (prefix ck_live_). Rate limited to 100 requests per minute per key.'
 	},
@@ -1060,7 +1060,7 @@ export const openApiSpec = {
 				operationId: 'resolveAddress',
 				summary: 'Resolve a US street address to district + officials',
 				description:
-					'Resolve a street address to its district, officials, and two independent freshness clocks (boundary geometry vs. officials sync). Requires read scope and a Bearer ck_live_ key. POST is metered and rate-capped per plan; inactive/no-plan keys receive a finite free-trial quota, not recurring free volume. Retries WITHOUT an Idempotency-Key re-bill under a fresh requestId; resupplying the same key WITH THE SAME address payload bills once (the key is bound to the payload — the same key with a different address is a distinct billable request, not an error).',
+					'Resolve a street address to its district, officials, and two independent freshness clocks (boundary geometry vs. officials sync). Requires read scope and a Bearer ck_live_ key. POST is metered and rate-capped per plan; inactive/no-plan keys receive a finite free-trial quota, not recurring free volume. Retries WITHOUT an Idempotency-Key re-bill under a fresh requestId; resupplying the same key WITH THE SAME address payload bills once (the key is bound to the payload — the same key with a different address is a distinct billable request, not an error). Returns the congressional district (`district`, unchanged) plus `districts`, an array of every boundary type the atlas serves at that address (state legislative, county, city, school, township, tribal — see `coverage.boundaryTypes` for the honest per-type coverage class). Officials rosters exist for congressional districts only (`coverage.officialsTypes`); other entries carry boundary identity without officials. Billing is per resolution call, never per district type returned.',
 				parameters: [
 					{
 						name: 'Idempotency-Key',
@@ -2094,9 +2094,27 @@ export const openApiSpec = {
 									id: { type: 'string', description: 'District id, e.g. "CA-12"' },
 									name: { type: 'string', description: 'Human-readable district name' },
 									jurisdiction: { type: 'string' },
-									district_type: { type: 'string', description: 'e.g. "congressional"' }
+									district_type: {
+										type: 'string',
+										enum: ['congressional'],
+										description:
+											"Always 'congressional' — this field is the congressional district. See districts[] for all boundary types."
+									}
 								}
 							},
+							districts: {
+								type: 'array',
+								items: { $ref: '#/components/schemas/ResolvedDistrict' },
+								description:
+									'All boundary types served at this address, ordered by broadest federal first ' +
+									'(congressional, then state legislative, county, city, school, township, tribal). ' +
+									'Includes the congressional entry (same id as district) when present. Empty when outside coverage; may be non-empty with district null if only non-congressional types resolve. ' +
+									'Only types listed in coverage.boundaryTypes can appear; absence of a listed type means ' +
+									'either no such district exists at this address or the data is partial for that type — ' +
+									'consult its coverage class. district_type is an open set: new types may be added, ' +
+									'existing values are never renamed.'
+							},
+							coverage: { $ref: '#/components/schemas/ResolveCoverage' },
 							provenance: { $ref: '#/components/schemas/ResolutionProvenance' },
 							confidence: {
 								type: 'number',
@@ -2131,6 +2149,62 @@ export const openApiSpec = {
 								description:
 									'Degraded-but-resolved guard. Its own field — never borrows either asOf clock.'
 							}
+				}
+			},
+			ResolvedDistrict: {
+				type: 'object',
+				required: ['id', 'geoid', 'name', 'jurisdiction', 'district_type'],
+				properties: {
+					id: {
+						type: 'string',
+						description:
+							'Stable district id. Congressional: display code ("MN-08"); other types: "{type-alias}-{TIGER GEOID}" ("sldu-27011").'
+					},
+					geoid: {
+						type: 'string',
+						description:
+							'Raw TIGER/Census GEOID ("27011", "2711B") — joinable against Census data products.'
+					},
+					name: { type: 'string' },
+					jurisdiction: { type: 'string', description: 'Same value as district_type.' },
+					district_type: {
+						type: 'string',
+						description:
+							'Stable boundary-type identifier. Currently served: congressional, state-senate, ' +
+							'state-house, county, city, unified-school, elementary-school, secondary-school, ' +
+							'township, tribal. Open set — clients must tolerate new values.'
+					}
+				}
+			},
+			ResolveCoverage: {
+				type: 'object',
+				required: ['boundaryTypes', 'officialsTypes'],
+				properties: {
+					boundaryTypes: {
+						type: 'object',
+						description:
+							'Per-district-type coverage disclosure, keyed by district_type. A type ABSENT from ' +
+							'this map is not served at all. "national": present wherever that district type ' +
+							'exists in US governance. "partial": known regional/structural limits or build gaps ' +
+							'— absence of that type in districts[] is not evidence no such district exists.',
+						additionalProperties: {
+							type: 'object',
+							required: ['coverage'],
+							properties: {
+								coverage: { type: 'string', enum: ['national', 'partial'] },
+								note: {
+									type: 'string',
+									description: 'Factual scope note (governance structure or known data gap).'
+								}
+							}
+						}
+					},
+					officialsTypes: {
+						type: 'array',
+						items: { type: 'string' },
+						description:
+							'District types with officials rosters. Currently ["congressional"] — all other entries carry boundary identity without officials.'
+					}
 				}
 			},
 			ErrorEnvelope: {

--- a/src/routes/api/v1/resolve-address/+server.ts
+++ b/src/routes/api/v1/resolve-address/+server.ts
@@ -14,6 +14,7 @@ import { requirePublicApi } from '$lib/server/api-v1/gate';
 import { checkApiPlanRateLimit } from '$lib/server/api-v1/rate-limit';
 import { apiOk, apiError } from '$lib/server/api-v1/response';
 import { resolveAddress, AtlasInfraError } from '$lib/core/shadow-atlas/client';
+import { DISTRICT_COVERAGE } from '$lib/core/shadow-atlas/coverage';
 import { serverMutation, serverQuery } from 'convex-sveltekit';
 import { api } from '$lib/convex';
 import { resolveAllowanceForPlan } from '$lib/server/billing/plans';
@@ -152,6 +153,15 @@ export const POST: RequestHandler = async ({ request }) => {
 		// The two freshness clocks are surfaced as DISTINCT keys, never collapsed.
 		const data = {
 			district: r.district,
+			// Additive multi-type view: every populated, served boundary type for the
+			// resolved cell (congressional included, same id as `district`). [] on an
+			// outside-coverage miss. Billing is UNCHANGED — one resolution is one metered
+			// event regardless of how many boundary types return (quantity: 1 below).
+			districts: r.districts ?? [],
+			// Static machine-readable coverage disclosure: which boundary types this API
+			// serves, each with an honest national/partial class, plus which types carry
+			// officials rosters (congressional only). Absent type = not served at all.
+			coverage: DISTRICT_COVERAGE,
 			provenance: r.provenance,
 			confidence: r.confidence,
 			asOf: {

--- a/tests/integration/components/address-collection-form.test.ts
+++ b/tests/integration/components/address-collection-form.test.ts
@@ -150,6 +150,7 @@ function shadowAtlasResponse(overrides: ResolveOverrides = {}): AddressResolutio
 			jurisdiction: districtJurisdiction,
 			district_type: districtType
 		},
+		districts: [],
 		officials,
 		cell_id: cellId,
 		provenance,

--- a/tests/unit/api-v1/openapi-resolve-address.test.ts
+++ b/tests/unit/api-v1/openapi-resolve-address.test.ts
@@ -10,6 +10,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { openApiSpec } from '$lib/server/api-v1/openapi';
+import { DISTRICT_COVERAGE } from '$lib/core/shadow-atlas/coverage';
 
 // JSON round-trip to assert the spec is a plain serializable object (as served).
 const spec = JSON.parse(JSON.stringify(openApiSpec));
@@ -79,6 +80,46 @@ describe('OpenAPI: /resolve-address', () => {
 			'district_type'
 		]);
 		expect(district.description.toLowerCase()).toContain('outside coverage');
+	});
+
+	it("pins the legacy district.district_type to exactly ['congressional'] — no implied multi-type promise", () => {
+		const districtType =
+			spec.components.schemas.ResolveAddressResult.properties.district.properties.district_type;
+		expect(districtType.enum).toEqual(['congressional']);
+	});
+
+	it('documents districts as an array of ResolvedDistrict with the exact required wire fields', () => {
+		const districts = spec.components.schemas.ResolveAddressResult.properties.districts;
+		expect(districts).toBeDefined();
+		expect(districts.type).toBe('array');
+		expect(districts.items.$ref).toBe('#/components/schemas/ResolvedDistrict');
+
+		const resolved = spec.components.schemas.ResolvedDistrict;
+		expect(resolved.required).toEqual(['id', 'geoid', 'name', 'jurisdiction', 'district_type']);
+	});
+
+	it('documents coverage as ResolveCoverage with required disclosure keys and the exact class enum', () => {
+		const coverage = spec.components.schemas.ResolveAddressResult.properties.coverage;
+		expect(coverage.$ref).toBe('#/components/schemas/ResolveCoverage');
+
+		const resolveCoverage = spec.components.schemas.ResolveCoverage;
+		expect(resolveCoverage.required).toEqual(['boundaryTypes', 'officialsTypes']);
+		expect(
+			resolveCoverage.properties.boundaryTypes.additionalProperties.properties.coverage.enum
+		).toEqual(['national', 'partial']);
+	});
+
+	it('names every served district_type from the live coverage table in the spec (anti-drift)', () => {
+		// Mirrors the zod-schema-match pattern above: the ResolvedDistrict
+		// district_type description enumerates the served types, so serving a new
+		// slot without updating the published contract fails red here.
+		const description: string =
+			spec.components.schemas.ResolvedDistrict.properties.district_type.description;
+		for (const districtType of Object.keys(DISTRICT_COVERAGE.boundaryTypes)) {
+			expect(description, `spec missing served district_type ${districtType}`).toContain(
+				districtType
+			);
+		}
 	});
 
 	it('matches the live zod addressSchema for ResolveAddressInput', () => {

--- a/tests/unit/api-v1/resolve-address.test.ts
+++ b/tests/unit/api-v1/resolve-address.test.ts
@@ -97,6 +97,9 @@ const { POST: resolveAddressHandler } = await import(
 // Routed through the mock above, which re-exports the actual class — so
 // instances constructed here are the SAME class the handler checks against.
 const { AtlasInfraError } = await import('$lib/core/shadow-atlas/client');
+// The REAL coverage module (only the client module is mocked): the handler embeds
+// this exact static disclosure object in every response.
+const { DISTRICT_COVERAGE } = await import('$lib/core/shadow-atlas/coverage');
 
 // =============================================================================
 // HELPERS
@@ -126,6 +129,11 @@ const ENRICHED_RESULT = {
 		country: 'US'
 	},
 	district: { id: 'CA-12', name: 'California 12th', jurisdiction: 'US', district_type: 'congressional' },
+	districts: [
+		{ id: 'CA-12', geoid: '0612', name: 'California 12th', jurisdiction: 'congressional', district_type: 'congressional' },
+		{ id: 'sldu-06011', geoid: '06011', name: 'State Senate 06011', jurisdiction: 'state-senate', district_type: 'state-senate' },
+		{ id: 'county-06075', geoid: '06075', name: 'County 06075', jurisdiction: 'county', district_type: 'county' }
+	],
 	officials: {
 		officials: [
 			{ name: 'Rep. Example', party: 'D', chamber: 'house', state: 'CA', district: '12', office: 'Representative, CA' }
@@ -230,6 +238,13 @@ describe('POST /api/v1/resolve-address', () => {
 
 		expect(res.status).toBe(200);
 		expect(body.data.district).toEqual(ENRICHED_RESULT.district);
+		// The multi-type view passes through verbatim (congressional entry included).
+		expect(body.data.districts).toEqual(ENRICHED_RESULT.districts);
+		// The static coverage disclosure is embedded in every response, and it is the
+		// REAL module object — which boundary types are served, at what honesty class,
+		// and that officials rosters are congressional-only.
+		expect(body.data.coverage).toEqual(JSON.parse(JSON.stringify(DISTRICT_COVERAGE)));
+		expect(body.data.coverage.officialsTypes).toEqual(['congressional']);
 		expect(body.data.provenance).toEqual({ source: 'nominatim', tigerVintage: '2023' });
 		expect(body.data.confidence).toBe(1.0);
 		expect(body.data.officials).toHaveLength(1);
@@ -262,6 +277,7 @@ describe('POST /api/v1/resolve-address', () => {
 		mockResolveAddress.mockResolvedValue({
 			...ENRICHED_RESULT,
 			district: null,
+			districts: [],
 			officials: null,
 			confidence: 0,
 			boundaryAsOf: null,
@@ -273,9 +289,47 @@ describe('POST /api/v1/resolve-address', () => {
 
 		expect(res.status).toBe(200);
 		expect(body.data.district).toBeNull();
+		// The multi-type view round-trips the honest empty array.
+		expect(body.data.districts).toEqual([]);
 		// The substrate ran → exactly one metered row, requestId echoed.
 		expect(mockServerMutation).toHaveBeenCalledTimes(1);
 		expect(body.meta.requestId).toBe(mockServerMutation.mock.calls[0][1].requestId);
+	});
+
+	it('(d5) billing is invariant in the number of district types returned — a 6-type result still meters quantity 1', async () => {
+		mockResolveAddress.mockResolvedValue({
+			...ENRICHED_RESULT,
+			districts: [
+				{ id: 'MN-08', geoid: '2708', name: "Minnesota's 8th Congressional District", jurisdiction: 'congressional', district_type: 'congressional' },
+				{ id: 'sldu-27011', geoid: '27011', name: 'State Senate 27011', jurisdiction: 'state-senate', district_type: 'state-senate' },
+				{ id: 'sldl-2711B', geoid: '2711B', name: 'State House/Assembly 2711B', jurisdiction: 'state-house', district_type: 'state-house' },
+				{ id: 'county-27115', geoid: '27115', name: 'County 27115', jurisdiction: 'county', district_type: 'county' },
+				{ id: 'unsd-2742750', geoid: '2742750', name: 'Unified School District 2742750', jurisdiction: 'unified-school', district_type: 'unified-school' },
+				{ id: 'cousub-2711532984', geoid: '2711532984', name: 'Township/MCD 2711532984', jurisdiction: 'township', district_type: 'township' }
+			]
+		});
+
+		const res = await resolveAddressHandler({ request: makeRequest() } as any);
+		const body = await res.json();
+
+		expect(res.status).toBe(200);
+		expect(body.data.districts).toHaveLength(6);
+		// One resolution = one meter event, regardless of how many types returned.
+		expect(mockServerMutation).toHaveBeenCalledTimes(1);
+		const [, meterArgs] = mockServerMutation.mock.calls[0];
+		expect(meterArgs.meter).toBe('resolve_address');
+		expect(meterArgs.quantity).toBe(1);
+	});
+
+	it('(d6) a resolver result WITHOUT a districts field still yields data.districts === [] (never undefined)', async () => {
+		const { districts: _omit, ...legacyShape } = ENRICHED_RESULT;
+		mockResolveAddress.mockResolvedValue(legacyShape);
+
+		const res = await resolveAddressHandler({ request: makeRequest() } as any);
+		const body = await res.json();
+
+		expect(res.status).toBe(200);
+		expect(body.data.districts).toEqual([]);
 	});
 
 	it('(d3) the metering write is AWAITED + fail-closed — a rejected ledger write yields a non-200, never a billed-but-unrecorded 200', async () => {
@@ -370,6 +424,7 @@ describe('POST /api/v1/resolve-address', () => {
 		mockResolveAddress.mockResolvedValue({
 			...ENRICHED_RESULT,
 			district: null,
+			districts: [],
 			officials: null,
 			confidence: 0,
 			boundaryAsOf: null,
@@ -380,6 +435,7 @@ describe('POST /api/v1/resolve-address', () => {
 		const body = await res.json();
 		expect(res.status).toBe(200);
 		expect(body.data.district).toBeNull();
+		expect(body.data.districts).toEqual([]);
 		expect(body.data.officials).toEqual([]);
 		expect(body.error).toBeUndefined();
 	});

--- a/tests/unit/identity/mdl-cell-resolution.test.ts
+++ b/tests/unit/identity/mdl-cell-resolution.test.ts
@@ -25,6 +25,7 @@ describe('resolveCellIdFromAddress', () => {
 		mockResolveAddress.mockResolvedValue({
 			geocode: { lat: 39.7392, lng: -104.9903, matched_address: 'Denver, CO 80202', confidence: 0.9, country: 'US' },
 			district: { id: 'CO-01', name: 'Congressional District 1', jurisdiction: 'US', district_type: 'cd' },
+			districts: [],
 			officials: { district_code: 'CO-01', state: 'CO', officials: [], special_status: null, cached: true, source: 'congress-legislators' },
 			cell_id: '08031000100',
 			provenance: { source: 'nominatim', tigerVintage: 'unknown' },
@@ -42,6 +43,7 @@ describe('resolveCellIdFromAddress', () => {
 		mockResolveAddress.mockResolvedValue({
 			geocode: { lat: 37.7749, lng: -122.4194, matched_address: 'San Francisco, CA 94103', confidence: 0.9, country: 'US' },
 			district: { id: 'CA-11', name: 'Congressional District 11', jurisdiction: 'US', district_type: 'cd' },
+			districts: [],
 			officials: null,
 			cell_id: '06075017601',
 			provenance: { source: 'nominatim', tigerVintage: 'unknown' },
@@ -79,6 +81,7 @@ describe('resolveCellIdFromAddress', () => {
 		mockResolveAddress.mockResolvedValue({
 			geocode: { lat: 39.7392, lng: -104.9903, matched_address: 'Denver, CO 80202', confidence: 0.9, country: 'US' },
 			district: { id: 'CO-01', name: 'Congressional District 1', jurisdiction: 'US', district_type: 'cd' },
+			districts: [],
 			officials: null,
 			cell_id: null,
 			provenance: { source: 'nominatim', tigerVintage: 'unknown' },
@@ -103,6 +106,7 @@ describe('resolveCellIdFromAddress', () => {
 		mockResolveAddress.mockResolvedValue({
 			geocode: { lat: 38.9072, lng: -77.0369, matched_address: 'Washington, DC 20001', confidence: 0.9, country: 'US' },
 			district: { id: 'DC-AL', name: 'At-Large Congressional District', jurisdiction: 'US', district_type: 'cd' },
+			districts: [],
 			officials: { district_code: 'DC-AL', state: 'DC', officials: [], special_status: { type: 'dc', message: 'DC residents have a non-voting delegate', has_senators: false, has_voting_representative: false }, cached: true, source: 'congress-legislators' },
 			cell_id: '11001000101',
 			provenance: { source: 'nominatim', tigerVintage: 'unknown' },

--- a/tests/unit/shadow-atlas/coverage.test.ts
+++ b/tests/unit/shadow-atlas/coverage.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Coverage-disclosure table integrity.
+ *
+ * The served-slot allowlist is the honesty contract of the multi-type resolve
+ * surface: a boundary type reaches the wire ONLY if this table discloses it.
+ * These tests pin the table to the populated-slot set of the live atlas build
+ * and to the shared US_SLOT_NAMES registry so disclosure, emission, and naming
+ * can never drift apart silently.
+ *
+ * Pure unit test: coverage.ts and district-format.ts have no runtime deps —
+ * no network, no mocks.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+	SERVED_SLOT_SET,
+	DISTRICT_COVERAGE,
+	type DistrictTypeCoverage
+} from '$lib/core/shadow-atlas/coverage';
+import { US_SLOT_NAMES } from '$lib/core/shadow-atlas/district-format';
+
+describe('shadow-atlas coverage disclosure', () => {
+	it('SERVED_SLOT_SET is exactly the populated-slot set of the live atlas build', () => {
+		// Ops rule: changing this set must accompany an atlas publish verification —
+		// diff the live district-index top-level slot keys against the new set and
+		// reconcile per-type counts BEFORE flipping the version pin.
+		expect([...SERVED_SLOT_SET].sort((a, b) => a - b)).toEqual([0, 2, 3, 4, 5, 7, 8, 9, 20, 22]);
+	});
+
+	it('boundaryTypes keys are exactly the US_SLOT_NAMES jurisdiction slugs of the served slots, in slot order', () => {
+		const expected = [...SERVED_SLOT_SET]
+			.sort((a, b) => a - b)
+			.map((slot) => US_SLOT_NAMES[slot].jurisdiction);
+		// Object.keys preserves the table's insertion order — canonical slot order.
+		expect(Object.keys(DISTRICT_COVERAGE.boundaryTypes)).toEqual(expected);
+	});
+
+	it("every disclosed type carries an honest class ∈ {'national','partial'}", () => {
+		for (const [districtType, entry] of Object.entries(DISTRICT_COVERAGE.boundaryTypes)) {
+			expect(['national', 'partial'], `bad class for ${districtType}`).toContain(
+				(entry as DistrictTypeCoverage).coverage
+			);
+		}
+	});
+
+	it("officialsTypes is exactly ['congressional'] — the machine-readable officials constraint", () => {
+		expect(DISTRICT_COVERAGE.officialsTypes).toEqual(['congressional']);
+	});
+
+	it('the disclosure object is deeply frozen — one shared instance serves every request', () => {
+		expect(Object.isFrozen(DISTRICT_COVERAGE)).toBe(true);
+		expect(Object.isFrozen(DISTRICT_COVERAGE.boundaryTypes)).toBe(true);
+		expect(Object.isFrozen(DISTRICT_COVERAGE.officialsTypes)).toBe(true);
+		for (const entry of Object.values(DISTRICT_COVERAGE.boundaryTypes)) {
+			expect(Object.isFrozen(entry)).toBe(true);
+		}
+	});
+
+	it('US_SLOT_NAMES holds exactly 24 entries with unique kebab-case jurisdiction slugs', () => {
+		expect(US_SLOT_NAMES).toHaveLength(24);
+		const slugs = US_SLOT_NAMES.map((s) => s.jurisdiction);
+		expect(new Set(slugs).size).toBe(24);
+		for (const slug of slugs) {
+			expect(slug).toMatch(/^[a-z][a-z0-9-]*$/);
+		}
+	});
+});

--- a/tests/unit/shadow-atlas/provenance-capture.test.ts
+++ b/tests/unit/shadow-atlas/provenance-capture.test.ts
@@ -163,6 +163,7 @@ function shadowAtlasResponse(overrides: ResolveOverrides = {}): AddressResolutio
 			jurisdiction: 'congressional',
 			district_type: 'congressional'
 		},
+		districts: [],
 		officials,
 		cell_id: cellId,
 		provenance,

--- a/tests/unit/shadow-atlas/redraw-externalize.test.ts
+++ b/tests/unit/shadow-atlas/redraw-externalize.test.ts
@@ -53,6 +53,7 @@ describe('redraw-signal.data', () => {
 				jurisdiction: 'congressional',
 				district_type: 'congressional',
 			},
+			districts: [],
 			officials: null,
 			cell_id: '8748a8a8effffff',
 			provenance: { source: 'nominatim', tigerVintage: 'TIGER2022' },

--- a/tests/unit/shadow-atlas/redraw-guard.test.ts
+++ b/tests/unit/shadow-atlas/redraw-guard.test.ts
@@ -38,6 +38,7 @@ function baseResult(
 			jurisdiction: 'congressional',
 			district_type: 'congressional',
 		},
+		districts: [],
 		officials: null,
 		cell_id: '8744d8a8effffff',
 		provenance: { source: 'nominatim', tigerVintage: 'TIGER2022' },

--- a/tests/unit/shadow-atlas/resolve-address.test.ts
+++ b/tests/unit/shadow-atlas/resolve-address.test.ts
@@ -249,6 +249,8 @@ describe('resolveAddress return shape — provenance + two-clock honesty', () =>
 
 		expect(result.district).toBeNull();
 		expect(result.confidence).toBe(0);
+		// The multi-type view misses in lockstep: no chunk → no boundary types.
+		expect(result.districts).toEqual([]);
 		// Geocode still succeeded — a degraded resolution is a SUCCESS, not a throw.
 		expect(result.geocode.lat).toBeCloseTo(37.7793);
 		expect(result.officials).toBeNull();
@@ -267,6 +269,8 @@ describe('resolveAddress return shape — provenance + two-clock honesty', () =>
 		expect(result.officialsAsOf).toBeNull();
 		expect(result.provenance.tigerVintage).toBe('unknown');
 		expect(result.confidence).toBe(1.0); // a clean district hit stays trusted
+		// The staleness guard passes districts through untouched — never drops or mutates it.
+		expect(result.districts.length).toBe(1);
 	});
 
 	it('(f) a non-404 chunk-fetch failure (infra fault) propagates as AtlasInfraError — never converted into a district miss', async () => {
@@ -290,6 +294,8 @@ describe('resolveAddress return shape — provenance + two-clock honesty', () =>
 
 		expect(result.district).toBeNull();
 		expect(result.confidence).toBe(0);
+		// The multi-type view misses in lockstep on a clean coverage miss.
+		expect(result.districts).toEqual([]);
 		// Geocode still succeeded — a degraded resolution is a SUCCESS, not a throw.
 		expect(result.geocode.lat).toBeCloseTo(37.7793);
 	});
@@ -378,5 +384,122 @@ describe('resolveAddress return shape — provenance + two-clock honesty', () =>
 		expect(result.geocode.confidence).toBe(0.6);
 		expect(result.confidence).toBe(0.6); // min(districtConfidence 1.0, zip factor 0.6)
 		expect(result.district?.id).toBe('CA-01');
+	});
+
+	it('(n) a multi-slot chunk projects EVERY populated served type into districts, slot-ordered, congressional first', async () => {
+		// Realistic 24-slot chunk: congressional + state senate/house + county +
+		// unified school + township populated (rural-MN shape), everything else empty.
+		const slots: (string | null)[] = new Array(24).fill(null);
+		slots[0] = 'cd-2708';
+		slots[2] = 'sldu-27011';
+		slots[3] = 'sldl-2711B';
+		slots[4] = 'county-27115';
+		slots[7] = 'unsd-2742750';
+		slots[20] = 'cousub-2711532984';
+		mockGetChunkForCell.mockResolvedValue(slots);
+		mockGetManifestVintage.mockResolvedValue({
+			tigerVintage: 'TIGER2024',
+			generated: '2024-09-01T00:00:00.000Z',
+			officialsGenerated: null
+		});
+
+		const result = await resolveAddress(ADDRESS);
+
+		expect(result.districts).toHaveLength(6);
+		// Canonical slot order, congressional first.
+		expect(result.districts.map((d) => d.district_type)).toEqual([
+			'congressional',
+			'state-senate',
+			'state-house',
+			'county',
+			'unified-school',
+			'township'
+		]);
+		// Congressional wire entry uses the DISPLAY code — identical id to the legacy field.
+		expect(result.districts[0]).toEqual({
+			id: 'MN-08',
+			geoid: '2708',
+			name: "Minnesota's 8th Congressional District",
+			jurisdiction: 'congressional',
+			district_type: 'congressional'
+		});
+		expect(result.districts[0].id).toBe(result.district?.id);
+		// Non-congressional entries keep the substrate id + stripped GEOID + label-based name.
+		expect(result.districts[1]).toEqual({
+			id: 'sldu-27011',
+			geoid: '27011',
+			name: 'State Senate 27011',
+			jurisdiction: 'state-senate',
+			district_type: 'state-senate'
+		});
+		// Alphanumeric TIGER GEOIDs survive the prefix strip intact.
+		expect(result.districts[2].geoid).toBe('2711B');
+		expect(result.districts[2].name).toBe('State House/Assembly 2711B');
+	});
+
+	it('(o) a populated slot OUTSIDE the served allowlist is never emitted — disclosure gates the wire', async () => {
+		const slots: (string | null)[] = new Array(24).fill(null);
+		slots[0] = 'cd-0601';
+		slots[11] = 'water-9999999'; // defined type, zero live coverage → not served
+		mockGetChunkForCell.mockResolvedValue(slots);
+		mockGetManifestVintage.mockResolvedValue({
+			tigerVintage: 'TIGER2024',
+			generated: '2024-09-01T00:00:00.000Z',
+			officialsGenerated: null
+		});
+
+		const result = await resolveAddress(ADDRESS);
+
+		// Only the congressional entry surfaces; the unserved type cannot reach the
+		// wire before the coverage table discloses it.
+		expect(result.districts).toHaveLength(1);
+		expect(result.districts[0].district_type).toBe('congressional');
+	});
+
+	it('(q) chunk present but slot 0 empty: primary-miss semantics unchanged while non-congressional types still surface', async () => {
+		mockGetChunkForCell.mockResolvedValue([null, null, 'sldu-27011']);
+		mockGetManifestVintage.mockResolvedValue({
+			tigerVintage: 'TIGER2024',
+			generated: '2024-09-01T00:00:00.000Z',
+			officialsGenerated: null
+		});
+
+		const result = await resolveAddress(ADDRESS);
+
+		// The PRIMARY miss stays keyed to slot 0: district null, confidence 0, loud warning.
+		expect(result.district).toBeNull();
+		expect(result.confidence).toBe(0);
+		expect(result.warning).toBe('district lookup miss');
+		// ...while the populated state-senate boundary still surfaces honestly.
+		expect(result.districts).toEqual([
+			{
+				id: 'sldu-27011',
+				geoid: '27011',
+				name: 'State Senate 27011',
+				jurisdiction: 'state-senate',
+				district_type: 'state-senate'
+			}
+		]);
+	});
+
+	it('(s) a single-element legacy chunk emits exactly one districts entry mirroring the legacy district', async () => {
+		mockGetChunkForCell.mockResolvedValue(['cd-0601']);
+		mockGetManifestVintage.mockResolvedValue({
+			tigerVintage: 'TIGER2024',
+			generated: '2024-09-01T00:00:00.000Z',
+			officialsGenerated: null
+		});
+
+		const result = await resolveAddress(ADDRESS);
+
+		expect(result.districts).toEqual([
+			{
+				id: 'CA-01',
+				geoid: '0601',
+				name: "California's 1st Congressional District",
+				jurisdiction: 'congressional',
+				district_type: 'congressional'
+			}
+		]);
 	});
 });


### PR DESCRIPTION
## Why

The paid resolve-address route structurally serves only slot 0 (congressional) and discards the other 23 positions of the cell chunk it already fetched. The live atlas build populates **10 of 24 slots** (congressional, state senate/house, county, city, unified/elementary/secondary school, township, tribal). This turns that latent data into served product — with honest, machine-readable coverage disclosure.

## What

**Additive `districts[]` + `coverage` on the response** (same single chunk fetch — no new network calls):
- Public wire speaks stable `district_type` slugs (`state-senate`, `county`, `township`…), never slot indexes. Documented open set: types may be added, never renamed.
- **Allowlist-gated serving** (`coverage.ts`): a slot reaches the wire only if the coverage table describes it, so disclosure and emission cannot drift. A future atlas publish populating a new slot changes nothing until the table is deliberately updated (allowlists-not-denylists).
- **Coverage honesty**: per-type `national`/`partial` classes; `officialsTypes: ['congressional']` makes officials-join scope explicit. Partial types cannot read as national.
- **Billing unchanged**: one resolution = one meter event regardless of type count — pinned by a quantity-1 invariance test.
- `district` field semantics byte-identical for every prior response class; `districts[]` contains the congressional entry with the same id. OpenAPI → 1.1.0 with `ResolvedDistrict`/`ResolveCoverage` schemas + anti-drift contract tests.

## Verification

- 247 tests green across api-v1 + shadow-atlas suites (new: coverage table, multi-slot extraction, billing invariance, OpenAPI anti-drift)
- svelte-check 0 errors / 8,155 files
- 3 independent adversarial review passes (data correctness against live v20260704 cells; contract/billing back-compat; disclosure honesty) — no blockers; minor findings fixed (non-string slot fail-soft guard, readonly coverage types, OpenAPI edge wording)

## Known edge (documented, theoretical today)

When a cell resolves but slot 0 is empty (0 cells in the live build), `cell_id` now populates where the old path threw it away; `district`/`confidence`/`warning` semantics unchanged. Noted in review as arguably more correct; flagged here for visibility since the person-layer `zk_eligible` derives from `cell_id`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Address resolution now returns a full list of served district boundaries, not just the primary district.
  * Added a new coverage disclosure in responses so clients can see which boundary types are supported.
  * The API contract has been updated to reflect the expanded response shape.

* **Bug Fixes**
  * Improved district resolution for multi-boundary addresses.
  * Addresses without a primary congressional match can still return other available boundary results.
  * Missing or malformed boundary data is handled more gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->